### PR TITLE
align query tool name

### DIFF
--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -30,7 +30,7 @@ information, say so clearly.
 """
 
 
-def pageindex_retrieve(doc_id: str, question: str, okb_dir: str, model: str) -> str:
+def _pageindex_retrieve_impl(doc_id: str, question: str, okb_dir: str, model: str) -> str:
     """Retrieve relevant content from a long document via PageIndex.
 
     Args:
@@ -148,7 +148,7 @@ def build_query_agent(wiki_root: str, okb_dir: str, model: str, language: str = 
         return read_wiki_file(path, wiki_root)
 
     @function_tool
-    def retrieve(doc_id: str, question: str) -> str:
+    def pageindex_retrieve(doc_id: str, question: str) -> str:
         """Retrieve relevant content from a long document via PageIndex.
 
         Use this when you need detailed content from a document that was
@@ -158,12 +158,12 @@ def build_query_agent(wiki_root: str, okb_dir: str, model: str, language: str = 
             doc_id: PageIndex document identifier (found in index.md).
             question: The question you are trying to answer.
         """
-        return pageindex_retrieve(doc_id, question, okb_dir, model)
+        return _pageindex_retrieve_impl(doc_id, question, okb_dir, model)
 
     return Agent(
         name="wiki-query",
         instructions=instructions,
-        tools=[list_files, read_file, retrieve],
+        tools=[list_files, read_file, pageindex_retrieve],
         model=model,
     )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from openkb.agent.query import build_query_agent, pageindex_retrieve, run_query
+from openkb.agent.query import _pageindex_retrieve_impl, build_query_agent, run_query
 from openkb.schema import SCHEMA_MD
 
 
@@ -24,7 +24,13 @@ class TestBuildQueryAgent:
         names = {t.name for t in agent.tools}
         assert "list_files" in names
         assert "read_file" in names
-        assert "retrieve" in names
+        assert "pageindex_retrieve" in names
+
+    def test_instructions_reference_registered_pageindex_tool(self, tmp_path):
+        agent = build_query_agent(str(tmp_path), str(tmp_path / "pi"), "gpt-4o-mini")
+        tool_names = {t.name for t in agent.tools}
+        assert "pageindex_retrieve" in agent.instructions
+        assert "pageindex_retrieve" in tool_names
 
     def test_schema_in_instructions(self, tmp_path):
         agent = build_query_agent(str(tmp_path), str(tmp_path / "pi"), "gpt-4o-mini")
@@ -63,7 +69,7 @@ class TestPageindexRetrieve:
             mock_llm.return_value = MagicMock(
                 choices=[MagicMock(message=MagicMock(content="1-2"))]
             )
-            result = pageindex_retrieve("doc123", "What is the intro?", "/db", "gpt-4o-mini")
+            result = _pageindex_retrieve_impl("doc123", "What is the intro?", "/db", "gpt-4o-mini")
 
         assert "Introduction text here." in result
         assert "More intro content." in result
@@ -76,7 +82,7 @@ class TestPageindexRetrieve:
         mock_client.collection.return_value = mock_col
 
         with patch("openkb.agent.query.PageIndexClient", return_value=mock_client):
-            result = pageindex_retrieve("doc456", "What?", "/db", "gpt-4o-mini")
+            result = _pageindex_retrieve_impl("doc456", "What?", "/db", "gpt-4o-mini")
 
         assert "No structure found" in result
 
@@ -88,7 +94,7 @@ class TestPageindexRetrieve:
         mock_client.collection.return_value = mock_col
 
         with patch("openkb.agent.query.PageIndexClient", return_value=mock_client):
-            result = pageindex_retrieve("doc789", "What?", "/db", "gpt-4o-mini")
+            result = _pageindex_retrieve_impl("doc789", "What?", "/db", "gpt-4o-mini")
 
         assert "Error" in result
 


### PR DESCRIPTION
## Summary

This PR aligns the long-document retrieval tool name exposed by the query agent with the name referenced in the agent instructions.

## What Changed

- renamed the internal PageIndex retrieval implementation to a private helper to avoid naming conflicts
- exposed the query agent tool as `pageindex_retrieve` so the registered tool name matches the prompt instructions
- updated query tests to assert the new tool name and added a guard that checks the instructions and registered tool stay aligned

## Why

The query agent instructions told the model to call `pageindex_retrieve`, but the actual registered tool name was `retrieve`. That mismatch made long-document retrieval less reliable because the model could be instructed to call a tool name that did not exist.

## Validation

- `python3 -m pytest -q tests/test_query.py -k 'TestBuildQueryAgent or TestPageindexRetrieve'