### PR TITLE
Fix: add litellm/ prefix for Agents SDK model routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,3 @@
 # Anthropic: LLM_API_KEY=sk-ant-...
 # Gemini:    LLM_API_KEY=AIza...
 LLM_API_KEY=your-key-here
-
-# PageIndex Cloud API key (optional, leave empty for local PageIndex)
-# Get your key at https://pageindex.dev
-# PAGEINDEX_API_KEY=your-key-here

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ pip install openkb
 ### Quick start
 
 ```bash
-# 1. Create a knowledge base
+# 1. Create a directory for your knowledge base
 mkdir my-kb && cd my-kb
 
-# 2. Initialize
+# 2. Initialize the knowledge base
 openkb init
 
 # 3. Add documents
@@ -66,7 +66,7 @@ openkb lint
 
 OpenKB comes with [multi-LLM support](https://docs.litellm.ai/docs/providers) (e.g., OpenAI, Claude, Gemini) via [LiteLLM](https://github.com/BerriAI/litellm) (pinned to a [safe version](https://docs.litellm.ai/blog/security-update-march-2026)).
 
-Create a `.env` file with your LLM API key. Choose your LLM during `openkb init` or edit [`.openkb/config.yaml`](#configuration) (model names follow [LiteLLM format](https://docs.litellm.ai/docs/providers), e.g. `gpt-5.4`, `anthropic/claude-sonnet-4-6`).
+Create a `.env` file with your LLM API key. Set your model during `openkb init`, or in [`.openkb/config.yaml`](#configuration), using LiteLLM `provider/model` format (e.g., `gpt-5.4`, `anthropic/claude-sonnet-4-6`).
 
 ```bash
 LLM_API_KEY=your_llm_api_key

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ pageindex_threshold: 20          # PDF pages threshold for PageIndex
 pageindex_api_key_env: ""        # (Optional) Environment variable for PageIndex Cloud API key
 ```
 
-Model names follow [LiteLLM format](https://docs.litellm.ai/docs/providers):
+Model names use `provider/model` [LiteLLM format](https://docs.litellm.ai/docs/providers):
 
 | Provider | Model example |
 |---|---|

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -108,7 +108,7 @@ def build_compiler_agent(wiki_root: str, model: str, language: str = "en") -> Ag
         name="wiki-compiler",
         instructions=instructions,
         tools=[list_files, read_file, write_file],
-        model=model,
+        model=f"litellm/{model}",
         model_settings=ModelSettings(parallel_tool_calls=False),
     )
 
@@ -195,7 +195,7 @@ def build_long_doc_compiler_agent(wiki_root: str, kb_dir: str, model: str, langu
         name="wiki-compiler",
         instructions=instructions,
         tools=[list_files, read_file, write_file, get_page_content],
-        model=_model,
+        model=f"litellm/{_model}",
         model_settings=ModelSettings(parallel_tool_calls=False),
     )
 

--- a/openkb/agent/linter.py
+++ b/openkb/agent/linter.py
@@ -72,7 +72,7 @@ def build_lint_agent(wiki_root: str, model: str, language: str = "en") -> Agent:
         name="wiki-linter",
         instructions=instructions,
         tools=[list_files, read_file],
-        model=model,
+        model=f"litellm/{model}",
     )
 
 

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -200,7 +200,7 @@ def build_query_agent(wiki_root: str, openkb_dir: str, model: str, language: str
         name="wiki-query",
         instructions=instructions,
         tools=[list_files, read_file, pageindex_retrieve],
-        model=model,
+        model=f"litellm/{model}",
         model_settings=ModelSettings(parallel_tool_calls=False),
     )
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -30,7 +30,7 @@ class TestBuildCompilerAgent:
 
     def test_agent_model(self, tmp_path):
         agent = build_compiler_agent(str(tmp_path), "my-custom-model")
-        assert agent.model == "my-custom-model"
+        assert agent.model == "litellm/my-custom-model"
 
     def test_tool_names(self, tmp_path):
         agent = build_compiler_agent(str(tmp_path), "gpt-4o-mini")

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -31,7 +31,7 @@ class TestBuildLintAgent:
 
     def test_agent_model(self, tmp_path):
         agent = build_lint_agent(str(tmp_path), "custom-model")
-        assert agent.model == "custom-model"
+        assert agent.model == "litellm/custom-model"
 
     def test_instructions_mention_contradictions(self, tmp_path):
         agent = build_lint_agent(str(tmp_path), "gpt-4o-mini")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -38,7 +38,7 @@ class TestBuildQueryAgent:
 
     def test_agent_model(self, tmp_path):
         agent = build_query_agent(str(tmp_path), str(tmp_path / "pi"), "my-model")
-        assert agent.model == "my-model"
+        assert agent.model == "litellm/my-model"
 
 
 class TestPageindexRetrieve:


### PR DESCRIPTION
## Summary

- Add `litellm/` prefix to all `Agent(model=...)` calls so non-OpenAI models (e.g., `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.5-pro`) are correctly routed through LiteLLM by the OpenAI Agents SDK
- `litellm.completion()` and `PageIndexClient` calls remain unchanged (they use LiteLLM format directly)
- Update README: improve quick start comments, polish model format docs
- Remove PageIndex section from `.env.example`

## Test plan

- [x] Verified all 4 model formats (`gpt-5.4`, `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.5-pro`) work with both `litellm.completion()` and `Agent(model=litellm/...)` using `LLM_API_KEY`
- [x] Unit tests pass