### PR TITLE
Simplify PageIndex API key config: remove pageindex_api_key_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Settings are initialized by `openkb init`, and stored in `.openkb/config.yaml`:
 model: gpt-5.4                   # LLM model (any LiteLLM-supported provider)
 language: en                     # Wiki output language
 pageindex_threshold: 20          # PDF pages threshold for PageIndex
-pageindex_api_key_env: ""        # (Optional) Environment variable for PageIndex Cloud API key
 ```
 
 Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/providers) (OpenAI models can omit the prefix):
@@ -208,7 +207,7 @@ OpenKB's wiki is a directory of Markdown files with `[[wikilinks]]`. Obsidian re
 
 ### Tech Stack
 
-- [PageIndex](https://github.com/VectifyAI/PageIndex) — Vectorless, reasoning-based document indexing
+- [PageIndex](https://github.com/VectifyAI/PageIndex) — Vectorless, reasoning-based document indexing and retrieval
 - [markitdown](https://github.com/microsoft/markitdown) — Universal file-to-markdown conversion
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) — Agent framework (supports non-OpenAI models via LiteLLM)
 - [LiteLLM](https://github.com/BerriAI/litellm) — Multi-provider LLM gateway

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,3 @@
 model: gpt-5.4                   # LLM model (any LiteLLM-supported provider)
-language: en                      # Wiki output language
-pageindex_threshold: 20           # PDF pages threshold for PageIndex
-pageindex_api_key_env: ""         # Env var name for PageIndex Cloud API key
+language: en                     # Wiki output language
+pageindex_threshold: 20          # PDF pages threshold for PageIndex

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -130,10 +130,9 @@ def build_long_doc_compiler_agent(wiki_root: str, kb_dir: str, model: str, langu
     openkb_dir = Path(kb_dir) / ".openkb"
     config = load_config(openkb_dir / "config.yaml")
     _model = config.get("model", model)
-    pi_key_env = config.get("pageindex_api_key_env", "") or "PAGEINDEX_API_KEY"
-    pi_api_key = os.environ.get(pi_key_env, "")
+    pageindex_api_key = os.environ.get("PAGEINDEX_API_KEY", "")
     client = PageIndexClient(
-        api_key=pi_api_key or None,
+        api_key=pageindex_api_key or None,
         model=_model,
         storage_path=str(openkb_dir),
     )

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -36,10 +36,7 @@ def _pageindex_retrieve_impl(doc_id: str, question: str, openkb_dir: str, model:
     For cloud-indexed docs: delegates to col.query() directly.
     For local docs: uses structure-based page selection + get_page_content.
     """
-    from openkb.config import load_config
-    config = load_config(Path(openkb_dir) / "config.yaml")
-    pi_key_env = config.get("pageindex_api_key_env", "") or "PAGEINDEX_API_KEY"
-    pi_api_key = os.environ.get(pi_key_env, "")
+    pageindex_api_key = os.environ.get("PAGEINDEX_API_KEY", "")
     # Determine if this doc was cloud-indexed (cloud doc_ids have "pi-" prefix)
     is_cloud_doc = doc_id.startswith("pi-")
 
@@ -49,7 +46,7 @@ def _pageindex_retrieve_impl(doc_id: str, question: str, openkb_dir: str, model:
         import asyncio
         import threading
 
-        client = PageIndexClient(api_key=pi_api_key or None, model=model)
+        client = PageIndexClient(api_key=pageindex_api_key or None, model=model)
         col = client.collection()
         try:
             stream = col.query(question, doc_ids=[doc_id], stream=True)

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -169,11 +169,6 @@ def init():
         default=DEFAULT_CONFIG["pageindex_threshold"],
         type=int,
     )
-    pageindex_api_key_env = click.prompt(
-        "PageIndex cloud API key env var (leave empty for local)",
-        default=DEFAULT_CONFIG["pageindex_api_key_env"],
-    )
-
     # Create directory structure
     Path("raw").mkdir(exist_ok=True)
     Path("wiki/sources/images").mkdir(parents=True, exist_ok=True)
@@ -196,7 +191,6 @@ def init():
         "model": model,
         "language": language,
         "pageindex_threshold": pageindex_threshold,
-        "pageindex_api_key_env": pageindex_api_key_env,
     }
     save_config(openkb_dir / "config.yaml", config)
     (openkb_dir / "hashes.json").write_text(json.dumps({}), encoding="utf-8")

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -9,7 +9,6 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "model": "gpt-5.4",
     "language": "en",
     "pageindex_threshold": 20,
-    "pageindex_api_key_env": "",  # Set to env var name (e.g. PAGEINDEX_API_KEY) to use cloud PageIndex
 }
 
 

--- a/openkb/indexer.py
+++ b/openkb/indexer.py
@@ -59,8 +59,7 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
     config = load_config(openkb_dir / "config.yaml")
 
     model: str = config.get("model", "gpt-5.4")
-    pi_key_env = config.get("pageindex_api_key_env", "") or "PAGEINDEX_API_KEY"
-    pi_api_key = os.environ.get(pi_key_env, "")
+    pageindex_api_key = os.environ.get("PAGEINDEX_API_KEY", "")
 
     index_config = IndexConfig(
         if_add_node_text=True,
@@ -69,7 +68,7 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
     )
 
     client = PageIndexClient(
-        api_key=pi_api_key or None,
+        api_key=pageindex_api_key or None,
         model=model,
         storage_path=str(openkb_dir),
         index_config=index_config,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,6 @@ def test_default_config_keys():
     assert "model" in DEFAULT_CONFIG
     assert "language" in DEFAULT_CONFIG
     assert "pageindex_threshold" in DEFAULT_CONFIG
-    assert "pageindex_api_key_env" in DEFAULT_CONFIG
 
 
 def test_default_config_values():


### PR DESCRIPTION
## Summary

- Remove `pageindex_api_key_env` config option, hardcode `PAGEINDEX_API_KEY` env var directly
- Simplify `openkb init` by removing one interactive prompt
- Rename `pi_api_key` to `pageindex_api_key` for clarity
- Update README and config.yaml.example

## Test plan

- [ ] Verify `pytest tests/test_config.py` passes
- [ ] Verify `openkb init` no longer prompts for PageIndex API key env var
- [ ] Verify PageIndex Cloud still works with `PAGEINDEX_API_KEY` in `.env`