### PR TITLE
Polish agent prompts and normalize get_page_content tool naming

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _SYSTEM_TEMPLATE = """\
-You are a wiki compilation agent for a personal knowledge base.
+You are OpenKB's wiki compilation agent for a personal knowledge base.
 
 {schema_md}
 

--- a/openkb/agent/linter.py
+++ b/openkb/agent/linter.py
@@ -11,7 +11,7 @@ MAX_TURNS = 50
 from openkb.schema import SCHEMA_MD, get_agents_md
 
 _LINTER_INSTRUCTIONS_TEMPLATE = """\
-You are a knowledge-base semantic lint agent. Your job is to audit the wiki
+You are OpenKB's semantic lint agent. Your job is to audit the wiki
 for quality issues that structural tools cannot detect.
 
 {schema_md}
@@ -50,7 +50,7 @@ def build_lint_agent(wiki_root: str, model: str, language: str = "en") -> Agent:
     """
     schema_md = get_agents_md(Path(wiki_root))
     instructions = _LINTER_INSTRUCTIONS_TEMPLATE.format(schema_md=schema_md)
-    instructions += f"\n\nIMPORTANT: Write all wiki content in {language} language."
+    instructions += f"\n\nIMPORTANT: Write the lint report in {language} language."
 
     @function_tool
     def list_files(directory: str) -> str:

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from agents import Agent, Runner, function_tool
 
 from agents import ToolOutputImage, ToolOutputText
-from openkb.agent.tools import read_wiki_file, read_wiki_image
+from openkb.agent.tools import get_wiki_page_content, read_wiki_file, read_wiki_image
 
 MAX_TURNS = 50
 from openkb.schema import get_agents_md
@@ -55,7 +55,7 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
         return read_wiki_file(path, wiki_root)
 
     @function_tool
-    def get_page_content_tool(doc_name: str, pages: str) -> str:
+    def get_page_content(doc_name: str, pages: str) -> str:
         """Get text content of specific pages from a PageIndex (long) document.
         Only use for documents with doc_type: pageindex. For short documents,
         use read_file instead.
@@ -63,8 +63,7 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
             doc_name: Document name (e.g. 'attention-is-all-you-need').
             pages: Page specification (e.g. '3-5,7,10-12').
         """
-        from openkb.agent.tools import get_page_content
-        return get_page_content(doc_name, pages, wiki_root)
+        return get_wiki_page_content(doc_name, pages, wiki_root)
 
     @function_tool
     def get_image(image_path: str) -> ToolOutputImage | ToolOutputText:
@@ -86,7 +85,7 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
     return Agent(
         name="wiki-query",
         instructions=instructions,
-        tools=[read_file, get_page_content_tool, get_image],
+        tools=[read_file, get_page_content, get_image],
         model=f"litellm/{model}",
         model_settings=ModelSettings(parallel_tool_calls=False),
     )

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -12,7 +12,7 @@ MAX_TURNS = 50
 from openkb.schema import get_agents_md
 
 _QUERY_INSTRUCTIONS_TEMPLATE = """\
-You are a knowledge-base Q&A agent. You answer questions by searching the wiki.
+You are OpenKB, a knowledge-base Q&A agent. You answer questions by searching the wiki.
 
 {schema_md}
 
@@ -20,7 +20,8 @@ You are a knowledge-base Q&A agent. You answer questions by searching the wiki.
 1. Read index.md to see all documents and concepts with brief summaries.
    Each document is marked (short) or (pageindex) to indicate its type.
 2. Read relevant summary pages (summaries/) for document overviews.
-   Note: summaries may omit details.
+   Summaries may omit details — if you need more, follow the summary's
+   `full_text` frontmatter field to the source (see step 4).
 3. Read concept pages (concepts/) for cross-document synthesis.
 4. When you need detailed source document content, each summary page has a
    `full_text` frontmatter field with the path to the original document content:
@@ -28,9 +29,8 @@ You are a knowledge-base Q&A agent. You answer questions by searching the wiki.
    - PageIndex documents (doc_type: pageindex): use get_page_content(doc_name, pages)
      with tight page ranges. The summary shows document tree structure with page
      ranges to help you target. Never fetch the whole document.
-5. When source content references images (e.g. ![image](sources/images/doc/file.png)),
-   use get_image to view them. Always view images when the question asks about
-   a figure, chart, diagram, or visual content.
+5. Source content may reference images (e.g. ![image](sources/images/doc/file.png)).
+   Use the get_image tool to view them when needed.
 6. Synthesize a clear, concise, well-cited answer grounded in wiki content.
 
 Answer based only on wiki content. Be concise.
@@ -44,7 +44,7 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
     """Build and return the Q&A agent."""
     schema_md = get_agents_md(Path(wiki_root))
     instructions = _QUERY_INSTRUCTIONS_TEMPLATE.format(schema_md=schema_md)
-    instructions += f"\n\nIMPORTANT: Write all wiki content in {language} language."
+    instructions += f"\n\nIMPORTANT: Answer in {language} language."
 
     @function_tool
     def read_file(path: str) -> str:
@@ -69,7 +69,10 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
     @function_tool
     def get_image(image_path: str) -> ToolOutputImage | ToolOutputText:
         """View an image from the wiki.
-        Use when source content references images you need to see.
+
+        Use when a question asks about a specific figure, chart, or diagram
+        you'd need to see to answer accurately.
+
         Args:
             image_path: Image path relative to wiki root (e.g. 'sources/images/doc/p1_img1.png').
         """

--- a/openkb/agent/tools.py
+++ b/openkb/agent/tools.py
@@ -89,7 +89,7 @@ def parse_pages(pages: str) -> list[int]:
     return sorted(n for n in result if n > 0)
 
 
-def get_page_content(doc_name: str, pages: str, wiki_root: str) -> str:
+def get_wiki_page_content(doc_name: str, pages: str, wiki_root: str) -> str:
     """Return formatted content for specified pages of a document.
 
     Reads ``{wiki_root}/sources/{doc_name}.json`` which must be a JSON array of

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from openkb.agent.tools import get_page_content, list_wiki_files, parse_pages, read_wiki_file, write_wiki_file
+from openkb.agent.tools import get_wiki_page_content, list_wiki_files, parse_pages, read_wiki_file, write_wiki_file
 
 
 # ---------------------------------------------------------------------------
@@ -159,11 +159,11 @@ class TestParsePages:
 
 
 # ---------------------------------------------------------------------------
-# get_page_content
+# get_wiki_page_content
 # ---------------------------------------------------------------------------
 
 
-class TestGetPageContent:
+class TestGetWikiPageContent:
     def test_reads_pages_from_json(self, tmp_path):
         import json
         wiki_root = str(tmp_path)
@@ -175,7 +175,7 @@ class TestGetPageContent:
             {"page": 3, "content": "Page three text."},
         ]
         (sources / "paper.json").write_text(json.dumps(pages), encoding="utf-8")
-        result = get_page_content("paper", "1,3", wiki_root)
+        result = get_wiki_page_content("paper", "1,3", wiki_root)
         assert "[Page 1]" in result
         assert "Page one text." in result
         assert "[Page 3]" in result
@@ -185,7 +185,7 @@ class TestGetPageContent:
     def test_returns_error_for_missing_file(self, tmp_path):
         wiki_root = str(tmp_path)
         (tmp_path / "sources").mkdir()
-        result = get_page_content("nonexistent", "1", wiki_root)
+        result = get_wiki_page_content("nonexistent", "1", wiki_root)
         assert "not found" in result.lower()
 
     def test_returns_error_for_no_matching_pages(self, tmp_path):
@@ -195,7 +195,7 @@ class TestGetPageContent:
         sources.mkdir()
         pages = [{"page": 1, "content": "Only page."}]
         (sources / "paper.json").write_text(json.dumps(pages), encoding="utf-8")
-        result = get_page_content("paper", "99", wiki_root)
+        result = get_wiki_page_content("paper", "99", wiki_root)
         assert "no content" in result.lower()
 
     def test_includes_images_info(self, tmp_path):
@@ -205,11 +205,11 @@ class TestGetPageContent:
         sources.mkdir()
         pages = [{"page": 1, "content": "Text.", "images": [{"path": "images/p/img.png", "width": 100, "height": 80}]}]
         (sources / "doc.json").write_text(json.dumps(pages), encoding="utf-8")
-        result = get_page_content("doc", "1", wiki_root)
+        result = get_wiki_page_content("doc", "1", wiki_root)
         assert "img.png" in result
 
     def test_path_escape_denied(self, tmp_path):
         wiki_root = str(tmp_path)
         (tmp_path / "sources").mkdir()
-        result = get_page_content("../../etc/passwd", "1", wiki_root)
+        result = get_wiki_page_content("../../etc/passwd", "1", wiki_root)
         assert "denied" in result.lower() or "not found" in result.lower()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -23,7 +23,7 @@ class TestBuildQueryAgent:
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
         names = {t.name for t in agent.tools}
         assert "read_file" in names
-        assert "get_page_content_tool" in names
+        assert "get_page_content" in names
         assert "get_image" in names
 
     def test_instructions_mention_get_page_content(self, tmp_path):


### PR DESCRIPTION
## Summary
- Fix a copy-paste bug where the Q&A and lint agents were told to "Write all wiki content in X language" — switched to "Answer in X" / "Write the lint report in X". The compiler agent keeps its original wording since it actually writes wiki content.
- Give all three agents an OpenKB identity in their opening line so the model introduces itself consistently when asked who it is.
- Tidy the Q&A search strategy: finish the thought on thin summaries (follow the `full_text` path), and move the get_image tool's "when to call" guidance from the instructions template into the tool docstring.
- Normalize the `get_page_content` tool naming so the helper, the `@function_tool` wrapper, and the instructions template all agree. Renames the helper to `get_wiki_page_content` (matching the `wiki_` sibling convention) and the wrapper to `get_page_content` (matching what the instructions have always said), and drops a lazy-import workaround that only existed to dodge a name collision.

## Test plan
- [ ] `pytest tests/test_agent_tools.py tests/test_query.py`
- [ ] Smoke a Q&A run and a lint run to confirm the language instruction reads naturally.