### PR TITLE
feat(cli): add `openkb remove` to safely delete a document (closes #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A single source might touch 10-15 wiki pages. Knowledge accumulates: each docume
 |---|---|
 | `openkb init` | Initialize a new knowledge base (interactive) |
 | <code>openkb&nbsp;add&nbsp;&lt;file_or_dir&gt;</code> | Add documents and compile to wiki |
+| <code>openkb&nbsp;remove&nbsp;&lt;doc&gt;</code> | Remove a document and clean up its wiki pages, images, registry, and PageIndex state (use `--dry-run` to preview, `--keep-raw` / `--keep-empty-concepts` to retain artifacts) |
 | <code>openkb&nbsp;query&nbsp;"question"</code> | Ask a question over the knowledge base (use `--save` to save the answer to `wiki/explorations/`) |
 | `openkb chat` | Start an interactive multi-turn chat (use `--resume`, `--list`, `--delete` to manage sessions) |
 | `openkb watch` | Watch `raw/` and auto-compile new files |

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -446,11 +446,13 @@ def _insert_section_entry(lines: list[str], heading: str, entry: str) -> bool:
 
 
 def _remove_section_entry(lines: list[str], heading: str, link: str) -> bool:
-    """Remove the first entry whose ``link`` appears in the named section.
+    """Remove the first entry whose line starts with ``- {link}`` in the named
+    section. Returns True if an entry was removed.
 
-    Returns True if an entry was removed. The match uses ``- {link}`` as
-    the prefix (the canonical bullet form that the other section helpers
-    produce); a fallback substring match catches custom bullet text.
+    Matching is intentionally strict (prefix-only, matching the canonical
+    bullet form written by ``_insert_section_entry`` and friends). An earlier
+    substring fallback could wrongly delete sibling bullets whose brief text
+    referenced the removed link.
     """
     bounds = _get_section_bounds(lines, heading)
     if bounds is None:
@@ -459,7 +461,7 @@ def _remove_section_entry(lines: list[str], heading: str, link: str) -> bool:
     start, end = bounds
     entry_prefix = f"- {link}"
     for i in range(start, end):
-        if lines[i].startswith(entry_prefix) or link in lines[i]:
+        if lines[i].startswith(entry_prefix):
             del lines[i]
             return True
     return False
@@ -750,8 +752,21 @@ def remove_doc_from_concept_pages(
             new_text = "\n".join(lines)
 
         # Drop standalone "See also: [[summaries/{doc_name}]]" lines.
+        # The dominant form (written by ``_add_related_link``) is a
+        # paragraph: preceded by a blank line and trailed by either a
+        # newline or end-of-string. The first regex matches that shape
+        # exactly, preserving one trailing newline so paragraph spacing
+        # in surrounding content survives.
         new_text = re.sub(
-            rf"^\s*See also:\s*\[\[{re.escape(bare_source)}\]\]\s*\n?",
+            rf"\n\n[ \t]*See also:[ \t]*\[\[{re.escape(bare_source)}\]\][ \t]*(\n|\Z)",
+            r"\1",
+            new_text,
+        )
+        # Fallback for hand-edited inline "See also:" lines that lack the
+        # paragraph-break separator above. Bounded to a single line via
+        # `[ \t]` and an optional trailing newline.
+        new_text = re.sub(
+            rf"^[ \t]*See also:[ \t]*\[\[{re.escape(bare_source)}\]\][ \t]*\n?",
             "",
             new_text,
             flags=re.MULTILINE,

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -445,6 +445,26 @@ def _insert_section_entry(lines: list[str], heading: str, entry: str) -> bool:
     return True
 
 
+def _remove_section_entry(lines: list[str], heading: str, link: str) -> bool:
+    """Remove the first entry whose ``link`` appears in the named section.
+
+    Returns True if an entry was removed. The match uses ``- {link}`` as
+    the prefix (the canonical bullet form that the other section helpers
+    produce); a fallback substring match catches custom bullet text.
+    """
+    bounds = _get_section_bounds(lines, heading)
+    if bounds is None:
+        return False
+
+    start, end = bounds
+    entry_prefix = f"- {link}"
+    for i in range(start, end):
+        if lines[i].startswith(entry_prefix) or link in lines[i]:
+            del lines[i]
+            return True
+    return False
+
+
 
 def _write_summary(wiki_dir: Path, doc_name: str, summary: str,
                     doc_type: str = "short") -> None:
@@ -562,6 +582,44 @@ def _prepend_source_to_frontmatter(text: str, source_file: str) -> str:
     return "\n".join(fm_lines) + body
 
 
+def _remove_source_from_frontmatter(text: str, source_file: str) -> tuple[str, bool]:
+    """Remove ``source_file`` from the inline ``sources:`` list in YAML frontmatter.
+
+    Returns ``(rewritten_text, sources_now_empty)``. ``sources_now_empty`` is
+    True when ``source_file`` was the only remaining item in the list (callers
+    can use this to decide whether to delete the page entirely).
+
+    If the frontmatter is missing, malformed, has no ``sources:`` line, or
+    the source is not present in the list, returns ``(text, False)``.
+    """
+    if not text.startswith("---"):
+        return text, False
+
+    fm_end = text.find("---", 3)
+    if fm_end == -1:
+        return text, False
+
+    fm_block = text[:fm_end]
+    body = text[fm_end:]
+    fm_lines = fm_block.split("\n")
+
+    for i, line in enumerate(fm_lines):
+        if not line.lstrip().startswith("sources:"):
+            continue
+        lb = line.find("[")
+        rb = line.rfind("]")
+        if lb == -1 or rb == -1 or rb < lb:
+            return text, False
+        items = [s.strip() for s in line[lb + 1:rb].split(",") if s.strip()]
+        if source_file not in items:
+            return text, False
+        items.remove(source_file)
+        fm_lines[i] = f"sources: [{', '.join(items)}]"
+        return "\n".join(fm_lines) + body, len(items) == 0
+
+    return text, False
+
+
 def _add_related_link(wiki_dir: Path, concept_slug: str, doc_name: str, source_file: str) -> None:
     """Add a cross-reference link to an existing concept page (no LLM call)."""
     concepts_dir = wiki_dir / "concepts"
@@ -630,6 +688,110 @@ def _backlink_concepts(wiki_dir: Path, doc_name: str, concept_slugs: list[str]) 
         _ensure_h2_section(lines, "## Related Documents")
         _insert_section_entry(lines, "## Related Documents", f"- {link}")
         path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def remove_doc_from_concept_pages(
+    wiki_dir: Path,
+    doc_name: str,
+    *,
+    keep_empty: bool = False,
+) -> dict[str, list[str]]:
+    """Update or delete concept pages affected by removing a document.
+
+    For each ``concepts/*.md`` whose frontmatter ``sources:`` lists
+    ``summaries/{doc_name}``:
+
+    - Remove that source from the frontmatter list.
+    - Remove any ``- [[summaries/{doc_name}]]`` entries from the
+      ``## Related Documents`` section.
+    - Remove any standalone ``See also: [[summaries/{doc_name}]]`` lines
+      (left by ``_add_related_link``).
+    - If the ``sources:`` list becomes empty AND ``keep_empty`` is False,
+      delete the concept page entirely.
+
+    Args:
+        wiki_dir: Path to the wiki root directory.
+        doc_name: The summary slug being removed (e.g.
+            ``"attention-is-all-you-need"``).
+        keep_empty: When True, retains concept pages whose only source
+            was the removed doc — leaves their frontmatter with an empty
+            ``sources: []`` list. Useful when the doc is being replaced
+            by a newer version that will repopulate the source on the
+            next ``openkb add``.
+
+    Returns:
+        ``{"modified": [slugs...], "deleted": [slugs...]}`` — concept
+        slugs whose pages were edited vs. deleted.
+    """
+    concepts_dir = wiki_dir / "concepts"
+    if not concepts_dir.is_dir():
+        return {"modified": [], "deleted": []}
+
+    source_file = f"summaries/{doc_name}.md"
+    bare_source = f"summaries/{doc_name}"
+    link = f"[[{bare_source}]]"
+
+    modified: list[str] = []
+    deleted: list[str] = []
+
+    for path in sorted(concepts_dir.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        # Cheap filter: skip pages that don't reference the doc at all.
+        if source_file not in text and bare_source not in text:
+            continue
+
+        new_text, sources_empty = _remove_source_from_frontmatter(text, source_file)
+
+        # Drop the doc's entry from the "## Related Documents" section.
+        if link in new_text:
+            lines = new_text.split("\n")
+            while _remove_section_entry(lines, "## Related Documents", link):
+                pass
+            new_text = "\n".join(lines)
+
+        # Drop standalone "See also: [[summaries/{doc_name}]]" lines.
+        new_text = re.sub(
+            rf"^\s*See also:\s*\[\[{re.escape(bare_source)}\]\]\s*\n?",
+            "",
+            new_text,
+            flags=re.MULTILINE,
+        )
+
+        if sources_empty and not keep_empty:
+            path.unlink()
+            deleted.append(path.stem)
+        elif new_text != text:
+            path.write_text(new_text, encoding="utf-8")
+            modified.append(path.stem)
+
+    return {"modified": modified, "deleted": deleted}
+
+
+def remove_doc_from_index(wiki_dir: Path, doc_name: str, concept_slugs_deleted: list[str]) -> None:
+    """Remove the document's entry from ``index.md`` along with any concept
+    entries for concepts that were deleted as a side effect.
+
+    No-op when ``index.md`` doesn't exist. Section headings are kept even
+    when their last entry is removed — adding a new doc later repopulates
+    them.
+    """
+    index_path = wiki_dir / "index.md"
+    if not index_path.exists():
+        return
+
+    lines = index_path.read_text(encoding="utf-8").split("\n")
+
+    doc_link = f"[[summaries/{doc_name}]]"
+    while _remove_section_entry(lines, "## Documents", doc_link):
+        pass
+
+    for slug in concept_slugs_deleted:
+        concept_link = f"[[concepts/{slug}]]"
+        while _remove_section_entry(lines, "## Concepts", concept_link):
+            pass
+
+    index_path.write_text("\n".join(lines), encoding="utf-8")
+
 
 def _update_index(
     wiki_dir: Path, doc_name: str, concept_names: list[str],

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -209,7 +209,11 @@ def add_single_file(file_path: Path, kb_dir: Path) -> None:
     # Register hash only after successful compilation
     if result.file_hash:
         doc_type = "long_pdf" if result.is_long_doc else file_path.suffix.lstrip(".")
-        registry.add(result.file_hash, {"name": file_path.name, "type": doc_type})
+        registry.add(result.file_hash, {
+            "name": file_path.name,
+            "doc_name": doc_name,
+            "type": doc_type,
+        })
 
     append_log(kb_dir / "wiki", "ingest", file_path.name)
     click.echo(f"  [OK] {file_path.name} added to knowledge base.")
@@ -528,28 +532,35 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
         actions.append(("DELETE", str(source_json.relative_to(kb_dir))))
 
     # Scan concept pages to predict which will be edited vs. deleted.
+    # Only frontmatter ``sources:`` membership drives the plan — body-only
+    # references (e.g. a stray ``See also:`` line a user added by hand
+    # without updating sources) are cleaned by the executor but don't
+    # affect the delete/edit classification, so the plan reflects what
+    # the executor will actually do.
     source_file_marker = f"summaries/{doc_name}.md"
-    bare_source = f"summaries/{doc_name}"
     affected_concepts: list[tuple[str, int]] = []  # (slug, remaining_sources)
     concepts_dir = wiki_dir / "concepts"
     if concepts_dir.is_dir():
         for path in sorted(concepts_dir.glob("*.md")):
             text = path.read_text(encoding="utf-8")
-            if source_file_marker not in text and bare_source not in text:
+            if not text.startswith("---"):
                 continue
-            # Quick parse of sources list
+            fm_end = text.find("---", 3)
+            if fm_end == -1:
+                continue
             sources_count = 0
-            if text.startswith("---"):
-                fm_end = text.find("---", 3)
-                if fm_end != -1:
-                    for line in text[:fm_end].split("\n"):
-                        if line.lstrip().startswith("sources:"):
-                            lb = line.find("[")
-                            rb = line.rfind("]")
-                            if lb != -1 and rb != -1 and rb > lb:
-                                items = [s.strip() for s in line[lb + 1:rb].split(",") if s.strip()]
-                                sources_count = len(items)
-                            break
+            source_in_frontmatter = False
+            for line in text[:fm_end].split("\n"):
+                if line.lstrip().startswith("sources:"):
+                    lb = line.find("[")
+                    rb = line.rfind("]")
+                    if lb != -1 and rb != -1 and rb > lb:
+                        items = [s.strip() for s in line[lb + 1:rb].split(",") if s.strip()]
+                        sources_count = len(items)
+                        source_in_frontmatter = source_file_marker in items
+                    break
+            if not source_in_frontmatter:
+                continue
             remaining = max(sources_count - 1, 0)
             affected_concepts.append((path.stem, remaining))
 

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -423,6 +423,204 @@ def query(ctx, question, save, raw):
         click.echo(f"\nSaved to {explore_path}")
 
 
+def _resolve_doc_identifier(registry, identifier: str) -> list[tuple[str, dict]]:
+    """Find registry entries matching ``identifier``.
+
+    Match precedence (returns immediately on the first non-empty bucket):
+      1. Exact match on ``metadata['name']`` (the original filename).
+      2. Exact match on ``metadata['doc_name']`` (the slug).
+      3. Case-insensitive substring match on either field.
+
+    Returns ``[(file_hash, metadata), ...]``. Callers handle the empty,
+    single, and multi-match cases.
+    """
+    entries = registry.all_entries()
+
+    exact_name = [(h, m) for h, m in entries.items() if m.get("name") == identifier]
+    if exact_name:
+        return exact_name
+
+    exact_slug = [(h, m) for h, m in entries.items() if m.get("doc_name") == identifier]
+    if exact_slug:
+        return exact_slug
+
+    needle = identifier.lower()
+    fuzzy = [
+        (h, m) for h, m in entries.items()
+        if needle in (m.get("name") or "").lower()
+        or needle in (m.get("doc_name") or "").lower()
+    ]
+    return fuzzy
+
+
+@cli.command()
+@click.argument("identifier")
+@click.option("--keep-raw", is_flag=True, default=False,
+              help="Don't delete the original file from raw/.")
+@click.option("--keep-empty-concepts", is_flag=True, default=False,
+              help="Keep concept pages whose only source was the removed doc "
+                   "(with empty sources frontmatter). Useful when replacing "
+                   "the doc with a newer version.")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Print what would be done without modifying anything.")
+@click.option("--yes", "-y", is_flag=True, default=False,
+              help="Skip the confirmation prompt.")
+@click.pass_context
+def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
+    """Remove a document from the knowledge base.
+
+    IDENTIFIER may be the original filename ("paper.pdf"), the doc_name
+    slug ("paper-a1b2c3d4e5f6"), or a substring that uniquely matches one.
+
+    Deletes the doc's summary and source files, prunes the doc from
+    concept-page frontmatter and Related Documents sections, drops the
+    Documents entry from index.md, removes the hash entry, and finally
+    runs `lint --fix` to clean any dangling wikilinks.
+
+    Concept pages whose only source was this doc are deleted by default;
+    use --keep-empty-concepts to retain them.
+    """
+    from openkb.agent.compiler import (
+        remove_doc_from_concept_pages,
+        remove_doc_from_index,
+    )
+    from openkb.lint import fix_broken_links
+    from openkb.state import HashRegistry
+
+    kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
+    if kb_dir is None:
+        click.echo("No knowledge base found. Run `openkb init` first.")
+        return
+
+    openkb_dir = kb_dir / ".openkb"
+    registry = HashRegistry(openkb_dir / "hashes.json")
+
+    matches = _resolve_doc_identifier(registry, identifier)
+    if not matches:
+        click.echo(f"No document matching '{identifier}' found in the KB.")
+        click.echo("Try `openkb list` to see indexed documents.")
+        return
+    if len(matches) > 1:
+        click.echo(f"'{identifier}' matches multiple documents:")
+        for _, m in matches:
+            click.echo(f"  - {m.get('name', '?')}  (doc_name: {m.get('doc_name', '?')})")
+        click.echo("Use a more specific name or the exact doc_name slug.")
+        return
+
+    file_hash, meta = matches[0]
+    name = meta.get("name", "?")
+    doc_name = meta.get("doc_name") or Path(name).stem
+    doc_type = meta.get("type", "")
+    wiki_dir = kb_dir / "wiki"
+
+    # ----- Build the plan (no side effects) -----
+    actions: list[tuple[str, str]] = []
+
+    summary_path = wiki_dir / "summaries" / f"{doc_name}.md"
+    if summary_path.exists():
+        actions.append(("DELETE", str(summary_path.relative_to(kb_dir))))
+
+    source_md = wiki_dir / "sources" / f"{doc_name}.md"
+    source_json = wiki_dir / "sources" / f"{doc_name}.json"
+    if source_md.exists():
+        actions.append(("DELETE", str(source_md.relative_to(kb_dir))))
+    if source_json.exists():
+        actions.append(("DELETE", str(source_json.relative_to(kb_dir))))
+
+    # Scan concept pages to predict which will be edited vs. deleted.
+    source_file_marker = f"summaries/{doc_name}.md"
+    bare_source = f"summaries/{doc_name}"
+    affected_concepts: list[tuple[str, int]] = []  # (slug, remaining_sources)
+    concepts_dir = wiki_dir / "concepts"
+    if concepts_dir.is_dir():
+        for path in sorted(concepts_dir.glob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            if source_file_marker not in text and bare_source not in text:
+                continue
+            # Quick parse of sources list
+            sources_count = 0
+            if text.startswith("---"):
+                fm_end = text.find("---", 3)
+                if fm_end != -1:
+                    for line in text[:fm_end].split("\n"):
+                        if line.lstrip().startswith("sources:"):
+                            lb = line.find("[")
+                            rb = line.rfind("]")
+                            if lb != -1 and rb != -1 and rb > lb:
+                                items = [s.strip() for s in line[lb + 1:rb].split(",") if s.strip()]
+                                sources_count = len(items)
+                            break
+            remaining = max(sources_count - 1, 0)
+            affected_concepts.append((path.stem, remaining))
+
+    concept_deletes = [s for s, r in affected_concepts if r == 0 and not keep_empty_concepts]
+    concept_edits = [s for s, r in affected_concepts if r > 0 or keep_empty_concepts]
+    for slug in concept_deletes:
+        actions.append(("DELETE", f"wiki/concepts/{slug}.md  (only source: this doc)"))
+    for slug in concept_edits:
+        actions.append(("MODIFY", f"wiki/concepts/{slug}.md  (drop this doc from sources)"))
+
+    if (wiki_dir / "index.md").exists():
+        actions.append(("MODIFY", "wiki/index.md  (remove Documents entry)"))
+
+    actions.append(("REGISTRY", f"remove hash entry  ({file_hash[:12]}…)"))
+
+    raw_path = None
+    if not keep_raw:
+        raw_dir = kb_dir / "raw"
+        candidate = raw_dir / name
+        if candidate.exists():
+            raw_path = candidate
+            actions.append(("DELETE", str(candidate.relative_to(kb_dir))))
+
+    # ----- Print the plan -----
+    click.echo(f"Removing '{name}' (doc_name: {doc_name}, type: {doc_type or '?'}).")
+    click.echo("")
+    for tag, target in actions:
+        click.echo(f"  {tag:<8} {target}")
+    if concept_deletes:
+        click.echo("")
+        click.echo(
+            f"  {len(concept_deletes)} concept(s) will be DELETED because this is their only source."
+        )
+        click.echo("  Pass --keep-empty-concepts to retain them instead.")
+    click.echo("")
+
+    if dry_run:
+        click.echo("(dry-run — nothing modified)")
+        return
+
+    if not yes:
+        if not click.confirm("Proceed?", default=False):
+            click.echo("Aborted.")
+            return
+
+    # ----- Execute -----
+    summary_path.unlink(missing_ok=True)
+    source_md.unlink(missing_ok=True)
+    source_json.unlink(missing_ok=True)
+
+    concept_result = remove_doc_from_concept_pages(
+        wiki_dir, doc_name, keep_empty=keep_empty_concepts,
+    )
+
+    remove_doc_from_index(wiki_dir, doc_name, concept_result["deleted"])
+
+    registry.remove_by_doc_name(doc_name)
+
+    if raw_path is not None:
+        raw_path.unlink(missing_ok=True)
+
+    # Tidy up any dangling wikilinks now pointing at the removed doc or
+    # deleted concept pages.
+    files_changed, ghosts = fix_broken_links(wiki_dir)
+    if files_changed:
+        click.echo(f"  lint --fix cleaned {ghosts} dangling wikilink(s) in {files_changed} file(s)")
+
+    append_log(wiki_dir, "remove", name)
+    click.echo(f"  [OK] {name} removed from knowledge base.")
+
+
 @cli.command()
 @click.option(
     "--resume", "-r", "resume",

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -10,6 +10,7 @@ warnings.filterwarnings("ignore")
 import asyncio
 import json
 import logging
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -162,6 +163,7 @@ def add_single_file(file_path: Path, kb_dir: Path) -> None:
         return
 
     doc_name = file_path.stem
+    index_result = None  # populated only on the long-doc branch
 
     # 3/4. Index and compile
     if result.is_long_doc:
@@ -209,11 +211,17 @@ def add_single_file(file_path: Path, kb_dir: Path) -> None:
     # Register hash only after successful compilation
     if result.file_hash:
         doc_type = "long_pdf" if result.is_long_doc else file_path.suffix.lstrip(".")
-        registry.add(result.file_hash, {
+        meta = {
             "name": file_path.name,
             "doc_name": doc_name,
             "type": doc_type,
-        })
+        }
+        # For long PDFs we also persist the PageIndex doc_id so `openkb
+        # remove` can later call ``Collection.delete_document(doc_id)``
+        # to free the managed PDF copy + SQLite row.
+        if index_result is not None:
+            meta["doc_id"] = index_result.doc_id
+        registry.add(result.file_hash, meta)
 
     append_log(kb_dir / "wiki", "ingest", file_path.name)
     click.echo(f"  [OK] {file_path.name} added to knowledge base.")
@@ -427,6 +435,45 @@ def query(ctx, question, save, raw):
         click.echo(f"\nSaved to {explore_path}")
 
 
+def _cleanup_pageindex(
+    openkb_dir: Path, kb_dir: Path, doc_name: str, doc_id: str | None,
+) -> tuple[bool, str]:
+    """Drop a long-doc entry from PageIndex's local SQLite + remove its
+    managed files. Returns ``(did_cleanup, message)``.
+
+    No-op (returns ``(False, "no PageIndex state")``) when no
+    ``pageindex.db`` exists — short-doc-only KBs never created any.
+
+    Falls back to matching by ``doc_name`` via ``list_documents()`` when
+    the registry entry pre-dates PR #51's ``doc_id`` field. Ambiguous
+    multi-match cases are skipped with a warning rather than guessed.
+    """
+    if not (openkb_dir / "pageindex.db").exists():
+        return False, "no PageIndex state"
+
+    from pageindex import PageIndexClient
+
+    _setup_llm_key(kb_dir)
+    config = load_config(openkb_dir / "config.yaml")
+    model = config.get("model", DEFAULT_CONFIG.get("model", "gpt-4o-mini"))
+    client = PageIndexClient(model=model, storage_path=str(openkb_dir))
+    col = client.collection()
+
+    if doc_id is None:
+        candidates = [d for d in col.list_documents() if d.get("doc_name") == doc_name]
+        if not candidates:
+            return False, "no PageIndex doc to delete"
+        if len(candidates) > 1:
+            return False, (
+                f"{len(candidates)} PageIndex docs match doc_name='{doc_name}'; "
+                "skipping (re-add to refresh)"
+            )
+        doc_id = candidates[0]["doc_id"]
+
+    col.delete_document(doc_id)
+    return True, f"deleted PageIndex doc ({doc_id[:12]}…)"
+
+
 def _resolve_doc_identifier(registry, identifier: str) -> list[tuple[str, dict]]:
     """Find registry entries matching ``identifier``.
 
@@ -531,6 +578,16 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
     if source_json.exists():
         actions.append(("DELETE", str(source_json.relative_to(kb_dir))))
 
+    # Per-doc extracted-images directory (PDF page images + base64 images
+    # from docx/pptx + copied relative refs from .md inputs). Created by
+    # openkb.images during ingest, keyed by doc_name.
+    images_dir = wiki_dir / "sources" / "images" / doc_name
+    if images_dir.is_dir():
+        actions.append((
+            "DELETE",
+            f"{images_dir.relative_to(kb_dir)}/  (images directory)",
+        ))
+
     # Scan concept pages to predict which will be edited vs. deleted.
     # Only frontmatter ``sources:`` membership drives the plan — body-only
     # references (e.g. a stray ``See also:`` line a user added by hand
@@ -576,6 +633,23 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
 
     actions.append(("REGISTRY", f"remove hash entry  ({file_hash[:12]}…)"))
 
+    # Long PDFs leave state in PageIndex's local store (`.openkb/pageindex.db`
+    # row + `.openkb/files/<collection>/<doc_id>.pdf` + extracted images).
+    # Only flag this when both the registry says long_pdf and PageIndex
+    # state exists on disk — short-doc-only KBs never created any.
+    pageindex_doc_id = meta.get("doc_id")
+    pageindex_state_exists = (openkb_dir / "pageindex.db").exists()
+    cleanup_pageindex = doc_type == "long_pdf" and pageindex_state_exists
+    if cleanup_pageindex:
+        if pageindex_doc_id:
+            actions.append((
+                "PAGEINDEX", f"delete document ({pageindex_doc_id[:12]}…)",
+            ))
+        else:
+            actions.append((
+                "PAGEINDEX", f"delete document (lookup by doc_name; legacy entry)",
+            ))
+
     raw_path = None
     if not keep_raw:
         raw_dir = kb_dir / "raw"
@@ -610,6 +684,8 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
     summary_path.unlink(missing_ok=True)
     source_md.unlink(missing_ok=True)
     source_json.unlink(missing_ok=True)
+    if images_dir.is_dir():
+        shutil.rmtree(images_dir, ignore_errors=True)
 
     concept_result = remove_doc_from_concept_pages(
         wiki_dir, doc_name, keep_empty=keep_empty_concepts,
@@ -621,6 +697,24 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
 
     if raw_path is not None:
         raw_path.unlink(missing_ok=True)
+
+    # Free PageIndex's local managed state for long PDFs. We do this last
+    # because the wiki side is now clean and we want a partial failure
+    # here to leave only PageIndex bloat, not a half-removed wiki.
+    if cleanup_pageindex:
+        try:
+            cleaned, msg = _cleanup_pageindex(
+                openkb_dir, kb_dir, doc_name, pageindex_doc_id,
+            )
+            click.echo(f"  PageIndex: {msg}")
+        except Exception as exc:
+            click.echo(
+                f"  [WARN] PageIndex cleanup failed: {exc} "
+                f"— .openkb/pageindex.db row and .openkb/files/ may still hold this doc"
+            )
+            logging.getLogger(__name__).debug(
+                "PageIndex cleanup traceback:", exc_info=True,
+            )
 
     # Tidy up any dangling wikilinks now pointing at the removed doc or
     # deleted concept pages.

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -681,6 +681,15 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
             return
 
     # ----- Execute -----
+    # Ordering rationale: every step before the registry write is
+    # idempotent (``unlink(missing_ok=True)``, ``shutil.rmtree(
+    # ignore_errors=True)``, concept/index helpers that no-op on
+    # already-clean state, and PageIndex's own delete-by-doc_id which
+    # uses ``missing_ok`` + ``if dir.exists()`` internally). The
+    # registry write is therefore the *commit point*: if anything
+    # before it raises (including PageIndex), the entry plus its
+    # ``doc_id`` survive and the user can simply re-run ``openkb
+    # remove`` to retry from a clean slate.
     summary_path.unlink(missing_ok=True)
     source_md.unlink(missing_ok=True)
     source_json.unlink(missing_ok=True)
@@ -693,14 +702,19 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
 
     remove_doc_from_index(wiki_dir, doc_name, concept_result["deleted"])
 
-    registry.remove_by_doc_name(doc_name)
+    # Strip dangling wikilinks now so a retry (after a PageIndex
+    # failure below) finds a clean wiki — no point in re-running this
+    # on every attempt.
+    files_changed, ghosts = fix_broken_links(wiki_dir)
+    if files_changed:
+        click.echo(f"  lint --fix cleaned {ghosts} dangling wikilink(s) in {files_changed} file(s)")
 
-    if raw_path is not None:
-        raw_path.unlink(missing_ok=True)
-
-    # Free PageIndex's local managed state for long PDFs. We do this last
-    # because the wiki side is now clean and we want a partial failure
-    # here to leave only PageIndex bloat, not a half-removed wiki.
+    # Free PageIndex's local managed state for long PDFs *before* the
+    # registry write so the user can retry on failure — leaving the
+    # entry intact preserves the ``doc_id`` we need for the second
+    # attempt. PageIndex's local dedup is SHA-256 based, so a stale row
+    # left behind here would silently re-bind on the next ``openkb
+    # add`` and the user would get the old parse back without warning.
     if cleanup_pageindex:
         try:
             cleaned, msg = _cleanup_pageindex(
@@ -710,17 +724,18 @@ def remove(ctx, identifier, keep_raw, keep_empty_concepts, dry_run, yes):
         except Exception as exc:
             click.echo(
                 f"  [WARN] PageIndex cleanup failed: {exc} "
-                f"— .openkb/pageindex.db row and .openkb/files/ may still hold this doc"
+                f"— registry entry kept; re-run `openkb remove {name}` to retry"
             )
             logging.getLogger(__name__).debug(
                 "PageIndex cleanup traceback:", exc_info=True,
             )
+            return
 
-    # Tidy up any dangling wikilinks now pointing at the removed doc or
-    # deleted concept pages.
-    files_changed, ghosts = fix_broken_links(wiki_dir)
-    if files_changed:
-        click.echo(f"  lint --fix cleaned {ghosts} dangling wikilink(s) in {files_changed} file(s)")
+    # ----- Commit point -----
+    registry.remove_by_doc_name(doc_name)
+
+    if raw_path is not None:
+        raw_path.unlink(missing_ok=True)
 
     append_log(wiki_dir, "remove", name)
     click.echo(f"  [OK] {name} removed from knowledge base.")

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -41,6 +41,15 @@ class HashRegistry:
         self._data[file_hash] = metadata
         self._persist()
 
+    def remove_by_doc_name(self, doc_name: str) -> bool:
+        """Remove the entry whose metadata['doc_name'] matches. Returns True if removed."""
+        for file_hash, meta in list(self._data.items()):
+            if meta.get("doc_name") == doc_name:
+                del self._data[file_hash]
+                self._persist()
+                return True
+        return False
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -682,3 +682,232 @@ def test_remove_doc_strips_trailing_see_also_cleanly(kb_dir):
     # Body content survives; the file does not end with two consecutive
     # newlines from a leftover blank line.
     assert out.rstrip().endswith("body")
+
+
+# ---------------------------------------------------------------------------
+# Functional-completeness fix: per-doc images directory cleanup
+# `openkb add` writes images into wiki/sources/images/<doc_name>/. Remove
+# must take that whole tree with it — otherwise image-heavy docs leak
+# tens to hundreds of MB per add → remove cycle.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_remove_deletes_per_doc_images_directory(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+
+    # Plant a populated images directory for attention.pdf.
+    images_dir = kb_dir / "wiki" / "sources" / "images" / "attention-h_a"
+    images_dir.mkdir(parents=True)
+    (images_dir / "p1_img1.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    (images_dir / "p2_img1.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    # Unrelated doc's images dir must survive.
+    other_images = kb_dir / "wiki" / "sources" / "images" / "llm-h_l"
+    other_images.mkdir(parents=True)
+    (other_images / "p1_img1.png").write_bytes(b"\x89PNG")
+
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "images directory" in result.output  # mentioned in plan
+    assert not images_dir.exists()
+    # Sibling doc's image dir is untouched.
+    assert other_images.exists()
+    assert (other_images / "p1_img1.png").exists()
+
+
+def test_cli_remove_dry_run_does_not_touch_images(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    images_dir = kb_dir / "wiki" / "sources" / "images" / "attention-h_a"
+    images_dir.mkdir(parents=True)
+    (images_dir / "p1_img1.png").write_bytes(b"\x89PNG")
+
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "images directory" in result.output
+    # Directory still on disk after dry-run.
+    assert images_dir.exists()
+    assert (images_dir / "p1_img1.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# Functional-completeness fix: `doc_id` is persisted for long PDFs so a
+# later `openkb remove` can call PageIndex's delete_document API.
+# ---------------------------------------------------------------------------
+
+
+def test_add_long_pdf_persists_doc_id_to_registry(tmp_path):
+    """Long-doc ingest must record `doc_id` in the registry. Without it,
+    the remove path has no handle to feed `Collection.delete_document`.
+    """
+    from openkb.converter import ConvertResult
+    from openkb.indexer import IndexResult
+
+    # Minimal KB
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki" / "summaries").mkdir(parents=True)
+    (tmp_path / "wiki" / "sources" / "images").mkdir(parents=True)
+    (tmp_path / "wiki" / "concepts").mkdir(parents=True)
+    (tmp_path / "wiki" / "explorations").mkdir(parents=True)
+    (tmp_path / "wiki" / "reports").mkdir(parents=True)
+    (tmp_path / "wiki" / "index.md").write_text(
+        "# Knowledge Base Index\n\n## Documents\n\n## Concepts\n\n## Explorations\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "wiki" / "log.md").write_text("# Log\n", encoding="utf-8")
+    openkb_dir = tmp_path / ".openkb"
+    openkb_dir.mkdir()
+    (openkb_dir / "config.yaml").write_text("model: gpt-4o-mini\n")
+    (openkb_dir / "hashes.json").write_text("{}")
+
+    pdf = tmp_path / "long.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n" + b"\x00" * 200)
+    raw_path = tmp_path / "raw" / "long.pdf"
+    raw_path.write_bytes(pdf.read_bytes())
+
+    convert_mock = ConvertResult(
+        raw_path=raw_path,
+        source_path=None,
+        is_long_doc=True,
+        file_hash="cafebabe" * 8,
+    )
+    index_mock = IndexResult(
+        doc_id="pi-doc-abc123", description="A long PDF", tree={},
+    )
+
+    runner = CliRunner()
+    with patch("openkb.cli._find_kb_dir", return_value=tmp_path), \
+         patch("openkb.cli.convert_document", return_value=convert_mock), \
+         patch("openkb.indexer.index_long_document", return_value=index_mock), \
+         patch("openkb.cli.asyncio.run"):
+        result = runner.invoke(cli, ["add", str(pdf)])
+
+    assert result.exit_code == 0, result.output
+    hashes = json.loads((openkb_dir / "hashes.json").read_text())
+    (_, meta), = hashes.items()
+    assert meta["type"] == "long_pdf"
+    assert meta["doc_id"] == "pi-doc-abc123"
+
+
+# ---------------------------------------------------------------------------
+# Functional-completeness fix: PageIndex local state cleanup on remove.
+# ---------------------------------------------------------------------------
+
+
+def _seed_long_pdf_kb(kb_dir: Path, doc_id: str | None = "pi-doc-xyz") -> None:
+    """Seed a KB with a single long-PDF entry plus a stub pageindex.db
+    file so the remove command treats the doc as PageIndex-backed.
+    """
+    meta = {
+        "name": "paper.pdf",
+        "doc_name": "paper",
+        "type": "long_pdf",
+        "path": "raw/paper.pdf",
+    }
+    if doc_id is not None:
+        meta["doc_id"] = doc_id
+    (kb_dir / ".openkb" / "hashes.json").write_text(json.dumps({"h_paper": meta}))
+    (kb_dir / "raw" / "paper.pdf").write_bytes(b"%PDF-fake")
+    (kb_dir / "wiki" / "summaries" / "paper.md").write_text(
+        "---\nsources: [raw/paper.pdf]\nbrief: x\n---\n# Paper\n", encoding="utf-8",
+    )
+    (kb_dir / "wiki" / "sources" / "paper.json").write_text("[]", encoding="utf-8")
+    (kb_dir / "wiki" / "index.md").write_text(
+        "# Knowledge Base Index\n\n## Documents\n- [[summaries/paper]] (long_pdf) - x\n\n"
+        "## Concepts\n\n## Explorations\n",
+        encoding="utf-8",
+    )
+    (kb_dir / "wiki" / "log.md").write_text("# Log\n", encoding="utf-8")
+    # Stub PageIndex state — its mere existence flips the cleanup path on.
+    (kb_dir / ".openkb" / "pageindex.db").write_bytes(b"SQLite format 3\x00")
+
+
+def test_cli_remove_calls_pageindex_delete_with_stored_doc_id(kb_dir):
+    """When the registry entry has a `doc_id`, remove must call
+    `Collection.delete_document(doc_id)` directly — no list_documents
+    lookup needed.
+    """
+    _seed_long_pdf_kb(kb_dir, doc_id="pi-doc-xyz")
+
+    fake_col = MagicMock()
+    fake_client = MagicMock()
+    fake_client.collection.return_value = fake_col
+
+    with patch("pageindex.PageIndexClient", return_value=fake_client) as mock_cls, \
+         patch("openkb.cli._setup_llm_key"):
+        result = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    mock_cls.assert_called_once()
+    # Storage path must point at the KB's .openkb directory.
+    _, kwargs = mock_cls.call_args
+    assert kwargs.get("storage_path") == str(kb_dir / ".openkb")
+    fake_col.delete_document.assert_called_once_with("pi-doc-xyz")
+    fake_col.list_documents.assert_not_called()  # No fallback needed
+    assert "PageIndex" in result.output
+
+
+def test_cli_remove_pageindex_fallback_lookup_by_doc_name(kb_dir):
+    """Legacy registry entries (added before PR #51) have no `doc_id`.
+    The remove path must fall back to matching by doc_name via
+    list_documents() so existing KBs aren't permanently leaking.
+    """
+    _seed_long_pdf_kb(kb_dir, doc_id=None)
+
+    fake_col = MagicMock()
+    fake_col.list_documents.return_value = [
+        {"doc_id": "pi-found-id", "doc_name": "paper", "doc_type": "pdf"},
+        {"doc_id": "pi-other-id", "doc_name": "other", "doc_type": "pdf"},
+    ]
+    fake_client = MagicMock()
+    fake_client.collection.return_value = fake_col
+
+    with patch("pageindex.PageIndexClient", return_value=fake_client), \
+         patch("openkb.cli._setup_llm_key"):
+        result = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    fake_col.list_documents.assert_called_once()
+    fake_col.delete_document.assert_called_once_with("pi-found-id")
+
+
+def test_cli_remove_pageindex_fallback_skips_on_ambiguous_match(kb_dir):
+    """Two PageIndex docs share doc_name='paper' (different ingests). The
+    fallback must refuse to guess; the rest of the remove flow still
+    completes and the WARN is surfaced.
+    """
+    _seed_long_pdf_kb(kb_dir, doc_id=None)
+
+    fake_col = MagicMock()
+    fake_col.list_documents.return_value = [
+        {"doc_id": "pi-a", "doc_name": "paper"},
+        {"doc_id": "pi-b", "doc_name": "paper"},
+    ]
+    fake_client = MagicMock()
+    fake_client.collection.return_value = fake_col
+
+    with patch("pageindex.PageIndexClient", return_value=fake_client), \
+         patch("openkb.cli._setup_llm_key"):
+        result = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    fake_col.delete_document.assert_not_called()
+    assert "skipping" in result.output
+    # The wiki-side cleanup still ran.
+    assert not (kb_dir / "wiki" / "summaries" / "paper.md").exists()
+
+
+def test_cli_remove_skips_pageindex_when_no_state_file(kb_dir):
+    """Short-doc-only KBs never created `.openkb/pageindex.db`. The
+    remove flow must not import or instantiate PageIndexClient in that
+    case — opening it would unnecessarily require an LLM key.
+    """
+    _seed_two_doc_kb(kb_dir)
+    assert not (kb_dir / ".openkb" / "pageindex.db").exists()
+
+    with patch("pageindex.PageIndexClient") as mock_cls:
+        result = _invoke(kb_dir, ["remove", "attention.pdf", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    mock_cls.assert_not_called()
+    assert "PageIndex" not in result.output

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -19,6 +19,7 @@ import pytest
 from click.testing import CliRunner
 
 from openkb.agent.compiler import (
+    _remove_section_entry,
     _remove_source_from_frontmatter,
     remove_doc_from_concept_pages,
     remove_doc_from_index,
@@ -477,3 +478,207 @@ def test_cli_remove_lint_cleans_dangling_links(kb_dir):
     assert result.exit_code == 0, result.output
     cleaned = llm_path.read_text()
     assert "[[summaries/attention-h_a]]" not in cleaned
+
+
+# ---------------------------------------------------------------------------
+# Regression: code-review issue #1
+# `openkb add` must persist `doc_name` so `remove_by_doc_name` can prune
+# the registry entry. Earlier add_single_file only stored `name` + `type`,
+# so the new remove flow silently no-op'd on the registry write.
+# ---------------------------------------------------------------------------
+
+
+def test_add_persists_doc_name_for_later_remove(tmp_path):
+    """End-to-end: `openkb add` writes a registry entry with `doc_name`,
+    and a subsequent `openkb remove` actually prunes that entry.
+    """
+    from openkb.converter import ConvertResult
+
+    # Minimal KB scaffolding (mirrors conftest.kb_dir but localised so we
+    # can fully control the add pipeline via mocks below).
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki" / "summaries").mkdir(parents=True)
+    (tmp_path / "wiki" / "sources" / "images").mkdir(parents=True)
+    (tmp_path / "wiki" / "concepts").mkdir(parents=True)
+    (tmp_path / "wiki" / "explorations").mkdir(parents=True)
+    (tmp_path / "wiki" / "reports").mkdir(parents=True)
+    (tmp_path / "wiki" / "index.md").write_text(
+        "# Knowledge Base Index\n\n## Documents\n\n## Concepts\n\n## Explorations\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "wiki" / "log.md").write_text("# Log\n", encoding="utf-8")
+    openkb_dir = tmp_path / ".openkb"
+    openkb_dir.mkdir()
+    (openkb_dir / "config.yaml").write_text("model: gpt-4o-mini\n")
+    (openkb_dir / "hashes.json").write_text("{}")
+
+    doc = tmp_path / "paper.md"
+    doc.write_text("# Hello", encoding="utf-8")
+    raw_path = tmp_path / "raw" / "paper.md"
+    raw_path.write_text("# Hello", encoding="utf-8")
+    source_path = tmp_path / "wiki" / "sources" / "paper.md"
+    source_path.write_text("# Hello converted", encoding="utf-8")
+    summary_path = tmp_path / "wiki" / "summaries" / "paper.md"
+    summary_path.write_text(
+        "---\nsources: [raw/paper.md]\nbrief: x\n---\n# Paper\n",
+        encoding="utf-8",
+    )
+
+    mock_result = ConvertResult(
+        raw_path=raw_path,
+        source_path=source_path,
+        is_long_doc=False,
+        file_hash="deadbeef" * 8,  # 64 hex chars
+    )
+
+    runner = CliRunner()
+    # Mock convert_document + asyncio.run to skip the LLM-driven compile.
+    with patch("openkb.cli._find_kb_dir", return_value=tmp_path), \
+         patch("openkb.cli.convert_document", return_value=mock_result), \
+         patch("openkb.cli.asyncio.run"):
+        add_res = runner.invoke(cli, ["add", str(doc)])
+    assert add_res.exit_code == 0, add_res.output
+
+    # The registry write contract: doc_name must be present.
+    hashes = json.loads((openkb_dir / "hashes.json").read_text())
+    assert len(hashes) == 1
+    (_, meta), = hashes.items()
+    assert meta["name"] == "paper.md"
+    assert meta["doc_name"] == "paper"
+    assert meta["type"] == "md"
+
+    # And the remove command must actually drop that entry — not silently no-op.
+    rm_res = runner.invoke(
+        cli, ["--kb-dir", str(tmp_path), "remove", "paper.md", "--keep-raw", "--yes"],
+    )
+    assert rm_res.exit_code == 0, rm_res.output
+    assert json.loads((openkb_dir / "hashes.json").read_text()) == {}
+
+
+# ---------------------------------------------------------------------------
+# Regression: code-review issue #2
+# `_remove_section_entry` must match the canonical `- {link}` bullet form
+# strictly; a substring fallback wrongly deleted sibling entries whose
+# brief text referenced the removed link.
+# ---------------------------------------------------------------------------
+
+
+def test_remove_section_entry_strict_prefix_no_sibling_overdelete():
+    lines = [
+        "## Documents",
+        "- [[summaries/attn-x]] (short) - The attn paper",
+        "- [[summaries/survey-y]] (short) - supersedes [[summaries/attn-x]]",
+        "- [[summaries/other-z]] (short) - unrelated",
+        "",
+        "## Concepts",
+    ]
+    removed = _remove_section_entry(lines, "## Documents", "[[summaries/attn-x]]")
+
+    assert removed is True
+    # Only the actual attn-x bullet is gone; the survey-y entry that
+    # *mentions* attn-x in its brief survives intact.
+    joined = "\n".join(lines)
+    assert "- [[summaries/attn-x]]" not in joined
+    assert "- [[summaries/survey-y]]" in joined
+    assert "supersedes [[summaries/attn-x]]" in joined
+    assert "- [[summaries/other-z]]" in joined
+
+
+def test_remove_section_entry_skips_non_bullet_mentions():
+    """A wikilink embedded in a paragraph (no bullet prefix) must not
+    be deleted — the helper only manages canonical bullet entries.
+    """
+    lines = [
+        "## Related Documents",
+        "This concept is mostly covered by [[summaries/attn-x]] in spirit.",
+        "- [[summaries/survey-y]]",
+        "",
+    ]
+    removed = _remove_section_entry(lines, "## Related Documents", "[[summaries/attn-x]]")
+
+    assert removed is False  # No `- [[summaries/attn-x]]` bullet in section.
+    assert any("This concept is mostly covered by [[summaries/attn-x]]" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# Regression: code-review issue #3
+# CLI plan-builder must classify concept pages by frontmatter `sources:`
+# membership only — body-only references (e.g. a stray "See also:" or an
+# unrelated wikilink in the body) should not flip the page into DELETE.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_remove_ignores_body_only_reference_in_plan(kb_dir):
+    """A concept whose frontmatter sources do NOT include the removed doc
+    but whose body has a `See also:` line should not appear in the DELETE
+    or MODIFY action list for that doc.
+    """
+    _seed_two_doc_kb(kb_dir)
+
+    # Plant a concept whose frontmatter source is llm-h_l only, but whose
+    # body mentions attention-h_a via "See also:". When we remove
+    # attention.pdf, this page should NOT be reported as affected.
+    stray = kb_dir / "wiki" / "concepts" / "stray.md"
+    stray.write_text(
+        "---\nsources: [summaries/llm-h_l.md]\nbrief: stray\n---\n"
+        "# Stray\n\nbody text\n\nSee also: [[summaries/attention-h_a]]\n",
+        encoding="utf-8",
+    )
+
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    # Plan must not announce any action on `stray` for this removal.
+    assert "concepts/stray.md" not in result.output
+    # Sanity: the regular affected concepts are still listed.
+    assert "concepts/transformer.md" in result.output
+    assert "concepts/attention.md" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Regression: code-review issue #4
+# `See also:` stripping must preserve surrounding paragraph spacing — the
+# earlier `\s*` greediness collapsed blank lines and left orphan blank
+# lines at end-of-file.
+# ---------------------------------------------------------------------------
+
+
+def test_remove_doc_strips_see_also_without_collapsing_paragraphs(kb_dir):
+    wiki = kb_dir / "wiki"
+    path = wiki / "concepts" / "c.md"
+    path.write_text(
+        "---\nsources: [summaries/a.md, summaries/b.md]\n---\n"
+        "# c\n\npara1\n\nSee also: [[summaries/a]]\n\npara2\n",
+        encoding="utf-8",
+    )
+
+    remove_doc_from_concept_pages(wiki, "a")
+
+    out = path.read_text(encoding="utf-8")
+    # The See also line is gone.
+    assert "See also: [[summaries/a]]" not in out
+    # And the surrounding blank-line separator between para1 and para2
+    # is preserved (markdown paragraph break still intact).
+    assert "para1\n\npara2" in out
+
+
+def test_remove_doc_strips_trailing_see_also_cleanly(kb_dir):
+    """When `_add_related_link` appends `\\n\\nSee also: link` and removal
+    is requested, the trailing See also block should disappear cleanly
+    without leaving a dangling double-blank line at end-of-file.
+    """
+    wiki = kb_dir / "wiki"
+    path = wiki / "concepts" / "c.md"
+    path.write_text(
+        "---\nsources: [summaries/a.md, summaries/b.md]\n---\n"
+        "# c\n\nbody\n\nSee also: [[summaries/a]]",
+        encoding="utf-8",
+    )
+
+    remove_doc_from_concept_pages(wiki, "a")
+
+    out = path.read_text(encoding="utf-8")
+    assert "See also" not in out
+    # Body content survives; the file does not end with two consecutive
+    # newlines from a leftover blank line.
+    assert out.rstrip().endswith("body")

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,479 @@
+"""Tests for the `openkb remove` feature.
+
+Covers:
+- compiler helpers (`_remove_source_from_frontmatter`,
+  `remove_doc_from_concept_pages`, `remove_doc_from_index`)
+- `HashRegistry.remove_by_doc_name`
+- The `openkb remove` CLI: identifier resolution, dry-run, --yes,
+  --keep-raw, --keep-empty-concepts, error paths, and the auto
+  `lint --fix` post-pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from openkb.agent.compiler import (
+    _remove_source_from_frontmatter,
+    remove_doc_from_concept_pages,
+    remove_doc_from_index,
+)
+from openkb.cli import _resolve_doc_identifier, cli
+from openkb.state import HashRegistry
+
+
+# ---------------------------------------------------------------------------
+# _remove_source_from_frontmatter
+# ---------------------------------------------------------------------------
+
+
+def test_remove_source_drops_only_target_and_marks_empty():
+    text = "---\nsources: [summaries/a.md]\nbrief: x\n---\n\nbody\n"
+    rewritten, empty = _remove_source_from_frontmatter(text, "summaries/a.md")
+    assert empty is True
+    assert "sources: []" in rewritten
+    assert rewritten.endswith("\nbody\n")
+
+
+def test_remove_source_keeps_others():
+    text = (
+        "---\nsources: [summaries/a.md, summaries/b.md, summaries/c.md]\n"
+        "brief: x\n---\n\nbody\n"
+    )
+    rewritten, empty = _remove_source_from_frontmatter(text, "summaries/b.md")
+    assert empty is False
+    assert "summaries/a.md" in rewritten
+    assert "summaries/c.md" in rewritten
+    assert "summaries/b.md" not in rewritten
+
+
+def test_remove_source_noop_when_not_present():
+    text = "---\nsources: [summaries/a.md]\n---\n\nbody\n"
+    rewritten, empty = _remove_source_from_frontmatter(text, "summaries/z.md")
+    assert rewritten == text
+    assert empty is False
+
+
+def test_remove_source_noop_without_frontmatter():
+    text = "# No frontmatter\n\nbody only\n"
+    rewritten, empty = _remove_source_from_frontmatter(text, "summaries/a.md")
+    assert rewritten == text
+    assert empty is False
+
+
+def test_remove_source_noop_malformed_brackets():
+    text = "---\nsources: summaries/a.md\n---\nbody\n"
+    rewritten, empty = _remove_source_from_frontmatter(text, "summaries/a.md")
+    assert rewritten == text
+    assert empty is False
+
+
+# ---------------------------------------------------------------------------
+# remove_doc_from_concept_pages
+# ---------------------------------------------------------------------------
+
+
+def _write_concept(wiki_dir: Path, slug: str, sources: list[str], body: str = "") -> Path:
+    src_inline = "[" + ", ".join(sources) + "]"
+    related = "\n".join(
+        f"- [[{s.replace('.md', '')}]]" for s in sources
+    )
+    text = (
+        f"---\nsources: {src_inline}\nbrief: stub\n---\n\n"
+        f"# {slug}\n\n{body}\n\n"
+        f"## Related Documents\n{related}\n"
+    )
+    path = wiki_dir / "concepts" / f"{slug}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_remove_doc_from_concept_pages_deletes_single_source(kb_dir):
+    wiki = kb_dir / "wiki"
+    p = _write_concept(wiki, "transformer", ["summaries/attn-x.md"])
+
+    result = remove_doc_from_concept_pages(wiki, "attn-x")
+
+    assert result == {"modified": [], "deleted": ["transformer"]}
+    assert not p.exists()
+
+
+def test_remove_doc_from_concept_pages_keeps_with_flag(kb_dir):
+    wiki = kb_dir / "wiki"
+    p = _write_concept(wiki, "transformer", ["summaries/attn-x.md"])
+
+    result = remove_doc_from_concept_pages(wiki, "attn-x", keep_empty=True)
+
+    assert result == {"modified": ["transformer"], "deleted": []}
+    assert p.exists()
+    text = p.read_text(encoding="utf-8")
+    assert "sources: []" in text
+    assert "[[summaries/attn-x]]" not in text
+
+
+def test_remove_doc_from_concept_pages_edits_multi_source(kb_dir):
+    wiki = kb_dir / "wiki"
+    p = _write_concept(
+        wiki, "attention",
+        ["summaries/attn-x.md", "summaries/survey-y.md"],
+    )
+
+    result = remove_doc_from_concept_pages(wiki, "attn-x")
+
+    assert result == {"modified": ["attention"], "deleted": []}
+    text = p.read_text(encoding="utf-8")
+    assert "summaries/attn-x.md" not in text
+    assert "summaries/survey-y.md" in text
+    assert "[[summaries/attn-x]]" not in text
+    assert "[[summaries/survey-y]]" in text
+
+
+def test_remove_doc_from_concept_pages_strips_see_also(kb_dir):
+    wiki = kb_dir / "wiki"
+    text = (
+        "---\nsources: [summaries/a.md, summaries/b.md]\n---\n"
+        "# c\n\nbody\n\nSee also: [[summaries/a]]\n"
+    )
+    p = wiki / "concepts" / "c.md"
+    p.write_text(text, encoding="utf-8")
+
+    remove_doc_from_concept_pages(wiki, "a")
+
+    out = p.read_text(encoding="utf-8")
+    assert "See also: [[summaries/a]]" not in out
+
+
+def test_remove_doc_from_concept_pages_skips_unrelated(kb_dir):
+    wiki = kb_dir / "wiki"
+    p = _write_concept(wiki, "other", ["summaries/unrelated-z.md"])
+    before = p.read_text(encoding="utf-8")
+
+    result = remove_doc_from_concept_pages(wiki, "attn-x")
+
+    assert result == {"modified": [], "deleted": []}
+    assert p.read_text(encoding="utf-8") == before
+
+
+def test_remove_doc_from_concept_pages_missing_dir(tmp_path):
+    # No concepts/ directory exists at all — should return empty result.
+    result = remove_doc_from_concept_pages(tmp_path / "nope", "anything")
+    assert result == {"modified": [], "deleted": []}
+
+
+# ---------------------------------------------------------------------------
+# remove_doc_from_index
+# ---------------------------------------------------------------------------
+
+
+def test_remove_doc_from_index_drops_doc_and_deleted_concepts(kb_dir):
+    wiki = kb_dir / "wiki"
+    (wiki / "index.md").write_text(
+        "# Knowledge Base Index\n\n"
+        "## Documents\n"
+        "- [[summaries/attn-x]] (short) - foo\n"
+        "- [[summaries/survey-y]] (short) - bar\n\n"
+        "## Concepts\n"
+        "- [[concepts/transformer]] - Architecture\n"
+        "- [[concepts/attention]] - Mechanism\n\n"
+        "## Explorations\n",
+        encoding="utf-8",
+    )
+
+    remove_doc_from_index(wiki, "attn-x", concept_slugs_deleted=["transformer"])
+
+    text = (wiki / "index.md").read_text(encoding="utf-8")
+    assert "[[summaries/attn-x]]" not in text
+    assert "[[summaries/survey-y]]" in text
+    assert "[[concepts/transformer]]" not in text
+    assert "[[concepts/attention]]" in text
+    # Section headings preserved even when last item removed
+    assert "## Documents" in text and "## Concepts" in text
+
+
+def test_remove_doc_from_index_noop_when_missing(tmp_path):
+    # Should not raise when index.md doesn't exist.
+    remove_doc_from_index(tmp_path / "wiki", "anything", [])
+
+
+# ---------------------------------------------------------------------------
+# HashRegistry.remove_by_doc_name
+# ---------------------------------------------------------------------------
+
+
+def test_hash_registry_remove_by_doc_name(tmp_path):
+    path = tmp_path / "hashes.json"
+    path.write_text(json.dumps({
+        "h1": {"name": "a.pdf", "doc_name": "a-h1", "type": "short"},
+        "h2": {"name": "b.pdf", "doc_name": "b-h2", "type": "short"},
+    }))
+
+    reg = HashRegistry(path)
+    assert reg.remove_by_doc_name("a-h1") is True
+    assert reg.remove_by_doc_name("a-h1") is False  # already gone
+    assert "h2" in reg.all_entries() and "h1" not in reg.all_entries()
+
+    # Persisted to disk
+    saved = json.loads(path.read_text())
+    assert list(saved.keys()) == ["h2"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_doc_identifier
+# ---------------------------------------------------------------------------
+
+
+def _make_registry(tmp_path: Path, entries: dict[str, dict]) -> HashRegistry:
+    p = tmp_path / "hashes.json"
+    p.write_text(json.dumps(entries))
+    return HashRegistry(p)
+
+
+def test_resolve_identifier_exact_name_wins(tmp_path):
+    reg = _make_registry(tmp_path, {
+        "h1": {"name": "attention.pdf", "doc_name": "attention-h1"},
+        "h2": {"name": "attention-survey.pdf", "doc_name": "attention-survey-h2"},
+    })
+    matches = _resolve_doc_identifier(reg, "attention.pdf")
+    assert [h for h, _ in matches] == ["h1"]
+
+
+def test_resolve_identifier_exact_doc_name(tmp_path):
+    reg = _make_registry(tmp_path, {
+        "h1": {"name": "a.pdf", "doc_name": "a-h1"},
+        "h2": {"name": "b.pdf", "doc_name": "b-h2"},
+    })
+    matches = _resolve_doc_identifier(reg, "b-h2")
+    assert [h for h, _ in matches] == ["h2"]
+
+
+def test_resolve_identifier_fuzzy_returns_all(tmp_path):
+    reg = _make_registry(tmp_path, {
+        "h1": {"name": "attention-paper.pdf", "doc_name": "attention-paper-h1"},
+        "h2": {"name": "llm-attention.pdf", "doc_name": "llm-attention-h2"},
+        "h3": {"name": "unrelated.pdf", "doc_name": "unrelated-h3"},
+    })
+    matches = _resolve_doc_identifier(reg, "attention")
+    assert sorted(h for h, _ in matches) == ["h1", "h2"]
+
+
+def test_resolve_identifier_empty(tmp_path):
+    reg = _make_registry(tmp_path, {
+        "h1": {"name": "a.pdf", "doc_name": "a-h1"},
+    })
+    assert _resolve_doc_identifier(reg, "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# CLI: openkb remove
+# ---------------------------------------------------------------------------
+
+
+def _seed_two_doc_kb(kb_dir: Path) -> None:
+    """Build a KB with two summaries and three concepts spanning them.
+
+    Layout:
+      raw/attention.pdf, raw/llm-survey.pdf
+      wiki/summaries/{attention-h_a.md, llm-h_l.md}
+      wiki/concepts/transformer.md (sources: attention only — single-source)
+      wiki/concepts/attention.md   (sources: both — multi-source)
+      wiki/concepts/llm.md         (sources: llm only — single-source)
+      wiki/index.md with both Documents and all three Concepts entries
+    """
+    (kb_dir / ".openkb" / "hashes.json").write_text(json.dumps({
+        "h_a": {
+            "name": "attention.pdf", "doc_name": "attention-h_a",
+            "type": "short", "path": "raw/attention.pdf",
+        },
+        "h_l": {
+            "name": "llm-survey.pdf", "doc_name": "llm-h_l",
+            "type": "short", "path": "raw/llm-survey.pdf",
+        },
+    }))
+    (kb_dir / "raw" / "attention.pdf").write_bytes(b"%PDF-attention")
+    (kb_dir / "raw" / "llm-survey.pdf").write_bytes(b"%PDF-llm")
+
+    (kb_dir / "wiki" / "summaries" / "attention-h_a.md").write_text(
+        "---\nsources: [raw/attention.pdf]\nbrief: Attn\n---\n"
+        "# Attention\n\nLinks [[concepts/transformer]] and [[concepts/attention]].\n",
+        encoding="utf-8",
+    )
+    (kb_dir / "wiki" / "summaries" / "llm-h_l.md").write_text(
+        "---\nsources: [raw/llm-survey.pdf]\nbrief: LLM\n---\n"
+        "# LLM Survey\n\nLinks [[concepts/llm]] and [[concepts/attention]].\n",
+        encoding="utf-8",
+    )
+
+    (kb_dir / "wiki" / "concepts" / "transformer.md").write_text(
+        "---\nsources: [summaries/attention-h_a.md]\nbrief: T\n---\n"
+        "# Transformer\n\n## Related Documents\n- [[summaries/attention-h_a]]\n",
+        encoding="utf-8",
+    )
+    (kb_dir / "wiki" / "concepts" / "attention.md").write_text(
+        "---\nsources: [summaries/attention-h_a.md, summaries/llm-h_l.md]\nbrief: A\n---\n"
+        "# Attention\n\n## Related Documents\n"
+        "- [[summaries/attention-h_a]]\n- [[summaries/llm-h_l]]\n",
+        encoding="utf-8",
+    )
+    (kb_dir / "wiki" / "concepts" / "llm.md").write_text(
+        "---\nsources: [summaries/llm-h_l.md]\nbrief: L\n---\n"
+        "# LLM\n\n## Related Documents\n- [[summaries/llm-h_l]]\n",
+        encoding="utf-8",
+    )
+
+    (kb_dir / "wiki" / "index.md").write_text(
+        "# Knowledge Base Index\n\n"
+        "## Documents\n"
+        "- [[summaries/attention-h_a]] (short) - Attn paper\n"
+        "- [[summaries/llm-h_l]] (short) - LLM survey\n\n"
+        "## Concepts\n"
+        "- [[concepts/transformer]] - Architecture\n"
+        "- [[concepts/attention]] - Mechanism\n"
+        "- [[concepts/llm]] - General LLM\n\n"
+        "## Explorations\n",
+        encoding="utf-8",
+    )
+
+    (kb_dir / "wiki" / "log.md").write_text("# Log\n", encoding="utf-8")
+
+
+def _invoke(kb_dir, args, input_text=None):
+    return CliRunner().invoke(
+        cli, ["--kb-dir", str(kb_dir), *args], input=input_text,
+    )
+
+
+def test_cli_remove_dry_run_does_nothing(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output
+    assert "DELETE" in result.output
+    # All files still present
+    assert (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+    assert (kb_dir / "wiki" / "concepts" / "transformer.md").exists()
+    assert (kb_dir / "raw" / "attention.pdf").exists()
+    hashes = json.loads((kb_dir / ".openkb" / "hashes.json").read_text())
+    assert "h_a" in hashes
+
+
+def test_cli_remove_yes_executes_full_plan(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--yes"])
+
+    assert result.exit_code == 0, result.output
+
+    # Summary + single-source concept gone
+    assert not (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+    assert not (kb_dir / "wiki" / "concepts" / "transformer.md").exists()
+
+    # Multi-source concept kept, but source dropped
+    attn = (kb_dir / "wiki" / "concepts" / "attention.md").read_text()
+    assert "attention-h_a" not in attn
+    assert "llm-h_l" in attn
+
+    # Untouched concept stays
+    assert (kb_dir / "wiki" / "concepts" / "llm.md").exists()
+
+    # Raw file gone (no --keep-raw)
+    assert not (kb_dir / "raw" / "attention.pdf").exists()
+
+    # Hash registry pruned
+    hashes = json.loads((kb_dir / ".openkb" / "hashes.json").read_text())
+    assert "h_a" not in hashes and "h_l" in hashes
+
+    # Index updated
+    index = (kb_dir / "wiki" / "index.md").read_text()
+    assert "summaries/attention-h_a" not in index
+    assert "concepts/transformer" not in index
+    assert "summaries/llm-h_l" in index
+    assert "concepts/attention" in index
+
+    # Log appended
+    assert "remove" in (kb_dir / "wiki" / "log.md").read_text()
+
+
+def test_cli_remove_keep_raw_preserves_file(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--keep-raw", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert (kb_dir / "raw" / "attention.pdf").exists()
+    assert not (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+
+
+def test_cli_remove_keep_empty_concepts(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(
+        kb_dir, ["remove", "attention.pdf", "--keep-empty-concepts", "--yes"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # transformer.md retained with empty sources
+    transformer = kb_dir / "wiki" / "concepts" / "transformer.md"
+    assert transformer.exists()
+    assert "sources: []" in transformer.read_text()
+
+
+def test_cli_remove_by_doc_name_slug(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(kb_dir, ["remove", "attention-h_a", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+
+
+def test_cli_remove_unknown_identifier(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    result = _invoke(kb_dir, ["remove", "no-such-doc", "--yes"])
+
+    assert result.exit_code == 0
+    assert "No document matching" in result.output
+    # Nothing modified
+    assert (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+
+
+def test_cli_remove_ambiguous_identifier(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    # "h_" substring matches both doc_names; should refuse to act.
+    result = _invoke(kb_dir, ["remove", "h_", "--yes"])
+
+    assert result.exit_code == 0
+    assert "matches multiple" in result.output
+    assert (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+    assert (kb_dir / "wiki" / "summaries" / "llm-h_l.md").exists()
+
+
+def test_cli_remove_confirm_no_aborts(kb_dir):
+    _seed_two_doc_kb(kb_dir)
+    # No --yes; reply "n" to the confirm prompt.
+    result = _invoke(kb_dir, ["remove", "attention.pdf"], input_text="n\n")
+
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    assert (kb_dir / "wiki" / "summaries" / "attention-h_a.md").exists()
+
+
+def test_cli_remove_lint_cleans_dangling_links(kb_dir):
+    """`openkb remove` must auto-run lint --fix so wikilinks pointing at
+    the deleted summary/concept get stripped from sibling pages.
+    """
+    _seed_two_doc_kb(kb_dir)
+    # Plant a stray reference to the about-to-be-deleted summary inside
+    # the surviving concept's body (not in any structured section).
+    llm_path = kb_dir / "wiki" / "concepts" / "llm.md"
+    llm_path.write_text(
+        llm_path.read_text() + "\nSee also [[summaries/attention-h_a]] for background.\n",
+        encoding="utf-8",
+    )
+
+    result = _invoke(kb_dir, ["remove", "attention.pdf", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    cleaned = llm_path.read_text()
+    assert "[[summaries/attention-h_a]]" not in cleaned

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -911,3 +911,77 @@ def test_cli_remove_skips_pageindex_when_no_state_file(kb_dir):
     assert result.exit_code == 0, result.output
     mock_cls.assert_not_called()
     assert "PageIndex" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Consistency-fix regression: PageIndex failure must NOT clear the registry,
+# so the user can retry. The previous order removed the registry entry first
+# and then attempted PageIndex cleanup — leaving an orphan SQLite row that
+# silently re-bound on the next `openkb add` via PageIndex's SHA-256 dedup.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_remove_pageindex_failure_preserves_registry_for_retry(kb_dir):
+    """When `_cleanup_pageindex` raises, the registry entry (and its
+    `doc_id`) must survive so a subsequent `openkb remove` invocation
+    has the handle needed to retry. Wiki-side cleanup still happens
+    because every step is idempotent across retries.
+    """
+    _seed_long_pdf_kb(kb_dir, doc_id="pi-doc-xyz")
+
+    fake_client = MagicMock()
+    fake_client.collection.side_effect = RuntimeError("LLM key missing")
+
+    with patch("pageindex.PageIndexClient", return_value=fake_client), \
+         patch("openkb.cli._setup_llm_key"):
+        result = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+
+    # Command exits cleanly with a WARN — not an error code — because the
+    # user has a clear path forward (re-run).
+    assert result.exit_code == 0, result.output
+    assert "[WARN]" in result.output
+    assert "re-run" in result.output
+
+    # Registry entry is intact for retry.
+    hashes = json.loads((kb_dir / ".openkb" / "hashes.json").read_text())
+    assert "h_paper" in hashes
+    assert hashes["h_paper"]["doc_id"] == "pi-doc-xyz"
+
+    # Wiki side was cleaned (idempotent on retry).
+    assert not (kb_dir / "wiki" / "summaries" / "paper.md").exists()
+    assert not (kb_dir / "wiki" / "sources" / "paper.json").exists()
+
+
+def test_cli_remove_retry_after_pageindex_failure_completes(kb_dir):
+    """First attempt fails at PageIndex; second attempt with a working
+    PageIndex completes the removal. Validates that the post-failure
+    state is fully retryable.
+    """
+    _seed_long_pdf_kb(kb_dir, doc_id="pi-doc-xyz")
+
+    # First attempt: PageIndex raises.
+    failing_client = MagicMock()
+    failing_client.collection.side_effect = RuntimeError("transient")
+    with patch("pageindex.PageIndexClient", return_value=failing_client), \
+         patch("openkb.cli._setup_llm_key"):
+        first = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+    assert first.exit_code == 0
+    assert "[WARN]" in first.output
+    # Registry entry survived for retry.
+    assert "h_paper" in json.loads((kb_dir / ".openkb" / "hashes.json").read_text())
+
+    # Second attempt: PageIndex succeeds. Same doc_id must drive the
+    # delete since it's still in the registry.
+    working_col = MagicMock()
+    working_client = MagicMock()
+    working_client.collection.return_value = working_col
+    with patch("pageindex.PageIndexClient", return_value=working_client), \
+         patch("openkb.cli._setup_llm_key"):
+        second = _invoke(kb_dir, ["remove", "paper.pdf", "--keep-raw", "--yes"])
+
+    assert second.exit_code == 0, second.output
+    working_col.delete_document.assert_called_once_with("pi-doc-xyz")
+
+    # Registry now empty; wiki cleanup remains complete.
+    assert json.loads((kb_dir / ".openkb" / "hashes.json").read_text()) == {}
+    assert not (kb_dir / "wiki" / "summaries" / "paper.md").exists()


### PR DESCRIPTION
## Summary
- Adds `openkb remove <identifier>` for safely deleting a document from a knowledge base in one step, with a plan/confirm flow.
- Identifier resolves by exact filename → exact `doc_name` slug → fuzzy substring; ambiguous matches refuse to act.
- Concept pages whose only source was the removed doc are deleted by default; `--keep-empty-concepts` retains them with empty sources (useful when replacing the doc with a newer version). `--keep-raw` preserves the original file in `raw/`. `--dry-run` prints the plan only, `--yes` skips the confirm prompt.
- Auto-runs `lint --fix` after removal so stray wikilinks pointing at the removed summary or deleted concept pages get stripped automatically.

Closes #41.

## Test plan
- [x] `pytest` — full suite 287 passed (260 prior + 27 new in `tests/test_remove.py`).
- [x] End-to-end smoke test on a 2-doc / 3-concept KB:
  - single-source concept is deleted; multi-source concept is edited; unrelated concept untouched
  - `index.md` Documents + deleted-Concepts entries pruned, surviving entries kept
  - `--keep-raw` and `--keep-empty-concepts` flag paths verified
  - `--dry-run` prints plan without touching disk
  - dangling `[[summaries/...]]` link in a sibling page is stripped by the auto `lint --fix` pass
- [x] Ambiguous and unknown identifiers fail safe (no files modified).