### PR TITLE
chore: clean up CodeQL py/* quality alerts (40 fixes across 3 rules)

### DIFF
--- a/openkb/agent/chat.py
+++ b/openkb/agent/chat.py
@@ -338,7 +338,6 @@ async def _run_turn(
     need_blank_before_text = False
 
     if use_color and not raw:
-        from rich.console import Console
         from rich.live import Live
 
         console = _make_rich_console()

--- a/openkb/agent/linter.py
+++ b/openkb/agent/linter.py
@@ -8,7 +8,7 @@ from agents import Agent, Runner, function_tool
 from openkb.agent.tools import list_wiki_files, read_wiki_file
 
 MAX_TURNS = 50
-from openkb.schema import SCHEMA_MD, get_agents_md
+from openkb.schema import get_agents_md
 
 _LINTER_INSTRUCTIONS_TEMPLATE = """\
 You are OpenKB's semantic lint agent. Your job is to audit the wiki

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -113,7 +113,7 @@ async def run_query(
         The agent's final answer as a string.
     """
     import sys
-    from agents import RawResponsesStreamEvent, RunItemStreamEvent, ItemHelpers
+    from agents import RawResponsesStreamEvent, RunItemStreamEvent
     from openai.types.responses import ResponseTextDeltaEvent
     from openkb.config import load_config
 

--- a/openkb/agent/tools.py
+++ b/openkb/agent/tools.py
@@ -6,6 +6,7 @@ tested in isolation without requiring the openai-agents runtime.
 """
 from __future__ import annotations
 
+import contextlib
 import json as _json
 from pathlib import Path
 
@@ -71,7 +72,9 @@ def parse_pages(pages: str) -> list[int]:
             segments = part.split("-")
             # Re-join to handle leading negatives: segments[0] may be empty
             # if part starts with "-".  We just try to parse start/end.
-            try:
+            # Silently skip malformed segments — parse_pages is a tolerant
+            # parser by design (user-supplied page specs may contain typos).
+            with contextlib.suppress(ValueError):
                 if len(segments) == 2:
                     start, end = int(segments[0]), int(segments[1])
                     result.update(range(start, end + 1))
@@ -79,13 +82,9 @@ def parse_pages(pages: str) -> list[int]:
                     # e.g. "-1" split gives ['', '1']
                     result.add(-int(segments[1]))
                 # More complex cases (e.g. negative range) are ignored.
-            except ValueError:
-                pass
         else:
-            try:
+            with contextlib.suppress(ValueError):
                 result.add(int(part))
-            except ValueError:
-                pass
     return sorted(n for n in result if n > 0)
 
 

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import shutil
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import pymupdf

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 from click.testing import CliRunner
 
 from openkb.cli import SUPPORTED_EXTENSIONS, _find_kb_dir, cli
@@ -71,7 +69,7 @@ class TestAddCommand:
         runner = CliRunner()
         with patch("openkb.cli.add_single_file") as mock_add, \
              patch("openkb.cli._find_kb_dir", return_value=kb_dir):
-            result = runner.invoke(cli, ["add", str(doc)])
+            runner.invoke(cli, ["add", str(doc)])
             mock_add.assert_called_once_with(doc, kb_dir)
 
     def test_add_directory_calls_helper_for_each_file(self, tmp_path):
@@ -85,7 +83,7 @@ class TestAddCommand:
         runner = CliRunner()
         with patch("openkb.cli.add_single_file") as mock_add, \
              patch("openkb.cli._find_kb_dir", return_value=kb_dir):
-            result = runner.invoke(cli, ["add", str(docs_dir)])
+            runner.invoke(cli, ["add", str(docs_dir)])
             # Should be called for .md and .txt but not .xyz
             assert mock_add.call_count == 2
             called_names = {call.args[0].name for call in mock_add.call_args_list}
@@ -121,7 +119,7 @@ class TestAddCommand:
 
         runner = CliRunner()
         with patch("openkb.cli._find_kb_dir", return_value=kb_dir), \
-             patch("openkb.cli.convert_document", return_value=mock_result) as mock_conv, \
+             patch("openkb.cli.convert_document", return_value=mock_result), \
              patch("openkb.cli.asyncio.run") as mock_arun:
             result = runner.invoke(cli, ["add", str(doc)])
             assert "SKIP" in result.output

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,9 +1,7 @@
 """Tests for openkb.agent.tools — plain function implementations."""
 from __future__ import annotations
 
-from pathlib import Path
 
-import pytest
 
 from openkb.agent.tools import get_wiki_page_content, list_wiki_files, parse_pages, read_wiki_file, write_wiki_file
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import json
 from unittest.mock import patch
 
-import pytest
 import yaml
 from click.testing import CliRunner
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-import pytest
-from pathlib import Path
 from openkb.config import DEFAULT_CONFIG, load_config, save_config
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,13 +1,10 @@
 """Tests for openkb.converter."""
 from __future__ import annotations
 
-import shutil
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
-from openkb.converter import ConvertResult, convert_document, get_pdf_page_count
+from openkb.converter import convert_document, get_pdf_page_count
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
-import pytest
 from click.testing import CliRunner
 
 from openkb.cli import (

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -2,10 +2,7 @@
 from __future__ import annotations
 
 import base64
-import shutil
-from pathlib import Path
 
-import pytest
 
 from openkb.images import copy_relative_images, extract_base64_images
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,10 +1,8 @@
 """Tests for openkb.indexer."""
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from openkb.indexer import IndexResult, index_long_document
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from openkb.lint import (
     _normalize_target,
@@ -195,7 +194,7 @@ class TestCheckIndexSync:
 
 class TestRunStructuralLint:
     def test_returns_markdown_report(self, tmp_path):
-        wiki = _make_wiki(tmp_path)
+        _make_wiki(tmp_path)
         raw = tmp_path / "raw"
         raw.mkdir()
 
@@ -208,7 +207,7 @@ class TestRunStructuralLint:
         assert "Index Sync" in report
 
     def test_clean_kb_shows_no_issues(self, tmp_path):
-        wiki = _make_wiki(tmp_path)
+        _make_wiki(tmp_path)
         raw = tmp_path / "raw"
         raw.mkdir()
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,7 +1,6 @@
 """Tests for openkb.agent.linter (Task 14)."""
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_list_status.py
+++ b/tests/test_list_status.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 from click.testing import CliRunner
 
 from openkb.cli import cli

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import io
 import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -15,7 +15,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from openkb.agent.compiler import (

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,4 @@
-import pytest
 import json
-from pathlib import Path
 from openkb.state import HashRegistry
 
 

--- a/tests/test_tree_renderer.py
+++ b/tests/test_tree_renderer.py
@@ -1,7 +1,6 @@
 """Tests for openkb.tree_renderer."""
 from __future__ import annotations
 
-import pytest
 
 from openkb.tree_renderer import render_summary_md
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,9 +1,8 @@
 """Tests for openkb.watcher (Task 12)."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 from openkb.watcher import DebouncedHandler
 


### PR DESCRIPTION
## Summary

Three CodeQL Code Quality rules cleared in one pass — **40 alerts → 0**, all 329 tests still pass, no behaviour change.

| Rule | Fixes | How |
|---|---|---|
| [`py/unused-import`](https://github.com/VectifyAI/OpenKB/security/quality/rules/py/unused-import) | 33 | `ruff check --select F401 --fix` |
| [`py/unused-local-variable`](https://github.com/VectifyAI/OpenKB/security/quality/rules/py/unused-local-variable) | 5 | hand-edits (drop binding, keep call's side effect) |
| [`py/empty-except`](https://github.com/VectifyAI/OpenKB/security/quality/rules/py/empty-except) | 2 | `except ValueError: pass` → `with contextlib.suppress(ValueError):` |

Also checked: `py/mixed-returns` and `py/multiple-definition` — both **0 hits** in the current codebase, no fixes needed.

## Production-code changes (5 files)

All are conservative — none change runtime behaviour:

| File | Change |
|---|---|
| `openkb/agent/chat.py:341` | drop unused `Console` import (line 307 already imports it) |
| `openkb/agent/linter.py:11` | drop unused `SCHEMA_MD`, keep `get_agents_md` |
| `openkb/agent/query.py:116` | drop unused `ItemHelpers`, keep `RawResponsesStreamEvent`, `RunItemStreamEvent` |
| `openkb/converter.py:6` | drop unused `field`, keep `dataclass` |
| `openkb/agent/tools.py` | `try/except ValueError: pass` × 2 → `contextlib.suppress(ValueError)` in `parse_pages` (tolerant page-range parser; behaviour preserved, intent now explicit) |

## Test-code changes

29 unused imports auto-removed across `tests/` (leftover `import pytest`, `from pathlib import Path`, unused mock classes from test scaffolding).

5 unused locals fixed:
- `tests/test_add_command.py:72, 86, 122` — captured `result = runner.invoke(...)` / `as mock_conv` but never asserted against them
- `tests/test_lint.py:197, 210` — captured `wiki = _make_wiki(tmp_path)` but only the helper's directory-creation side effect mattered

## Test plan
- [x] `uv run ruff check --select F401,F841,S110,S112,F811 openkb/ tests/` → All checks passed!
- [x] `uv run pytest -q` → 329 passed (zero regression)
- [x] Manual AST scan for empty `except` blocks: 0
- [ ] CI green