### PR TITLE
fix(compiler): enable JSON mode + harden plan handling (closes #71)

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -357,6 +357,22 @@ def _filter_concept_items(items: list, label: str) -> list[dict]:
     return valid
 
 
+def _require_nonempty_content(content, name: str) -> None:
+    """Raise if a concept body is missing or whitespace-only.
+
+    Under ``response_format=json_object`` the LLM can legally return
+    ``{"content": null}`` or ``{"content": ""}`` — typically a refusal
+    or a content-policy hit. Without this guard, ``_gen_create`` /
+    ``_gen_update`` would return an empty tuple that ``pending_writes``
+    accepts as a successful concept, then ``_write_concept`` would commit
+    an empty Markdown page to disk and ``[OK]`` would print as if all
+    was well. Raising here makes the failure visible through the
+    existing ``failure_types`` collector + partial-failure ``[WARN]``.
+    """
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError(f"LLM returned empty content for concept {name!r}")
+
+
 def _filter_related_slugs(items: list) -> list[str]:
     """Keep only non-empty string slugs; warn about anything else.
 
@@ -1055,6 +1071,25 @@ async def _compile_concepts(
     update_items = plan["update"]
     related_items = plan["related"]
 
+    # Detect "plan had items but the filters dropped them all". Without
+    # this, the early-return below looks identical to "LLM legitimately
+    # had nothing to add" — the exact silent-loss-looks-like-success bug
+    # PR #75's [WARN] mechanism set out to fix.
+    if isinstance(parsed, list):
+        original_total = len(parsed)
+    else:
+        original_total = sum(
+            len(parsed.get(k, [])) if isinstance(parsed.get(k), list) else 0
+            for k in ("create", "update", "related")
+        )
+    post_filter_total = len(create_items) + len(update_items) + len(related_items)
+    if original_total > 0 and post_filter_total == 0:
+        sys.stdout.write(
+            f"    [WARN] concepts plan for {doc_name} had {original_total} "
+            f"item(s), all dropped as malformed — see log (stderr).\n"
+        )
+        sys.stdout.flush()
+
     if not create_items and not update_items and not related_items:
         if rewrite_summary:
             _write_v1_summary_stripped()
@@ -1113,9 +1148,15 @@ async def _compile_concepts(
         try:
             parsed = _parse_json(raw)
             brief = parsed.get("brief", "")
-            content = parsed.get("content", raw)
+            # ``.get("content", raw)`` only uses the default when the key is
+            # absent — ``{"content": null}`` (legal under json_object mode
+            # for a refused/empty page) returns None. ``or raw`` collapses
+            # null/empty to the raw fallback so the validator below sees
+            # a consistent string-or-empty.
+            content = parsed.get("content") or raw
         except (json.JSONDecodeError, ValueError):
             brief, content = "", raw
+        _require_nonempty_content(content, name)
         return name, content, False, brief
 
     async def _gen_update(concept: dict) -> tuple[str, str, bool, str]:
@@ -1145,9 +1186,10 @@ async def _compile_concepts(
         try:
             parsed = _parse_json(raw)
             brief = parsed.get("brief", "")
-            content = parsed.get("content", raw)
+            content = parsed.get("content") or raw
         except (json.JSONDecodeError, ValueError):
             brief, content = "", raw
+        _require_nonempty_content(content, name)
         return name, content, True, brief
 
     tasks = []

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -306,23 +306,53 @@ def _parse_json(text: str) -> list | dict:
 
 
 def _filter_concept_items(items: list, label: str) -> list[dict]:
-    """Keep only dict items; warn about anything else.
+    """Keep only dicts that carry a non-empty ``name``; warn about anything else.
 
     The concepts-plan prompt asks for ``[{"name": ..., "title": ...}, ...]``
-    but LLMs occasionally emit nested lists or bare strings. Letting those
-    through crashes ``_gen_create`` at ``concept.get("title")`` and silently
-    loses every concept in the batch (issue #71).
+    but LLMs occasionally emit nested lists, bare strings, or dicts that
+    forgot ``name``. JSON mode constrains syntax, not schema, so all of
+    these still slip through ``_parse_json``. Without this guard a
+    name-less dict crashes the ``planned_slugs`` set comprehension
+    (``c["name"]`` → KeyError) and aborts the whole concepts step.
     """
     if not isinstance(items, list):
         logger.warning("concepts plan: %s was %s, expected list — dropping",
                        label, type(items).__name__)
         return []
-    valid = [c for c in items if isinstance(c, dict)]
+    valid = [c for c in items if isinstance(c, dict) and isinstance(c.get("name"), str) and c["name"].strip()]
     if len(valid) < len(items):
-        bad_types = sorted({type(c).__name__ for c in items if not isinstance(c, dict)})
+        reasons: list[str] = []
+        for c in items:
+            if not isinstance(c, dict):
+                reasons.append(type(c).__name__)
+            elif not isinstance(c.get("name"), str) or not c["name"].strip():
+                reasons.append("dict-missing-name")
         logger.warning(
-            "concepts plan: dropped %d malformed %s item(s) (types: %s)",
-            len(items) - len(valid), label, ", ".join(bad_types),
+            "concepts plan: dropped %d malformed %s item(s) (reasons: %s)",
+            len(items) - len(valid), label, ", ".join(sorted(set(reasons))),
+        )
+    return valid
+
+
+def _filter_related_slugs(items: list) -> list[str]:
+    """Keep only non-empty string slugs; warn about anything else.
+
+    ``related`` is documented in the prompt as "array of slug strings",
+    but the same shape drift that motivates ``_filter_concept_items``
+    applies here. Non-strings reaching ``_sanitize_concept_name`` raise
+    TypeError inside ``unicodedata.normalize`` and crash the whole
+    ``_compile_concepts`` call.
+    """
+    if not isinstance(items, list):
+        logger.warning("concepts plan: related was %s, expected list — dropping",
+                       type(items).__name__)
+        return []
+    valid = [s for s in items if isinstance(s, str) and s.strip()]
+    if len(valid) < len(items):
+        bad_types = sorted({type(s).__name__ for s in items if not (isinstance(s, str) and s.strip())})
+        logger.warning(
+            "concepts plan: dropped %d malformed related item(s) (types: %s)",
+            len(items) - len(valid), ", ".join(bad_types),
         )
     return valid
 
@@ -993,7 +1023,7 @@ async def _compile_concepts(
         plan = {
             "create": _filter_concept_items(parsed.get("create", []), "create"),
             "update": _filter_concept_items(parsed.get("update", []), "update"),
-            "related": parsed.get("related", []),
+            "related": _filter_related_slugs(parsed.get("related", [])),
         }
 
     create_items = plan["create"]

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -37,12 +37,8 @@ logger = logging.getLogger(__name__)
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-# JSON-mode hint for calls whose prompt asks the LLM to return a JSON object.
-# Most providers (OpenAI, DeepSeek, Qwen, Kimi, GLM, MiniMax, Doubao) accept
-# this kwarg and switch into a JSON-constrained decoding mode; providers that
-# don't will either ignore it or raise BadRequestError (caller's choice).
-# DeepSeek/Qwen also require the prompt itself to mention "json", which the
-# templates below already satisfy.
+# DeepSeek/Qwen require the prompt itself to mention "json" when this kwarg
+# is set; the templates below already do.
 _JSON_RESPONSE_FORMAT = {"type": "json_object"}
 
 _SYSTEM_TEMPLATE = """\
@@ -293,12 +289,10 @@ async def _llm_call_async(model: str, messages: list[dict], step_name: str, **kw
 
 
 def _warn_if_truncated(response, step_name: str, max_tokens: int | None) -> None:
-    """Surface ``finish_reason == 'length'`` as a visible warning.
+    """Emit a warning when the LLM hit the max_tokens cap.
 
-    When the LLM hits the ``max_tokens`` cap mid-response, ``json_repair``
-    will often salvage the truncated prefix and parsing silently succeeds
-    with a smaller-than-intended payload. Flagging it here lets users
-    distinguish "LLM emitted a short plan" from "LLM was cut off".
+    ``json_repair`` will silently salvage the truncated prefix, so without
+    this the caller can't tell a short response from a cut-off one.
     """
     try:
         finish_reason = response.choices[0].finish_reason
@@ -329,15 +323,7 @@ def _parse_json(text: str) -> list | dict:
 
 
 def _filter_concept_items(items: list, label: str) -> list[dict]:
-    """Keep only dicts that carry a non-empty ``name``; warn about anything else.
-
-    The concepts-plan prompt asks for ``[{"name": ..., "title": ...}, ...]``
-    but LLMs occasionally emit nested lists, bare strings, or dicts that
-    forgot ``name``. JSON mode constrains syntax, not schema, so all of
-    these still slip through ``_parse_json``. Without this guard a
-    name-less dict crashes the ``planned_slugs`` set comprehension
-    (``c["name"]`` → KeyError) and aborts the whole concepts step.
-    """
+    """Keep only dicts that carry a non-empty ``name``; warn about anything else."""
     if not isinstance(items, list):
         logger.warning("concepts plan: %s was %s, expected list — dropping",
                        label, type(items).__name__)
@@ -358,30 +344,13 @@ def _filter_concept_items(items: list, label: str) -> list[dict]:
 
 
 def _require_nonempty_content(content, name: str) -> None:
-    """Raise if a concept body is missing or whitespace-only.
-
-    Under ``response_format=json_object`` the LLM can legally return
-    ``{"content": null}`` or ``{"content": ""}`` — typically a refusal
-    or a content-policy hit. Without this guard, ``_gen_create`` /
-    ``_gen_update`` would return an empty tuple that ``pending_writes``
-    accepts as a successful concept, then ``_write_concept`` would commit
-    an empty Markdown page to disk and ``[OK]`` would print as if all
-    was well. Raising here makes the failure visible through the
-    existing ``failure_types`` collector + partial-failure ``[WARN]``.
-    """
+    """Raise if a concept body is missing or whitespace-only."""
     if not isinstance(content, str) or not content.strip():
         raise ValueError(f"LLM returned empty content for concept {name!r}")
 
 
 def _filter_related_slugs(items: list) -> list[str]:
-    """Keep only non-empty string slugs; warn about anything else.
-
-    ``related`` is documented in the prompt as "array of slug strings",
-    but the same shape drift that motivates ``_filter_concept_items``
-    applies here. Non-strings reaching ``_sanitize_concept_name`` raise
-    TypeError inside ``unicodedata.normalize`` and crash the whole
-    ``_compile_concepts`` call.
-    """
+    """Keep only non-empty string slugs; warn about anything else."""
     if not isinstance(items, list):
         logger.warning("concepts plan: related was %s, expected list — dropping",
                        type(items).__name__)
@@ -1034,9 +1003,6 @@ async def _compile_concepts(
     try:
         parsed = _parse_json(plan_raw)
     except (json.JSONDecodeError, ValueError) as exc:
-        # Surface the first 500 chars at WARNING so operators not running
-        # with DEBUG enabled can still diagnose; keep the full raw at
-        # DEBUG for the truncation-past-500 case (see issue #71).
         preview = plan_raw[:500] + ("..." if len(plan_raw) > 500 else "")
         logger.warning(
             "Failed to parse concepts plan: %s. Raw output (first 500 chars): %r",
@@ -1055,8 +1021,6 @@ async def _compile_concepts(
         return
 
     # Fallback: if LLM returns a flat list, treat all items as "create".
-    # Validate each item is a dict — without this, a nested list like
-    # [[{...}]] crashes _gen_create at `concept.get("title")` (issue #71).
     if isinstance(parsed, list):
         plan = {"create": _filter_concept_items(parsed, "list"),
                 "update": [], "related": []}
@@ -1071,10 +1035,7 @@ async def _compile_concepts(
     update_items = plan["update"]
     related_items = plan["related"]
 
-    # Detect "plan had items but the filters dropped them all". Without
-    # this, the early-return below looks identical to "LLM legitimately
-    # had nothing to add" — the exact silent-loss-looks-like-success bug
-    # PR #75's [WARN] mechanism set out to fix.
+    # Distinguish "filters dropped everything" from "LLM emitted an empty plan".
     if isinstance(parsed, list):
         original_total = len(parsed)
     else:
@@ -1148,11 +1109,8 @@ async def _compile_concepts(
         try:
             parsed = _parse_json(raw)
             brief = parsed.get("brief", "")
-            # ``.get("content", raw)`` only uses the default when the key is
-            # absent — ``{"content": null}`` (legal under json_object mode
-            # for a refused/empty page) returns None. ``or raw`` collapses
-            # null/empty to the raw fallback so the validator below sees
-            # a consistent string-or-empty.
+            # ``or raw``: ``.get("content", raw)`` returns None for
+            # ``{"content": null}`` (legal under json_object mode).
             content = parsed.get("content") or raw
         except (json.JSONDecodeError, ValueError):
             brief, content = "", raw
@@ -1220,12 +1178,8 @@ async def _compile_concepts(
             if brief:
                 concept_briefs_map[safe_name] = brief
 
-        # Surface partial/total failure prominently: WARNING logs are easy to
-        # miss in long compile output, and the [OK] line at the end of `add`
-        # is unconditional. Issue #71: silent loss of all concepts looked
-        # like success to the user. Include exception type names inline so
-        # the stdout line is self-contained (the per-failure WARNING logs
-        # go to stderr, which a stdout-only consumer never sees).
+        # Include exception type names inline so the stdout line is
+        # self-contained — per-failure WARNINGs go to stderr.
         written = len(pending_writes)
         if written < total:
             reason = (

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -37,6 +37,14 @@ logger = logging.getLogger(__name__)
 # Prompt templates
 # ---------------------------------------------------------------------------
 
+# JSON-mode hint for calls whose prompt asks the LLM to return a JSON object.
+# Most providers (OpenAI, DeepSeek, Qwen, Kimi, GLM, MiniMax, Doubao) accept
+# this kwarg and switch into a JSON-constrained decoding mode; providers that
+# don't will either ignore it or raise BadRequestError (caller's choice).
+# DeepSeek/Qwen also require the prompt itself to mention "json", which the
+# templates below already satisfy.
+_JSON_RESPONSE_FORMAT = {"type": "json_object"}
+
 _SYSTEM_TEMPLATE = """\
 You are OpenKB's wiki compilation agent for a personal knowledge base.
 
@@ -295,6 +303,28 @@ def _parse_json(text: str) -> list | dict:
     if not isinstance(result, (dict, list)):
         raise ValueError(f"Expected JSON object or array, got {type(result).__name__}")
     return result
+
+
+def _filter_concept_items(items: list, label: str) -> list[dict]:
+    """Keep only dict items; warn about anything else.
+
+    The concepts-plan prompt asks for ``[{"name": ..., "title": ...}, ...]``
+    but LLMs occasionally emit nested lists or bare strings. Letting those
+    through crashes ``_gen_create`` at ``concept.get("title")`` and silently
+    loses every concept in the batch (issue #71).
+    """
+    if not isinstance(items, list):
+        logger.warning("concepts plan: %s was %s, expected list — dropping",
+                       label, type(items).__name__)
+        return []
+    valid = [c for c in items if isinstance(c, dict)]
+    if len(valid) < len(items):
+        bad_types = sorted({type(c).__name__ for c in items if not isinstance(c, dict)})
+        logger.warning(
+            "concepts plan: dropped %d malformed %s item(s) (types: %s)",
+            len(items) - len(valid), label, ", ".join(bad_types),
+        )
+    return valid
 
 
 # ---------------------------------------------------------------------------
@@ -911,7 +941,7 @@ async def _compile_concepts(
         {"role": "user", "content": _CONCEPTS_PLAN_USER.format(
             concept_briefs=concept_briefs,
         )},
-    ], "concepts-plan", max_tokens=1024)
+    ], "concepts-plan", max_tokens=1024, response_format=_JSON_RESPONSE_FORMAT)
 
     def _write_v1_summary_stripped() -> None:
         """Fallback writer for the v1 summary on early-return paths.
@@ -935,20 +965,34 @@ async def _compile_concepts(
     try:
         parsed = _parse_json(plan_raw)
     except (json.JSONDecodeError, ValueError) as exc:
-        logger.warning("Failed to parse concepts plan: %s", exc)
-        logger.debug("Raw: %s", plan_raw)
+        # Include raw output preview in the WARNING itself (was DEBUG-only).
+        # Without this, users hitting LLM gibberish have no way to diagnose
+        # why no concepts were generated — see issue #71.
+        preview = plan_raw[:500] + ("..." if len(plan_raw) > 500 else "")
+        logger.warning(
+            "Failed to parse concepts plan: %s. Raw output (first 500 chars): %r",
+            exc, preview,
+        )
+        sys.stdout.write(
+            f"    [WARN] concepts plan unparseable for {doc_name} — "
+            f"no concept pages generated. See log above.\n"
+        )
+        sys.stdout.flush()
         if rewrite_summary:
             _write_v1_summary_stripped()
         _update_index(wiki_dir, doc_name, [], doc_brief=doc_brief, doc_type=doc_type)
         return
 
-    # Fallback: if LLM returns a flat list, treat all items as "create"
+    # Fallback: if LLM returns a flat list, treat all items as "create".
+    # Validate each item is a dict — without this, a nested list like
+    # [[{...}]] crashes _gen_create at `concept.get("title")` (issue #71).
     if isinstance(parsed, list):
-        plan = {"create": parsed, "update": [], "related": []}
+        plan = {"create": _filter_concept_items(parsed, "list"),
+                "update": [], "related": []}
     else:
         plan = {
-            "create": parsed.get("create", []),
-            "update": parsed.get("update", []),
+            "create": _filter_concept_items(parsed.get("create", []), "create"),
+            "update": _filter_concept_items(parsed.get("update", []), "update"),
             "related": parsed.get("related", []),
         }
 
@@ -1010,7 +1054,7 @@ async def _compile_concepts(
                     title=title, doc_name=doc_name,
                     update_instruction="",
                 )},
-            ], f"concept: {name}")
+            ], f"concept: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
             parsed = _parse_json(raw)
             brief = parsed.get("brief", "")
@@ -1042,7 +1086,7 @@ async def _compile_concepts(
                     title=title, doc_name=doc_name,
                     existing_content=existing_content,
                 )},
-            ], f"update: {name}")
+            ], f"update: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
             parsed = _parse_json(raw)
             brief = parsed.get("brief", "")
@@ -1076,6 +1120,18 @@ async def _compile_concepts(
             concept_names.append(safe_name)
             if brief:
                 concept_briefs_map[safe_name] = brief
+
+        # Surface partial/total failure prominently: WARNING logs are easy to
+        # miss in long compile output, and the [OK] line at the end of `add`
+        # is unconditional. Issue #71: silent loss of all concepts looked
+        # like success to the user.
+        written = len(pending_writes)
+        if written < total:
+            sys.stdout.write(
+                f"    [WARN] {total} concept(s) planned but only {written} written "
+                f"for {doc_name} — check warnings above.\n"
+            )
+            sys.stdout.flush()
 
     # Strip unresolved wikilinks from concept bodies before writing. The
     # whitelist includes existing files + this round's planned slugs +
@@ -1212,7 +1268,8 @@ async def compile_short_doc(
     # for the plan + concept-generation calls, then rewritten into a final
     # v2 (with a whitelist of known wikilink targets) inside
     # _compile_concepts before being written to disk.
-    summary_raw = _llm_call(model, [system_msg, doc_msg], "summary")
+    summary_raw = _llm_call(model, [system_msg, doc_msg], "summary",
+                             response_format=_JSON_RESPONSE_FORMAT)
     try:
         summary_parsed = _parse_json(summary_raw)
         doc_brief = summary_parsed.get("brief", "")

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -266,6 +266,7 @@ def _llm_call(model: str, messages: list[dict], step_name: str, **kwargs) -> str
 
     response = litellm.completion(model=model, messages=messages, **kwargs)
     content = response.choices[0].message.content or ""
+    _warn_if_truncated(response, step_name, kwargs.get("max_tokens"))
 
     spinner.stop(_format_usage(time.time() - t0, response.usage))
     logger.debug("LLM response [%s]:\n%s", step_name, content[:500] + ("..." if len(content) > 500 else ""))
@@ -282,12 +283,34 @@ async def _llm_call_async(model: str, messages: list[dict], step_name: str, **kw
 
     response = await litellm.acompletion(model=model, messages=messages, **kwargs)
     content = response.choices[0].message.content or ""
+    _warn_if_truncated(response, step_name, kwargs.get("max_tokens"))
 
     elapsed = time.time() - t0
     sys.stdout.write(f"    {step_name}... {_format_usage(elapsed, response.usage)}\n")
     sys.stdout.flush()
     logger.debug("LLM response [%s]:\n%s", step_name, content[:500] + ("..." if len(content) > 500 else ""))
     return content.strip()
+
+
+def _warn_if_truncated(response, step_name: str, max_tokens: int | None) -> None:
+    """Surface ``finish_reason == 'length'`` as a visible warning.
+
+    When the LLM hits the ``max_tokens`` cap mid-response, ``json_repair``
+    will often salvage the truncated prefix and parsing silently succeeds
+    with a smaller-than-intended payload. Flagging it here lets users
+    distinguish "LLM emitted a short plan" from "LLM was cut off".
+    """
+    try:
+        finish_reason = response.choices[0].finish_reason
+    except (AttributeError, IndexError):
+        return
+    if finish_reason != "length":
+        return
+    cap = f" (max_tokens={max_tokens})" if max_tokens else ""
+    logger.warning("LLM [%s] hit length limit%s — output may be truncated.",
+                   step_name, cap)
+    sys.stdout.write(f"    [WARN] {step_name} hit length limit{cap} — output may be truncated.\n")
+    sys.stdout.flush()
 
 
 def _parse_json(text: str) -> list | dict:
@@ -971,7 +994,7 @@ async def _compile_concepts(
         {"role": "user", "content": _CONCEPTS_PLAN_USER.format(
             concept_briefs=concept_briefs,
         )},
-    ], "concepts-plan", max_tokens=1024, response_format=_JSON_RESPONSE_FORMAT)
+    ], "concepts-plan", max_tokens=2048, response_format=_JSON_RESPONSE_FORMAT)
 
     def _write_v1_summary_stripped() -> None:
         """Fallback writer for the v1 summary on early-return paths.
@@ -995,17 +1018,19 @@ async def _compile_concepts(
     try:
         parsed = _parse_json(plan_raw)
     except (json.JSONDecodeError, ValueError) as exc:
-        # Include raw output preview in the WARNING itself (was DEBUG-only).
-        # Without this, users hitting LLM gibberish have no way to diagnose
-        # why no concepts were generated — see issue #71.
+        # Surface the first 500 chars at WARNING so operators not running
+        # with DEBUG enabled can still diagnose; keep the full raw at
+        # DEBUG for the truncation-past-500 case (see issue #71).
         preview = plan_raw[:500] + ("..." if len(plan_raw) > 500 else "")
         logger.warning(
             "Failed to parse concepts plan: %s. Raw output (first 500 chars): %r",
             exc, preview,
         )
+        logger.debug("Concepts plan raw output (full, %d chars): %s",
+                     len(plan_raw), plan_raw)
         sys.stdout.write(
             f"    [WARN] concepts plan unparseable for {doc_name} — "
-            f"no concept pages generated. See log above.\n"
+            f"no concept pages generated. See log (stderr) for details.\n"
         )
         sys.stdout.flush()
         if rewrite_summary:
@@ -1140,9 +1165,11 @@ async def _compile_concepts(
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        failure_types: list[str] = []
         for r in results:
             if isinstance(r, Exception):
                 logger.warning("Concept generation failed: %s", r)
+                failure_types.append(type(r).__name__)
                 continue
             name, page_content, is_update, brief = r
             pending_writes.append((name, page_content, is_update, brief))
@@ -1154,12 +1181,18 @@ async def _compile_concepts(
         # Surface partial/total failure prominently: WARNING logs are easy to
         # miss in long compile output, and the [OK] line at the end of `add`
         # is unconditional. Issue #71: silent loss of all concepts looked
-        # like success to the user.
+        # like success to the user. Include exception type names inline so
+        # the stdout line is self-contained (the per-failure WARNING logs
+        # go to stderr, which a stdout-only consumer never sees).
         written = len(pending_writes)
         if written < total:
+            reason = (
+                ", ".join(sorted(set(failure_types)))
+                if failure_types else "see log (stderr)"
+            )
             sys.stdout.write(
                 f"    [WARN] {total} concept(s) planned but only {written} written "
-                f"for {doc_name} — check warnings above.\n"
+                f"for {doc_name} ({reason}).\n"
             )
             sys.stdout.flush()
 


### PR DESCRIPTION
## Summary

Fixes #71. `openkb compile` could silently produce zero concept pages when the LLM emitted malformed JSON for the concepts plan — the failure was caught, logged at `WARNING`, and the command still printed `[OK]`, leaving the user to discover the empty `wiki/concepts/` on their own.

Two failure modes from the issue:
- **Mode 2** — `_parse_json` raised; the raw plan was only logged at DEBUG and the function returned silently.
- **Mode 1** — LLM returned a structurally-wrong shape (e.g. nested list `[[{...}]]`), the list fallback at `compiler.py:946-947` passed list items through as if they were dicts, and each per-concept task crashed at `concept.get("title")`.

### Fix (two layers)

**Primary** — pass `response_format={\"type\": \"json_object\"}` on the four LLM calls whose prompt asks for a JSON object (summary, concepts-plan, concept create, concept update). Constrains the decoder so providers that support json mode (OpenAI, DeepSeek, Qwen, Kimi, GLM, MiniMax, Doubao) can no longer return prose. The existing \"Return ONLY valid JSON\" prompt language already satisfies the DeepSeek/Qwen \"prompt must mention json\" requirement.

**Defense in depth** (addresses the issue's 3 suggestions):
- New `_filter_concept_items` drops non-dict entries from `create` / `update` before they reach `_gen_create` / `_gen_update`. Logs the dropped count and the offending types.
- Plan parse-failure WARNING now includes the first 500 chars of the raw LLM output (was DEBUG-only).
- Compile prints a stdout `[WARN]` line on both \"plan unparseable\" and \"planned N, wrote K\" — silent regressions no longer masquerade as `[OK]`.

## Test plan

- [x] Reproduced and verified end-to-end against the issue's failure surface: `pandoc <epub> -t markdown | openkb add` with a ~152K-char Chinese document.
  - **gpt-5.4-mini**: clean compile, no regressions (3 concepts + summary + rewrite).
  - **deepseek/deepseek-v4-flash** (issue author's provider family): clean compile, no parse warnings.
- [x] Read through the diff — defense paths (`_filter_concept_items`, parse-fail message, planned-vs-written stdout line) reviewed for behavior under each malformed-input shape discussed in the issue. They are not exercised by the happy-path runs above; if reviewers want explicit unit coverage I'm happy to add it.
- [ ] (Reviewer) Sanity check on at least one of: Qwen / Kimi / GLM / MiniMax — `response_format` is widely supported but provider-by-provider edge cases (e.g. older Qwen variants) may still ignore or reject the kwarg.