### PR TITLE
fix: sync plugin manifest version to v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills for navigating an OpenKB-compiled knowledge base from agent CLIs (Claude Code, Codex, Gemini CLI).",
-    "version": "0.1.4"
+    "version": "0.3.0"
   },
   "plugins": [
     {
@@ -14,7 +14,7 @@
       "description": "Navigate an OpenKB-compiled wiki: discover documents and concepts via openkb CLI commands, read concept and summary pages directly, and follow wikilinks across the knowledge graph.",
       "source": "./",
       "strict": false,
-      "version": "0.1.4",
+      "version": "0.3.0",
       "author": {
         "name": "Ray",
         "email": "ray@vectify.ai"


### PR DESCRIPTION
## Summary

Update `.claude-plugin/marketplace.json` version fields from `0.1.4` to `0.3.0` to match the latest git tag.

## Details

- Plugin skill files use `"source": "./"`, so they already load the latest code from the local checkout -- only the manifest metadata was stale at v0.1.4.
- This aligns the manifest `version` fields with the actual release tag `v0.3.0`.

## Test plan

- [x] Diff shows only version string changes (0.1.4 → 0.3.0)
- [x] No structural changes to marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)