### PR TITLE
feat: add KB mutation locks and atomic state writes

### DIFF
--- a/openkb/agent/chat.py
+++ b/openkb/agent/chat.py
@@ -733,18 +733,24 @@ async def _handle_slash(
         if not session.user_turns:
             _fmt(style, ("class:error", "Nothing to save yet.\n"))
             return None
-        path = _save_transcript(kb_dir, session, arg or None)
+        from openkb.locks import kb_ingest_lock
+        with kb_ingest_lock(kb_dir / ".openkb"):
+            path = _save_transcript(kb_dir, session, arg or None)
         _fmt(style, ("class:slash.ok", f"Saved to {path}\n"))
         return None
 
     if head == "/status":
+        from openkb.locks import kb_read_lock
         from openkb.cli import print_status
-        print_status(kb_dir)
+        with kb_read_lock(kb_dir / ".openkb"):
+            print_status(kb_dir)
         return None
 
     if head == "/list":
+        from openkb.locks import kb_read_lock
         from openkb.cli import print_list
-        print_list(kb_dir)
+        with kb_read_lock(kb_dir / ".openkb"):
+            print_list(kb_dir)
         return None
 
     if head == "/lint":
@@ -899,7 +905,9 @@ async def run_chat(
                 prompt_session = _make_prompt_session(session, style, use_color, kb_dir)
             continue
 
-        append_log(kb_dir / "wiki", "query", user_input)
+        from openkb.locks import kb_ingest_lock
+        with kb_ingest_lock(kb_dir / ".openkb"):
+            append_log(kb_dir / "wiki", "query", user_input)
         try:
             await _run_turn(agent, session, user_input, style, use_color=use_color, raw=raw)
         except KeyboardInterrupt:

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -13,6 +13,7 @@ import logging
 import shutil
 import sys
 import time
+from functools import wraps
 from pathlib import Path
 from typing import Literal
 
@@ -42,6 +43,7 @@ from dotenv import load_dotenv
 
 from openkb.config import DEFAULT_CONFIG, load_config, save_config, load_global_config, register_kb
 from openkb.converter import convert_document
+from openkb.locks import atomic_write_json, atomic_write_text, kb_ingest_lock, kb_read_lock
 from openkb.log import append_log
 from openkb.schema import AGENTS_MD, INDEX_SEED, PAGE_CONTENT_DIRS
 
@@ -260,6 +262,12 @@ def _clear_existing_skill_dir(kb_dir: Path, name: str) -> None:
 
 
 def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped", "failed"]:
+    """Convert, index, and compile a single document under the KB mutation lock."""
+    with kb_ingest_lock(kb_dir / ".openkb"):
+        return _add_single_file_locked(file_path, kb_dir)
+
+
+def _add_single_file_locked(file_path: Path, kb_dir: Path) -> Literal["added", "skipped", "failed"]:
     """Convert, index, and compile a single document into the knowledge base.
 
     Steps:
@@ -390,6 +398,23 @@ def cli(ctx, verbose, kb_dir_override):
             ctx.obj["kb_dir_override"] = Path(env_kb).resolve()
         else:
             ctx.obj["kb_dir_override"] = None
+
+
+def _with_kb_lock(*, exclusive: bool):
+    """Wrap a Click command in the appropriate KB lock when a KB exists."""
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(ctx, *args, **kwargs):
+            kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
+            if kb_dir is None:
+                return fn(ctx, *args, **kwargs)
+            if exclusive:
+                with kb_ingest_lock(kb_dir / ".openkb"):
+                    return fn(ctx, *args, **kwargs)
+            with kb_read_lock(kb_dir / ".openkb"):
+                return fn(ctx, *args, **kwargs)
+        return wrapper
+    return decorator
 
 
 @cli.command()
@@ -541,9 +566,9 @@ def init(model, language):
     Path("wiki/entities").mkdir(parents=True, exist_ok=True)
 
     # Write wiki files
-    Path("wiki/AGENTS.md").write_text(AGENTS_MD, encoding="utf-8")
-    Path("wiki/index.md").write_text(INDEX_SEED, encoding="utf-8")
-    Path("wiki/log.md").write_text("# Operations Log\n\n", encoding="utf-8")
+    atomic_write_text(Path("wiki/AGENTS.md"), AGENTS_MD)
+    atomic_write_text(Path("wiki/index.md"), INDEX_SEED)
+    atomic_write_text(Path("wiki/log.md"), "# Operations Log\n\n")
 
     # Create .openkb/ state directory
     openkb_dir.mkdir()
@@ -553,7 +578,7 @@ def init(model, language):
         "pageindex_threshold": DEFAULT_CONFIG["pageindex_threshold"],
     }
     save_config(openkb_dir / "config.yaml", config)
-    (openkb_dir / "hashes.json").write_text(json.dumps({}), encoding="utf-8")
+    atomic_write_json(openkb_dir / "hashes.json", {})
 
     # Write API key to KB-local .env (0600) if the user provided one
     if api_key:
@@ -574,6 +599,7 @@ def init(model, language):
 @cli.command()
 @click.argument("path")
 @click.pass_context
+@_with_kb_lock(exclusive=True)
 def add(ctx, path):
     """Add a document or directory of documents at PATH to the knowledge base.
 
@@ -784,6 +810,7 @@ def _resolve_doc_identifier(registry, identifier: str) -> list[tuple[str, dict]]
 @click.option("--yes", "-y", is_flag=True, default=False,
               help="Skip the confirmation prompt.")
 @click.pass_context
+@_with_kb_lock(exclusive=True)
 def remove(ctx, identifier, keep_raw, keep_empty, dry_run, yes):
     """Remove a document from the knowledge base.
 
@@ -1065,6 +1092,7 @@ def _refresh_schema(wiki_dir: Path) -> bool:
               help="Overwrite wiki/AGENTS.md with the bundled schema (backs up "
                    "the old one to AGENTS.md.bak) if it differs.")
 @click.pass_context
+@_with_kb_lock(exclusive=True)
 def recompile(ctx, doc_name, all_docs, dry_run, yes, refresh_schema):
     """Re-run the current compile pipeline on already-indexed documents.
 
@@ -1368,40 +1396,42 @@ async def run_lint(kb_dir: Path) -> Path | None:
 
     openkb_dir = kb_dir / ".openkb"
 
-    # Skip lint entirely when the KB has no indexed documents
-    hashes_file = openkb_dir / "hashes.json"
-    if hashes_file.exists():
-        hashes = json.loads(hashes_file.read_text(encoding="utf-8"))
-    else:
-        hashes = {}
-    if not hashes:
-        click.echo("Nothing to lint — no documents indexed yet. Run `openkb add` first.")
-        return
+    with kb_read_lock(openkb_dir):
+        # Skip lint entirely when the KB has no indexed documents
+        hashes_file = openkb_dir / "hashes.json"
+        if hashes_file.exists():
+            hashes = json.loads(hashes_file.read_text(encoding="utf-8"))
+        else:
+            hashes = {}
+        if not hashes:
+            click.echo("Nothing to lint — no documents indexed yet. Run `openkb add` first.")
+            return
 
-    config = load_config(openkb_dir / "config.yaml")
-    _setup_llm_key(kb_dir)
-    model: str = config.get("model", DEFAULT_CONFIG["model"])
+        config = load_config(openkb_dir / "config.yaml")
+        _setup_llm_key(kb_dir)
+        model: str = config.get("model", DEFAULT_CONFIG["model"])
 
-    click.echo("Running structural lint...")
-    structural_report = run_structural_lint(kb_dir)
-    click.echo(structural_report)
+        click.echo("Running structural lint...")
+        structural_report = run_structural_lint(kb_dir)
+        click.echo(structural_report)
 
-    click.echo("Running knowledge lint...")
-    try:
-        knowledge_report = await run_knowledge_lint(kb_dir, model)
-    except Exception as exc:
-        knowledge_report = f"Knowledge lint failed: {exc}"
-    click.echo(knowledge_report)
+        click.echo("Running knowledge lint...")
+        try:
+            knowledge_report = await run_knowledge_lint(kb_dir, model)
+        except Exception as exc:
+            knowledge_report = f"Knowledge lint failed: {exc}"
+        click.echo(knowledge_report)
 
     # Write combined report
-    reports_dir = kb_dir / "wiki" / "reports"
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    import datetime
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    report_path = reports_dir / f"lint_{timestamp}.md"
-    report_content = f"# Lint Report — {timestamp}\n\n## Structural\n\n{structural_report}\n\n## Semantic\n\n{knowledge_report}\n"
-    report_path.write_text(report_content, encoding="utf-8")
-    append_log(kb_dir / "wiki", "lint", f"report → {report_path.name}")
+    with kb_ingest_lock(openkb_dir):
+        reports_dir = kb_dir / "wiki" / "reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        report_path = reports_dir / f"lint_{timestamp}.md"
+        report_content = f"# Lint Report — {timestamp}\n\n## Structural\n\n{structural_report}\n\n## Semantic\n\n{knowledge_report}\n"
+        report_path.write_text(report_content, encoding="utf-8")
+        append_log(kb_dir / "wiki", "lint", f"report → {report_path.name}")
     click.echo(f"\nReport written to {report_path}")
     return report_path
 
@@ -1419,7 +1449,8 @@ def lint(ctx, fix):
         return
     if fix:
         from openkb.lint import fix_broken_links
-        files_changed, ghosts = fix_broken_links(kb_dir / "wiki")
+        with kb_ingest_lock(kb_dir / ".openkb"):
+            files_changed, ghosts = fix_broken_links(kb_dir / "wiki")
         if files_changed:
             click.echo(
                 f"Fixed {ghosts} wikilink(s) across {files_changed} file(s)."
@@ -1494,6 +1525,7 @@ def print_list(kb_dir: Path) -> None:
 
 @cli.command(name="list")
 @click.pass_context
+@_with_kb_lock(exclusive=False)
 def list_cmd(ctx):
     """List all documents in the knowledge base."""
     kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
@@ -1564,6 +1596,7 @@ def print_status(kb_dir: Path) -> None:
 
 @cli.command()
 @click.pass_context
+@_with_kb_lock(exclusive=False)
 def status(ctx):
     """Show the current status of the knowledge base.
 

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import logging
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import yaml
+
+from openkb.locks import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +27,32 @@ DEFAULT_ENTITY_TYPES: tuple[str, ...] = (
 
 GLOBAL_CONFIG_DIR = Path.home() / ".config" / "openkb"
 GLOBAL_CONFIG_PATH = GLOBAL_CONFIG_DIR / "global.yaml"
+GLOBAL_CONFIG_LOCK_PATH = GLOBAL_CONFIG_DIR / "global.lock"
+
+
+@contextlib.contextmanager
+def _with_global_config_lock() -> Iterator[None]:
+    GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with GLOBAL_CONFIG_LOCK_PATH.open("a+", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _atomic_yaml_dump(path: Path, config: dict[str, Any]) -> None:
+    atomic_write_text(
+        path,
+        yaml.safe_dump(config, allow_unicode=True, sort_keys=True),
+    )
+
+
+def _load_global_config_unlocked() -> dict[str, Any]:
+    if GLOBAL_CONFIG_PATH.exists():
+        with GLOBAL_CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
 
 
 def resolve_entity_types(config: dict) -> list[str]:
@@ -81,33 +111,28 @@ def load_config(config_path: Path) -> dict[str, Any]:
 
 def save_config(config_path: Path, config: dict) -> None:
     """Persist config dict to YAML, creating parent directories as needed."""
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(config, fh, allow_unicode=True, sort_keys=True)
+    _atomic_yaml_dump(config_path, config)
 
 
 def load_global_config() -> dict[str, Any]:
     """Load the global config from ~/.config/openkb/global.yaml."""
-    if GLOBAL_CONFIG_PATH.exists():
-        with GLOBAL_CONFIG_PATH.open("r", encoding="utf-8") as fh:
-            return yaml.safe_load(fh) or {}
-    return {}
+    return _load_global_config_unlocked()
 
 
 def save_global_config(config: dict[str, Any]) -> None:
     """Save the global config to ~/.config/openkb/global.yaml."""
-    GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    with GLOBAL_CONFIG_PATH.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(config, fh, allow_unicode=True, sort_keys=True)
+    with _with_global_config_lock():
+        _atomic_yaml_dump(GLOBAL_CONFIG_PATH, config)
 
 
 def register_kb(kb_path: Path) -> None:
     """Register a KB path in the global config's known_kbs list."""
-    gc = load_global_config()
-    known = gc.get("known_kbs", [])
-    resolved = str(kb_path.resolve())
-    if resolved not in known:
-        known.append(resolved)
-        gc["known_kbs"] = known
-    gc["default_kb"] = resolved
-    save_global_config(gc)
+    with _with_global_config_lock():
+        gc = _load_global_config_unlocked()
+        known = gc.get("known_kbs", [])
+        resolved = str(kb_path.resolve())
+        if resolved not in known:
+            known.append(resolved)
+            gc["known_kbs"] = known
+        gc["default_kb"] = resolved
+        _atomic_yaml_dump(GLOBAL_CONFIG_PATH, gc)

--- a/openkb/locks.py
+++ b/openkb/locks.py
@@ -1,0 +1,183 @@
+"""Cooperative filesystem locks and atomic writes for OpenKB.
+
+The lock protocol is advisory and intended for local filesystem access by
+OpenKB processes. It does not guarantee cross-host coordination on networked
+or synced filesystems where ``fcntl.flock`` may be unavailable or inconsistent.
+"""
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Iterator
+
+_LOCKS_GUARD = threading.Lock()
+_LOCAL_LOCKS: dict[Path, "_LocalRwLock"] = {}
+_HELD_LOCKS = threading.local()
+
+
+class _LocalRwLock:
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.Lock())
+        self._readers = 0
+        self._writer = False
+
+    @contextlib.contextmanager
+    def read(self) -> Iterator[None]:
+        with self._condition:
+            while self._writer:
+                self._condition.wait()
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._condition.notify_all()
+
+    @contextlib.contextmanager
+    def write(self) -> Iterator[None]:
+        with self._condition:
+            while self._writer or self._readers:
+                self._condition.wait()
+            self._writer = True
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._writer = False
+                self._condition.notify_all()
+
+
+def _held_locks() -> dict[Path, tuple[int, int]]:
+    held = getattr(_HELD_LOCKS, "counts", None)
+    if held is None:
+        held = {}
+        _HELD_LOCKS.counts = held
+    return held
+
+
+def _local_lock(lock_path: Path) -> _LocalRwLock:
+    resolved = lock_path.resolve()
+    with _LOCKS_GUARD:
+        lock = _LOCAL_LOCKS.get(resolved)
+        if lock is None:
+            lock = _LocalRwLock()
+            _LOCAL_LOCKS[resolved] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def kb_lock(openkb_dir: Path, *, exclusive: bool) -> Iterator[None]:
+    """Hold a KB-level advisory lock."""
+    lock_path = openkb_dir / "ingest.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved = lock_path.resolve()
+    held = _held_locks()
+    exclusive_depth, shared_depth = held.get(resolved, (0, 0))
+
+    if exclusive_depth or shared_depth:
+        if exclusive and not exclusive_depth:
+            raise RuntimeError("Cannot upgrade an existing KB read lock to a write lock")
+        held[resolved] = (
+            exclusive_depth + (1 if exclusive else 0),
+            shared_depth + (0 if exclusive else 1),
+        )
+        try:
+            yield
+        finally:
+            current_exclusive, current_shared = held[resolved]
+            next_counts = (
+                current_exclusive - (1 if exclusive else 0),
+                current_shared - (0 if exclusive else 1),
+            )
+            if next_counts == (0, 0):
+                del held[resolved]
+            else:
+                held[resolved] = next_counts
+        return
+
+    local_lock = _local_lock(lock_path)
+    local_context = local_lock.write() if exclusive else local_lock.read()
+    with local_context:
+        with lock_path.open("a+", encoding="utf-8") as fh:
+            mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+            fcntl.flock(fh.fileno(), mode)
+            held[resolved] = (1, 0) if exclusive else (0, 1)
+            try:
+                yield
+            finally:
+                held.pop(resolved, None)
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def kb_ingest_lock(openkb_dir: Path):
+    """Hold an exclusive KB mutation lock."""
+    return kb_lock(openkb_dir, exclusive=True)
+
+
+def kb_read_lock(openkb_dir: Path):
+    """Hold a shared KB read lock."""
+    return kb_lock(openkb_dir, exclusive=False)
+
+
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _default_file_mode() -> int:
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o666 & ~current_umask
+
+
+def _target_mode(path: Path) -> int:
+    try:
+        return path.stat().st_mode & 0o777
+    except FileNotFoundError:
+        return _default_file_mode()
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically replace *path* with binary *content*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            os.fchmod(fh.fileno(), _target_mode(path))
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Atomically replace *path* with text *content*."""
+    atomic_write_bytes(path, content.encode(encoding))
+
+
+def atomic_write_json(
+    path: Path,
+    data: object,
+    *,
+    ensure_ascii: bool = True,
+    default=None,
+) -> None:
+    """Atomically replace *path* with formatted JSON."""
+    atomic_write_text(
+        path,
+        json.dumps(data, indent=2, ensure_ascii=ensure_ascii, default=default) + "\n",
+    )

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -4,6 +4,8 @@ import hashlib
 import json
 from pathlib import Path
 
+from openkb.locks import atomic_write_json
+
 
 class HashRegistry:
     """Persistent registry mapping file SHA-256 hashes to metadata dicts."""
@@ -69,9 +71,7 @@ class HashRegistry:
     # ------------------------------------------------------------------
 
     def _persist(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        with self._path.open("w", encoding="utf-8") as fh:
-            json.dump(self._data, fh, indent=2)
+        atomic_write_json(self._path, self._data)
 
     # ------------------------------------------------------------------
     # Static utility

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,104 @@
+"""Tests for OpenKB KB locks and atomic writes."""
+from __future__ import annotations
+
+import json
+import stat
+import threading
+
+import pytest
+
+from openkb.locks import (
+    atomic_write_json,
+    atomic_write_text,
+    kb_ingest_lock,
+    kb_read_lock,
+)
+
+
+def test_write_lock_is_reentrant(tmp_path):
+    openkb_dir = tmp_path / ".openkb"
+
+    with kb_ingest_lock(openkb_dir):
+        with kb_ingest_lock(openkb_dir):
+            assert (openkb_dir / "ingest.lock").exists()
+
+
+def test_read_lock_is_reentrant(tmp_path):
+    openkb_dir = tmp_path / ".openkb"
+
+    with kb_read_lock(openkb_dir):
+        with kb_read_lock(openkb_dir):
+            assert (openkb_dir / "ingest.lock").exists()
+
+
+def test_read_locks_do_not_block_each_other_in_process(tmp_path):
+    openkb_dir = tmp_path / ".openkb"
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+
+    def first_reader():
+        with kb_read_lock(openkb_dir):
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+
+    def second_reader():
+        assert first_entered.wait(timeout=2)
+        with kb_read_lock(openkb_dir):
+            second_entered.set()
+
+    first = threading.Thread(target=first_reader)
+    second = threading.Thread(target=second_reader)
+    first.start()
+    second.start()
+    assert second_entered.wait(timeout=2)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+    assert not first.is_alive()
+    assert not second.is_alive()
+
+
+def test_read_to_write_upgrade_fails(tmp_path):
+    openkb_dir = tmp_path / ".openkb"
+
+    with kb_read_lock(openkb_dir):
+        with pytest.raises(RuntimeError, match="Cannot upgrade"):
+            with kb_ingest_lock(openkb_dir):
+                pass
+
+
+def test_write_lock_can_take_nested_read(tmp_path):
+    openkb_dir = tmp_path / ".openkb"
+
+    with kb_ingest_lock(openkb_dir):
+        with kb_read_lock(openkb_dir):
+            assert (openkb_dir / "ingest.lock").exists()
+
+
+def test_atomic_write_text_replaces_file(tmp_path):
+    target = tmp_path / "nested" / "file.txt"
+    atomic_write_text(target, "first")
+    atomic_write_text(target, "second")
+
+    assert target.read_text(encoding="utf-8") == "second"
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_atomic_write_text_preserves_existing_mode(tmp_path):
+    target = tmp_path / "file.txt"
+    target.write_text("first", encoding="utf-8")
+    target.chmod(0o640)
+
+    atomic_write_text(target, "second")
+
+    assert target.read_text(encoding="utf-8") == "second"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_atomic_write_json_replaces_file(tmp_path):
+    target = tmp_path / "hashes.json"
+
+    atomic_write_json(target, {"a": {"name": "doc.pdf"}}, ensure_ascii=False)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"a": {"name": "doc.pdf"}}


### PR DESCRIPTION
## Summary

This PR adds cooperative KB-level locking and atomic state/config writes.

It is a reliability hardening change for the current CLI/chat flows and a foundation for future concurrent ingestion / compilation work. The scope is intentionally limited to synchronization and safer persistence; concurrent ingestion and transactional recovery are left for follow-up PRs.

## Why

Several OpenKB commands mutate shared KB files such as `.openkb/hashes.json`, `.openkb/config.yaml`, `wiki/`, `raw/`, and generated reports. If two OpenKB processes modify the same KB at the same time, or if a process is interrupted while writing state, the KB can be left in a partially written or inconsistent state.

This matters today for commands such as `openkb add`, `openkb remove`, `openkb recompile`, `openkb watch`, `openkb lint --fix`, and matching chat slash commands.

## Changes

- Add `openkb.locks` with KB-level advisory locks:
  - exclusive locks for mutation sections
  - shared locks for read-only sections
  - reentrant same-thread lock handling
  - in-process concurrent shared readers
  - explicit rejection of read-to-write lock upgrades
- Document the local-filesystem/advisory nature of the `fcntl.flock` protocol.
- Add atomic write helpers for text and JSON writes.
- Preserve target file permissions on atomic replace and fsync the parent directory after `os.replace`.
- Use atomic writes for:
  - KB config writes
  - global config writes
  - hash registry persistence
  - initial `hashes.json` seeding during `openkb init`
- Guard global config read-modify-write with a global config lock.
- Apply KB locks at the operation boundary:
  - `add_single_file` takes the mutation lock, so CLI `add`, `watch`, and chat `/add` are covered without locking the full watch lifetime.
  - `lint --fix` takes the mutation lock only while applying fixes.
  - `run_lint` takes a shared read lock while reading/running lint and a mutation lock only when writing the report/log.
  - chat `/save`, `/status`, `/list`, and query logging use the appropriate locks.
- Keep unused speculative helpers out of this PR.

## Notes

The lock is advisory and cooperative: it protects OpenKB commands that use these helpers. It does not make arbitrary external edits to the KB directory safe, and it does not guarantee cross-host safety on networked or synced filesystems where `fcntl.flock` may be unavailable or inconsistent.

## Testing

- `uv run pytest tests/test_locks.py tests/test_config.py tests/test_cli.py tests/test_lint_cli.py`