### PR TITLE
fix(compiler): unwrap JSON-array LLM responses so concept/entity pages aren't silently dropped

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -393,6 +393,23 @@ def _parse_json(text: str) -> list | dict:
     return result
 
 
+def _as_obj(parsed: list | dict) -> dict:
+    """Coerce a parsed JSON result to a dict.
+
+    The page/entity generators expect a JSON object, but the LLM sometimes
+    wraps that single object in a one-element array. Unwrap the first dict
+    element so ``.get(...)`` doesn't blow up with AttributeError on a list.
+    Raises ValueError when no dict is recoverable, so callers' existing
+    ``except (json.JSONDecodeError, ValueError)`` falls back to the raw body.
+    """
+    if isinstance(parsed, dict):
+        return parsed
+    for item in parsed:
+        if isinstance(item, dict):
+            return item
+    raise ValueError("Expected JSON object, got list with no dict element")
+
+
 def _filter_concept_items(items: list, label: str) -> list[dict]:
     """Keep only dicts that carry a non-empty ``name``; warn about anything else."""
     if not isinstance(items, list):
@@ -1603,7 +1620,7 @@ async def _compile_concepts(
                 )},
             ], f"concept: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
-            parsed = _parse_json(raw)
+            parsed = _as_obj(_parse_json(raw))
             brief = parsed.get("brief", "")
             # Parse succeeded: do NOT fall back to ``raw`` (the JSON string).
             # An empty/None ``content`` field yields "" so
@@ -1641,7 +1658,7 @@ async def _compile_concepts(
                 )},
             ], f"update: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
-            parsed = _parse_json(raw)
+            parsed = _as_obj(_parse_json(raw))
             brief = parsed.get("brief", "")
             # Parse succeeded: do NOT fall back to ``raw`` (the JSON string).
             content = parsed.get("content") or ""
@@ -1666,7 +1683,7 @@ async def _compile_concepts(
                 ).replace("__ENTITY_TYPES__", types_str)},
             ], f"entity: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
-            parsed = _parse_json(raw)
+            parsed = _as_obj(_parse_json(raw))
             brief = parsed.get("brief", "")
             etype_out = parsed.get("type") if parsed.get("type") in valid_types else etype
             # Parse succeeded: do NOT fall back to ``raw`` (the JSON string).
@@ -1703,7 +1720,7 @@ async def _compile_concepts(
                 ).replace("__ENTITY_TYPES__", types_str)},
             ], f"entity-update: {name}", response_format=_JSON_RESPONSE_FORMAT)
         try:
-            parsed = _parse_json(raw)
+            parsed = _as_obj(_parse_json(raw))
             brief = parsed.get("brief", "")
             etype_out = parsed.get("type") if parsed.get("type") in valid_types else etype
             # Parse succeeded: do NOT fall back to ``raw`` (the JSON string).

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -11,6 +11,7 @@ from openkb.agent.compiler import (
     compile_short_doc,
     _compile_concepts,
     _parse_json,
+    _as_obj,
     _sanitize_concept_name,
     _write_summary,
     _write_concept,
@@ -43,6 +44,27 @@ class TestParseJson:
     def test_invalid_json(self):
         with pytest.raises((json.JSONDecodeError, ValueError)):
             _parse_json("not json")
+
+
+class TestAsObj:
+    def test_dict_passthrough(self):
+        assert _as_obj({"brief": "x"}) == {"brief": "x"}
+
+    def test_unwraps_single_element_list(self):
+        # Models sometimes wrap the page object in a one-element array.
+        assert _as_obj([{"content": "body", "brief": "b"}]) == {"content": "body", "brief": "b"}
+
+    def test_unwraps_first_dict_in_list(self):
+        assert _as_obj(["junk", {"content": "body"}]) == {"content": "body"}
+
+    def test_list_without_dict_raises(self):
+        # Falls through to callers' (JSONDecodeError, ValueError) raw-body fallback.
+        with pytest.raises(ValueError):
+            _as_obj(["a", "b"])
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError):
+            _as_obj([])
 
 
 class TestParseConceptsPlan:


### PR DESCRIPTION
## Problem
The four page generators in `compiler.py` (`_gen_create`, `_gen_update`, `_gen_entity_create`, `_gen_entity_update`) do:

```python
parsed = _parse_json(raw)
brief = parsed.get("brief", "")
```

When the model returns a **JSON array** instead of an object, `_parse_json` returns a `list`, and `parsed.get(...)` raises `AttributeError: 'list' object has no attribute 'get'`. That error is **not** caught by the surrounding `except (json.JSONDecodeError, ValueError)`, so the whole coroutine dies and the page is silently dropped:

```
openkb.agent.compiler WARNING: Entity generation failed: 'list' object has no attribute 'get'
[WARN] N entity(ies) planned but only M written ... (AttributeError).
```

This is the `'list' object has no attribute 'get'` failure reported in #71. It still reproduces on current `main` (observed across a 165-doc ingest with several models — deepseek, qwen — affecting ~20% of docs, each losing one or more pages).

## Fix
Add `_as_obj()` next to `_parse_json()`: if the parsed value is a list, unwrap the first dict element (the common "model wrapped the object in a one-element array" case); otherwise raise `ValueError` so the callers' existing raw-body fallback applies. Wrap all four call sites as `parsed = _as_obj(_parse_json(raw))`.

No behavior change for the normal object case.

## Tests
Adds `TestAsObj` covering dict passthrough, single-element unwrap, first-dict-in-list, and the list-without-dict / empty-list `ValueError` paths. Full suite green locally.

Relates to #71.