### PR TITLE
fix(compiler): don't cap concepts-plan at max_tokens=2048 (empty plans on reasoning models)

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -1414,7 +1414,7 @@ async def _compile_concepts(
             concept_briefs=concept_briefs,
             entity_briefs=entity_briefs,
         ).replace("__ENTITY_TYPES__", types_str)},
-    ], "concepts-plan", max_tokens=2048, response_format=_JSON_RESPONSE_FORMAT)
+    ], "concepts-plan", response_format=_JSON_RESPONSE_FORMAT)
 
     def _write_v1_summary_stripped() -> None:
         """Fallback writer for the v1 summary on early-return paths.


### PR DESCRIPTION
## Problem
The `concepts-plan` LLM call is hard-capped at `max_tokens=2048`:

```python
], "concepts-plan", max_tokens=2048, response_format=_JSON_RESPONSE_FORMAT)
```

With **reasoning / thinking models** (e.g. `ollama/qwen3.6:27b`, deepseek reasoners), the model can spend the entire 2048-token budget on reasoning before emitting any JSON, so the response comes back **empty**. The plan then fails to parse and **zero concept pages are generated** — silently, while the doc is still marked `[OK]`:

```
openkb.agent.compiler WARNING: Failed to parse concepts plan: Expecting value: line 1 column 1 (char 0). Raw output (first 500 chars): ''
[WARN] concepts plan unparseable for <doc> — no concept pages generated.
```

This is the failure in #80 (`model: ollama/qwen3.6:27b`). Observed hitting ~50% of docs with a local thinking model before the cap was lifted.

## Fix
Remove the `max_tokens=2048` cap so `concepts-plan` is uncapped, matching the existing uncapped `summary` call in the same pipeline. Content-rich plans (and reasoning-model preludes) then complete instead of truncating to empty.

## Note / alternative
If a hard ceiling is preferred for cost control, an alternative would be to make it **configurable** (e.g. a `concepts_plan_max_tokens` config key, default high or `None`) rather than a fixed 2048. Happy to adjust to whichever you prefer — but the current fixed 2048 is too low for reasoning models and fails closed (empty output → no concepts).

Fixes #80.