### PR TITLE
fix(cli): close litellm async clients after each compile/index (CLOSE-WAIT/FD leak)

### DIFF
--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -259,6 +259,20 @@ def _clear_existing_skill_dir(kb_dir: Path, name: str) -> None:
         shutil.rmtree(target)
 
 
+def _close_litellm_async_clients() -> None:
+    """Best-effort cleanup of cached LiteLLM async clients.
+
+    LiteLLM caches aiohttp clients per event loop; with ``asyncio.run`` creating
+    a fresh loop per doc, the old clients' connections linger in CLOSE-WAIT and
+    accumulate sockets/FDs over a long ingest. Closing them after each
+    compile/index frees those connections. Cleanup must never break ingest.
+    """
+    try:
+        asyncio.run(litellm.close_litellm_async_clients())
+    except Exception:
+        pass
+
+
 def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped", "failed"]:
     """Convert, index, and compile a single document into the knowledge base.
 
@@ -307,7 +321,10 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Long document detected — indexing with PageIndex...")
         try:
             from openkb.indexer import index_long_document
-            index_result = index_long_document(result.raw_path, kb_dir)
+            try:
+                index_result = index_long_document(result.raw_path, kb_dir)
+            finally:
+                _close_litellm_async_clients()
         except Exception as exc:
             click.echo(f"  [ERROR] Indexing failed: {exc}")
             logger.debug("Indexing traceback:", exc_info=True)
@@ -317,10 +334,13 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Compiling long doc (doc_id={index_result.doc_id})...")
         for attempt in range(2):
             try:
-                asyncio.run(
-                    compile_long_doc(doc_name, summary_path, index_result.doc_id, kb_dir, model,
-                                     doc_description=index_result.description)
-                )
+                try:
+                    asyncio.run(
+                        compile_long_doc(doc_name, summary_path, index_result.doc_id, kb_dir, model,
+                                         doc_description=index_result.description)
+                    )
+                finally:
+                    _close_litellm_async_clients()
                 break
             except Exception as exc:
                 if attempt == 0:
@@ -334,7 +354,10 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Compiling short doc...")
         for attempt in range(2):
             try:
-                asyncio.run(compile_short_doc(doc_name, result.source_path, kb_dir, model))
+                try:
+                    asyncio.run(compile_short_doc(doc_name, result.source_path, kb_dir, model))
+                finally:
+                    _close_litellm_async_clients()
                 break
             except Exception as exc:
                 if attempt == 0:

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -145,5 +145,10 @@ class TestAddCommand:
              patch("openkb.cli.convert_document", return_value=mock_result), \
              patch("openkb.cli.asyncio.run") as mock_arun:
             result = runner.invoke(cli, ["add", str(doc)])
-            mock_arun.assert_called_once()
+            # asyncio.run drives both the compile and the post-compile
+            # litellm async-client cleanup, so it is called more than once;
+            # assert the compiler coroutine itself was run.
+            assert mock_arun.called
+            ran = [c.args[0] for c in mock_arun.call_args_list if c.args]
+            assert any(getattr(co, "__name__", "") == "compile_short_doc" for co in ran)
             assert "OK" in result.output


### PR DESCRIPTION
## Problem
`add_single_file` compiles each document in a fresh `asyncio.run()` event loop. LiteLLM caches its async (aiohttp) clients per event loop, so when each loop ends the previous doc's clients are abandoned without being closed. Their HTTP connections sit in `CLOSE-WAIT` and **accumulate sockets/file descriptors across a long ingest**.

Observed on a 165-document ingest against a remote API: the process held **200+ sockets in CLOSE-WAIT**, climbing per doc. (On a box with a low `ulimit -n` this would eventually exhaust FDs and start failing compilations.)

## Fix
Add a best-effort `_close_litellm_async_clients()` (calls litellm's own `close_litellm_async_clients()`, never raises) and invoke it in `try/finally` around the three async entry points in `add_single_file`:
- `index_long_document(...)`
- `asyncio.run(compile_long_doc(...))`
- `asyncio.run(compile_short_doc(...))`

So cached clients are closed after each doc whether it succeeds or fails.

## Verification
Added a doc end-to-end after the change: `CLOSE-WAIT` returns to ~0 after each doc instead of accumulating. Updated `test_add_short_doc_runs_compiler` (the compile path now drives `asyncio.run` for both the compile and the cleanup, so it asserts the `compile_short_doc` coroutine was run rather than that `asyncio.run` was called exactly once).

## Relation to #44
#44 carried this same intent but is now ~23 commits behind `main` and conflicts with the current `indexer.py`/`cli.py`. This is a minimal reimplementation on current `main`, so it supersedes #44.