### PR TITLE
feat(compiler): opt-in top-K retrieval for concepts-plan (bound plan prompt as the KB grows)

### DIFF
--- a/docs_retrieval_findings.md
+++ b/docs_retrieval_findings.md
@@ -1,0 +1,19 @@
+# Retrieval-plan prototype — benchmark findings (2026-06-09)
+
+Ground truth: each summary's `[[concepts/X]]` links = concepts that doc used.
+recall@K = fraction of a doc's linked concepts present in the top-K retrieved
+when querying with the doc summary. Corpus: 335 concepts, 162 summaries w/ links.
+
+| K  | TF-IDF | Embeddings (text-embedding-3-small) | prompt size |
+|----|--------|-------------------------------------|-------------|
+| 20 | 0.790  | 0.666                               | 6% of full  |
+| 40 | 0.897  | 0.785                               | 12% of full |
+
+**Conclusion:** dependency-free TF-IDF is the better default here — briefs are
+LLM-generated and lexically overlap the summaries heavily, so lexical ranking
+wins, and it costs nothing (no embedding API/latency per doc). The embedding
+ranker is kept as an option (`select_relevant_briefs_embed`) for corpora with
+more paraphrase/synonym drift, or for a future hybrid. K=40 recovers ~90% of
+relevant concepts at 12% of the full-inject prompt size.
+
+Reproduce: `OPENKB_KB=/path/to/kb PYTHONPATH=. uv run python scripts/bench_retrieval.py`

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -1402,6 +1402,18 @@ async def _compile_concepts(
     concept_briefs = _read_concept_briefs(wiki_dir)
     entity_briefs = _read_entity_briefs(wiki_dir)
 
+    # Opt-in scaling prototype: instead of injecting every brief (O(N) prompt
+    # growth + worse reconciliation as the KB grows), keep only the top-K
+    # briefs most relevant to this document's summary. Off by default, so
+    # behaviour is byte-identical unless explicitly enabled in config.
+    from openkb.config import load_config
+    _cfg = load_config(kb_dir / ".openkb" / "config.yaml")
+    if _cfg.get("concepts_plan_retrieval", False):
+        from openkb.retrieval import select_relevant_briefs
+        _k = int(_cfg.get("concepts_plan_retrieval_k", 40))
+        concept_briefs = select_relevant_briefs(summary, concept_briefs, _k)
+        entity_briefs = select_relevant_briefs(summary, entity_briefs, _k)
+
     # Second cache breakpoint: end of the assistant summary message. Covers
     # (system + doc + summary) for the plan call and every concept call.
     summary_msg = {"role": "assistant", "content": _cached_text(summary)}

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -13,6 +13,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "model": "gpt-5.4-mini",
     "language": "en",
     "pageindex_threshold": 20,
+    # Scaling prototype (opt-in): when true, the concepts-plan step ranks
+    # existing concept/entity briefs against the doc summary and injects only
+    # the top-K, instead of all of them. Bounds the plan prompt as the KB grows.
+    "concepts_plan_retrieval": False,
+    "concepts_plan_retrieval_k": 40,
 }
 
 # Default entity-type vocabulary. Overridable per-KB via the optional

--- a/openkb/retrieval.py
+++ b/openkb/retrieval.py
@@ -77,3 +77,34 @@ def select_relevant_briefs(query: str, briefs_block: str, k: int) -> str:
     )
     keep = sorted(scored[:k])  # restore original (stable) order for the prompt
     return "\n".join(lines[i] for i in keep)
+
+
+# --- Embedding-based ranker (optional, provider-agnostic) ----------------
+# TF-IDF is dependency-free but lexical: it misses paraphrase/synonym overlap
+# ("LLM" vs "language model"). An embedding ranker captures semantic
+# similarity. The provider is injected (embed_fn) so this module stays free of
+# any SDK dependency; the caller supplies e.g. litellm.embedding.
+
+def _cosine_dense(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def select_relevant_briefs_embed(query: str, briefs_block: str, k: int, embed_fn) -> str:
+    """Top-K brief lines by embedding cosine similarity to ``query``.
+
+    ``embed_fn(texts: list[str]) -> list[list[float]]`` returns one vector per
+    input (batch). Same no-op semantics as :func:`select_relevant_briefs`.
+    """
+    if not briefs_block or briefs_block.strip() == _NONE:
+        return briefs_block
+    lines = [ln for ln in briefs_block.splitlines() if ln.strip()]
+    if k <= 0 or len(lines) <= k:
+        return briefs_block
+    vecs = embed_fn(lines + [query])
+    q_vec = vecs[-1]
+    scored = sorted(range(len(lines)), key=lambda i: _cosine_dense(vecs[i], q_vec), reverse=True)
+    keep = sorted(scored[:k])
+    return "\n".join(lines[i] for i in keep)

--- a/openkb/retrieval.py
+++ b/openkb/retrieval.py
@@ -1,0 +1,79 @@
+"""Relevance retrieval for the concepts-plan step (scaling prototype).
+
+The default OpenKB pipeline injects *every* existing concept/entity brief into
+the ``concepts-plan`` prompt. That makes the plan prompt grow O(N) with the KB
+(observed: ~2k tokens early -> ~18k tokens at a few hundred concepts), which
+hurts both speed/cost and the model's ability to reconcile the new doc against
+the right existing pages (it starts creating near-duplicates).
+
+This module provides an opt-in post-filter: given the current document's
+summary as a query, rank the formatted brief lines and keep only the top-K
+most relevant. Converts the per-doc plan context from O(N) back to ~O(K).
+
+First cut uses a dependency-free TF-IDF cosine over the brief lines. The
+interface (``select_relevant_briefs``) is intentionally swappable for an
+embedding-based ranker later without touching the compiler.
+"""
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_NONE = "(none yet)"
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _tfidf_vectors(docs: list[list[str]]) -> tuple[list[dict[str, float]], dict[str, float]]:
+    """Return per-doc tf-idf vectors and the idf map for a small corpus."""
+    n = len(docs)
+    df: Counter[str] = Counter()
+    for toks in docs:
+        df.update(set(toks))
+    idf = {t: math.log((n + 1) / (c + 1)) + 1.0 for t, c in df.items()}
+    vecs: list[dict[str, float]] = []
+    for toks in docs:
+        tf = Counter(toks)
+        vecs.append({t: (cnt / len(toks)) * idf.get(t, 0.0) for t, cnt in tf.items()} if toks else {})
+    return vecs, idf
+
+
+def _cosine(a: dict[str, float], q: dict[str, float]) -> float:
+    if not a or not q:
+        return 0.0
+    dot = sum(v * q.get(t, 0.0) for t, v in a.items())
+    na = math.sqrt(sum(v * v for v in a.values()))
+    nq = math.sqrt(sum(v * v for v in q.values()))
+    return dot / (na * nq) if na and nq else 0.0
+
+
+def select_relevant_briefs(query: str, briefs_block: str, k: int) -> str:
+    """Keep the top-K brief lines most relevant to ``query``.
+
+    ``briefs_block`` is the formatted output of ``_read_concept_briefs`` /
+    ``_read_entity_briefs`` (one ``- ...`` line per page). Returns a block of
+    the same shape. No-ops when the block is empty/"(none yet)" or already
+    within the budget, so behaviour is unchanged for small KBs.
+    """
+    if not briefs_block or briefs_block.strip() == _NONE:
+        return briefs_block
+    lines = [ln for ln in briefs_block.splitlines() if ln.strip()]
+    if k <= 0 or len(lines) <= k:
+        return briefs_block
+
+    # Corpus = brief lines + the query, so idf is shared across the comparison.
+    line_toks = [_tokenize(ln) for ln in lines]
+    q_toks = _tokenize(query)
+    vecs, _ = _tfidf_vectors(line_toks + [q_toks])
+    q_vec = vecs[-1]
+    scored = sorted(
+        range(len(lines)),
+        key=lambda i: _cosine(vecs[i], q_vec),
+        reverse=True,
+    )
+    keep = sorted(scored[:k])  # restore original (stable) order for the prompt
+    return "\n".join(lines[i] for i in keep)

--- a/scripts/bench_retrieval.py
+++ b/scripts/bench_retrieval.py
@@ -1,0 +1,65 @@
+import os, re, glob, pathlib, statistics, sys
+sys.path.insert(0, ".")
+import yaml, litellm
+from openkb.retrieval import select_relevant_briefs, select_relevant_briefs_embed
+litellm.suppress_debug_info = True
+
+KB = pathlib.Path(os.environ.get("OPENKB_KB", "kb"))
+# key
+for ln in (KB/".env").read_text().splitlines():
+    if ln.startswith("LLM_API_KEY="): os.environ["OPENAI_API_KEY"]=ln.split("=",1)[1].strip()
+
+def body_and_fm(text):
+    if text.startswith("---"):
+        end=text.find("---",3)
+        if end!=-1:
+            try: fm=yaml.safe_load(text[3:end]) or {}
+            except Exception: fm={}
+            return text[end+3:], fm
+    return text, {}
+
+# concept briefs -> formatted lines "- slug: brief" (slug recoverable by parse)
+concept_lines=[]
+for p in sorted((KB/"wiki/concepts").glob("*.md")):
+    body,fm=body_and_fm(p.read_text())
+    brief = fm.get("brief") if isinstance(fm.get("brief"),str) else ""
+    if not brief: brief=body.strip().replace("\n"," ")[:150]
+    concept_lines.append(f"- {p.stem}: {brief}")
+block="\n".join(concept_lines)
+valid_slugs={ln[2:].split(":",1)[0] for ln in concept_lines}
+print(f"concepts: {len(concept_lines)}")
+
+LINK=re.compile(r"\[\[concepts/([^\]\|]+)(?:\|[^\]]*)?\]\]")
+samples=[]
+for p in sorted((KB/"wiki/summaries").glob("*.md")):
+    body,_=body_and_fm(p.read_text())
+    gt={s.strip() for s in LINK.findall(body)} & valid_slugs
+    if gt: samples.append((body.strip()[:6000], gt))
+print(f"summaries with concept links: {len(samples)}")
+
+# batch-embed all distinct texts (concept lines + queries) once
+def embed_all(texts):
+    out=[]; B=200
+    for i in range(0,len(texts),B):
+        r=litellm.embedding(model="text-embedding-3-small", input=texts[i:i+B])
+        out += [d["embedding"] for d in r.data]
+    return out
+print("embedding corpus...")
+all_texts = concept_lines + [q for q,_ in samples]
+emb = embed_all(all_texts)
+line_emb = emb[:len(concept_lines)]
+query_emb = {i: emb[len(concept_lines)+i] for i in range(len(samples))}
+def embed_fn_cached(texts):  # texts == concept_lines + [query]; reuse cache
+    q=texts[-1]; qi=[i for i,(s,_) in enumerate(samples) if s==q]
+    return line_emb + [query_emb[qi[0]]]
+
+def slugs_of(blk): return {ln[2:].split(":",1)[0] for ln in blk.splitlines() if ln.startswith("- ")}
+def recall(ret, gt): return len(ret & gt)/len(gt)
+
+for K in (20,40):
+    rt=[]; re_=[]
+    for q,gt in samples:
+        rt.append(recall(slugs_of(select_relevant_briefs(q,block,K)), gt))
+        re_.append(recall(slugs_of(select_relevant_briefs_embed(q,block,K,embed_fn_cached)), gt))
+    print(f"K={K:>2}: TF-IDF recall@K={statistics.mean(rt):.3f} | Embeddings recall@K={statistics.mean(re_):.3f}  "
+          f"(prompt: {K}/{len(concept_lines)} briefs = {100*K/len(concept_lines):.0f}% of full)")

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,37 @@
+from openkb.retrieval import select_relevant_briefs
+
+
+def _block(*lines: str) -> str:
+    return "\n".join(lines)
+
+
+def test_none_and_empty_passthrough():
+    assert select_relevant_briefs("q", "(none yet)", 5) == "(none yet)"
+    assert select_relevant_briefs("q", "", 5) == ""
+
+
+def test_under_budget_is_unchanged():
+    block = _block("- a: alpha", "- b: beta")
+    assert select_relevant_briefs("anything", block, 5) == block
+
+
+def test_selects_relevant_top_k():
+    block = _block(
+        "- agent-swarm: spawning many sub-agents for parallel code generation",
+        "- retirement-funds: using 401k money to fund a business tax-free",
+        "- prompt-caching: reusing cached prompt prefixes to cut token cost",
+    )
+    out = select_relevant_briefs(
+        "A workflow that spawns parallel sub-agents to generate code.", block, 1
+    )
+    assert out == "- agent-swarm: spawning many sub-agents for parallel code generation"
+    assert len(out.splitlines()) == 1
+
+
+def test_preserves_original_order_among_kept():
+    block = _block("- one: alpha beta", "- two: beta gamma", "- three: gamma delta")
+    out = select_relevant_briefs("beta gamma delta", block, 2)
+    lines = out.splitlines()
+    # whichever two are kept, they appear in their original relative order
+    assert lines == [l for l in block.splitlines() if l in lines]
+    assert len(lines) == 2


### PR DESCRIPTION
## Motivation
The `concepts-plan` step injects **every** existing concept/entity brief into the prompt (`_read_concept_briefs` / `_read_entity_briefs` read the whole `concepts/` and `entities/` dirs). So the plan prompt grows **O(N)** with the KB. On a 165-doc KB this was observed climbing from ~2k tokens early to ~15–18k tokens at a few hundred concepts — which hurts cost/latency on every subsequent doc and degrades the model's ability to reconcile a new doc against the *right* existing pages (it starts creating near-duplicate concepts).

## What this does (opt-in, default off)
Adds `openkb/retrieval.py` and a small block in `_compile_concepts` that, **only when enabled**, keeps the top-K briefs most relevant to the current doc's summary instead of all of them. Two config keys (default off → behaviour byte-identical):

```yaml
concepts_plan_retrieval: false     # set true to enable
concepts_plan_retrieval_k: 40
```

- Default ranker is **dependency-free TF-IDF cosine** over the brief lines (no new deps, no extra API calls).
- An optional **embedding ranker** (`select_relevant_briefs_embed`, provider injected — no SDK dependency in the module) is included for higher-drift corpora / future hybrid use.
- No-ops when the brief set is already within budget, so small KBs are unaffected.

## Benchmark (recall@K vs. ground-truth concept links)
On a real 335-concept / 489-entity KB, using each summary's `[[concepts/X]]` links as ground truth and the summary as the query (`scripts/bench_retrieval.py`):

| K  | TF-IDF | Embeddings (text-embedding-3-small) | prompt size |
|----|--------|-------------------------------------|-------------|
| 20 | 0.79   | 0.67                                | 6% of full  |
| 40 | 0.90   | 0.79                                | 12% of full |

TF-IDF wins here (LLM-generated briefs share heavy lexical overlap with summaries) and is free per-doc, so it's the default. **K=40 recovers ~90% of the relevant concepts at 12% of the full-inject prompt size.**

## Tradeoff
At K=40, ~10% of relevant *existing* concepts may fall outside the window for a given doc (small risk of a duplicate concept) in exchange for a bounded plan prompt as the KB scales. Off by default; tune `..._k` higher to trade prompt size for recall.

Tests: `tests/test_retrieval.py` (ranker behaviour) + full suite green.