### PR TITLE
refactor(cli,compiler): close litellm async clients inside the compile loop

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -359,6 +359,23 @@ async def _llm_call_async(model: str, messages: list[dict], step_name: str, **kw
     return content.strip()
 
 
+async def _close_async_llm_clients() -> None:
+    """Close LiteLLM's cached async (aiohttp) clients for the current loop.
+
+    LiteLLM caches its async clients per event loop. ``add_single_file`` runs
+    each doc in its own ``asyncio.run`` loop, so without this the clients are
+    orphaned when the loop is torn down and their connections pile up in
+    CLOSE-WAIT, leaking sockets/FDs across a long ingest. Call this from a
+    ``finally`` inside the compile coroutines so the clients are closed in the
+    same loop that created them. Best-effort: never raises, so cleanup can't
+    mask a real compilation error or break ingest.
+    """
+    try:
+        await litellm.close_litellm_async_clients()
+    except Exception:
+        logger.debug("litellm async client cleanup failed", exc_info=True)
+
+
 def _warn_if_truncated(response, step_name: str, max_tokens: int | None) -> None:
     """Emit a warning when the LLM hit the max_tokens cap.
 
@@ -1981,11 +1998,16 @@ async def compile_short_doc(
         summary = summary_raw
 
     # --- Steps 2-4: Concept plan → generate/update → summary rewrite → index ---
-    await _compile_concepts(
-        wiki_dir, kb_dir, model, system_msg, doc_msg,
-        summary, doc_name, max_concurrency, doc_brief=doc_brief,
-        doc_type="short", rewrite_summary=True, entity_types=entity_types,
-    )
+    try:
+        await _compile_concepts(
+            wiki_dir, kb_dir, model, system_msg, doc_msg,
+            summary, doc_name, max_concurrency, doc_brief=doc_brief,
+            doc_type="short", rewrite_summary=True, entity_types=entity_types,
+        )
+    finally:
+        # Close per-loop litellm async clients before asyncio.run tears this
+        # loop down, to avoid the CLOSE-WAIT/FD leak across a long ingest.
+        await _close_async_llm_clients()
 
 
 async def compile_long_doc(
@@ -2026,8 +2048,13 @@ async def compile_long_doc(
     overview = _llm_call(model, [system_msg, doc_msg], "overview")
 
     # --- Steps 2-4: Concept plan → generate/update → index ---
-    await _compile_concepts(
-        wiki_dir, kb_dir, model, system_msg, doc_msg,
-        overview, doc_name, max_concurrency, doc_brief=doc_description,
-        doc_type="pageindex", entity_types=entity_types,
-    )
+    try:
+        await _compile_concepts(
+            wiki_dir, kb_dir, model, system_msg, doc_msg,
+            overview, doc_name, max_concurrency, doc_brief=doc_description,
+            doc_type="pageindex", entity_types=entity_types,
+        )
+    finally:
+        # Close per-loop litellm async clients before asyncio.run tears this
+        # loop down, to avoid the CLOSE-WAIT/FD leak across a long ingest.
+        await _close_async_llm_clients()

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -259,20 +259,6 @@ def _clear_existing_skill_dir(kb_dir: Path, name: str) -> None:
         shutil.rmtree(target)
 
 
-def _close_litellm_async_clients() -> None:
-    """Best-effort cleanup of cached LiteLLM async clients.
-
-    LiteLLM caches aiohttp clients per event loop; with ``asyncio.run`` creating
-    a fresh loop per doc, the old clients' connections linger in CLOSE-WAIT and
-    accumulate sockets/FDs over a long ingest. Closing them after each
-    compile/index frees those connections. Cleanup must never break ingest.
-    """
-    try:
-        asyncio.run(litellm.close_litellm_async_clients())
-    except Exception:
-        pass
-
-
 def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped", "failed"]:
     """Convert, index, and compile a single document into the knowledge base.
 
@@ -321,10 +307,7 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Long document detected — indexing with PageIndex...")
         try:
             from openkb.indexer import index_long_document
-            try:
-                index_result = index_long_document(result.raw_path, kb_dir)
-            finally:
-                _close_litellm_async_clients()
+            index_result = index_long_document(result.raw_path, kb_dir)
         except Exception as exc:
             click.echo(f"  [ERROR] Indexing failed: {exc}")
             logger.debug("Indexing traceback:", exc_info=True)
@@ -334,13 +317,10 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Compiling long doc (doc_id={index_result.doc_id})...")
         for attempt in range(2):
             try:
-                try:
-                    asyncio.run(
-                        compile_long_doc(doc_name, summary_path, index_result.doc_id, kb_dir, model,
-                                         doc_description=index_result.description)
-                    )
-                finally:
-                    _close_litellm_async_clients()
+                asyncio.run(
+                    compile_long_doc(doc_name, summary_path, index_result.doc_id, kb_dir, model,
+                                     doc_description=index_result.description)
+                )
                 break
             except Exception as exc:
                 if attempt == 0:
@@ -354,10 +334,7 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Compiling short doc...")
         for attempt in range(2):
             try:
-                try:
-                    asyncio.run(compile_short_doc(doc_name, result.source_path, kb_dir, model))
-                finally:
-                    _close_litellm_async_clients()
+                asyncio.run(compile_short_doc(doc_name, result.source_path, kb_dir, model))
                 break
             except Exception as exc:
                 if attempt == 0:

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -145,10 +145,5 @@ class TestAddCommand:
              patch("openkb.cli.convert_document", return_value=mock_result), \
              patch("openkb.cli.asyncio.run") as mock_arun:
             result = runner.invoke(cli, ["add", str(doc)])
-            # asyncio.run drives both the compile and the post-compile
-            # litellm async-client cleanup, so it is called more than once;
-            # assert the compiler coroutine itself was run.
-            assert mock_arun.called
-            ran = [c.args[0] for c in mock_arun.call_args_list if c.args]
-            assert any(getattr(co, "__name__", "") == "compile_short_doc" for co in ran)
+            mock_arun.assert_called_once()
             assert "OK" in result.output


### PR DESCRIPTION
## Background

Follow-up to #91, which fixed a real CLOSE-WAIT/FD leak: litellm caches its async (aiohttp) clients per event loop, and `add_single_file` runs each doc in its own `asyncio.run` loop, so the clients were orphaned (never closed) and their connections piled up in CLOSE-WAIT across a long ingest.

#91 fixed it from the **CLI layer**: a `_close_litellm_async_clients()` helper that spins up a *separate* `asyncio.run(litellm.close_litellm_async_clients())`, wrapped in `try/finally` around the three async entry points, with a bare `except: pass`.

The catch: that close runs **after** the loop that created the clients has already been torn down, from a *different* loop — exactly the `Event loop is closed` situation, which is why it had to swallow exceptions. It also added an extra `asyncio.run()` per doc and a no-op wrap around `index_long_document` (the indexer doesn't use litellm).

## Change

Close the clients in the **same loop that created them**. The only async litellm usage is `litellm.acompletion` in `_llm_call_async`, reached solely via `_compile_concepts` inside `compile_short_doc` / `compile_long_doc`. So the natural place to close is a `finally` inside those coroutines.

- add `compiler._close_async_llm_clients()` — `await litellm.close_litellm_async_clients()`, best-effort but logs at `debug` instead of silently swallowing
- call it from the `finally` of `compile_short_doc` / `compile_long_doc` (wrapping the single `_compile_concepts` call)
- drop `cli._close_litellm_async_clients()` and the three CLI-layer `try/finally` wraps
- drop the no-op cleanup around `index_long_document`
- revert the `test_add_command` assertion to `assert_called_once()` (the CLI no longer drives a second `asyncio.run`)

## Why this is better

- closes in the correct loop → no `Event loop is closed`, cleanup actually runs and no longer needs to swallow errors (logs at debug instead)
- removes the extra `asyncio.run()` per doc and keeps `add_single_file` clean
- **also covers the `recompile` command** (`cli.py:1191`/`1211`), which runs the same per-doc `asyncio.run(compile_*)` loop and had the identical leak — #91 only patched `add_single_file`, so pushing the cleanup into the coroutines fixes recompile for free
- same close frequency as #91 (once per `asyncio.run` loop); within a loop the client is created once, reused across all concurrent calls, and closed once after `gather` completes — no extra open/close churn
- scope unchanged elsewhere: `query` / `lint` / `chat` / skill paths each run a single event loop per process, so they don't accumulate and need no cleanup

## Tests

- `tests/test_add_command.py` + `tests/test_compiler.py`: 126 passed
- full suite: 680 passed (the 4 `test_url_ingest` failures are pre-existing — missing optional `trafilatura` dep in this env — and reproduce on clean `main`)