### PR TITLE
fix: collision-resistant doc_name — same-stem documents no longer overwrite each other

### DIFF
--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -41,7 +41,7 @@ litellm.suppress_debug_info = True
 from dotenv import load_dotenv
 
 from openkb.config import DEFAULT_CONFIG, load_config, save_config, load_global_config, register_kb
-from openkb.converter import convert_document
+from openkb.converter import _registry_path, convert_document
 from openkb.log import append_log
 from openkb.schema import AGENTS_MD, INDEX_SEED, PAGE_CONTENT_DIRS
 
@@ -299,7 +299,7 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  [SKIP] Already in knowledge base: {file_path.name}")
         return "skipped"
 
-    doc_name = file_path.stem
+    doc_name = result.doc_name or file_path.stem
     index_result = None  # populated only on the long-doc branch
 
     # 3/4. Index and compile
@@ -307,7 +307,7 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
         click.echo(f"  Long document detected — indexing with PageIndex...")
         try:
             from openkb.indexer import index_long_document
-            index_result = index_long_document(result.raw_path, kb_dir)
+            index_result = index_long_document(result.raw_path, kb_dir, doc_name=doc_name)
         except Exception as exc:
             click.echo(f"  [ERROR] Indexing failed: {exc}")
             logger.debug("Indexing traceback:", exc_info=True)
@@ -352,12 +352,21 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
             "name": file_path.name,
             "doc_name": doc_name,
             "type": doc_type,
+            "path": _registry_path(file_path, kb_dir),
         }
+        if result.raw_path is not None:
+            meta["raw_path"] = _registry_path(result.raw_path, kb_dir)
+        if result.source_path is not None:
+            meta["source_path"] = _registry_path(result.source_path, kb_dir)
         # For long PDFs we also persist the PageIndex doc_id so `openkb
         # remove` can later call ``Collection.delete_document(doc_id)``
         # to free the managed PDF copy + SQLite row.
         if index_result is not None:
             meta["doc_id"] = index_result.doc_id
+        # An edited document arrives with a new content hash; drop the
+        # stale entry for the same doc_name so the registry keeps exactly
+        # one entry per document.
+        registry.remove_by_doc_name(doc_name)
         registry.add(result.file_hash, meta)
 
     append_log(kb_dir / "wiki", "ingest", file_path.name)

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -923,10 +923,18 @@ def remove(ctx, identifier, keep_raw, keep_empty, dry_run, yes):
     raw_path = None
     if not keep_raw:
         raw_dir = kb_dir / "raw"
-        candidate = raw_dir / name
-        if candidate.exists():
-            raw_path = candidate
-            actions.append(("DELETE", str(candidate.relative_to(kb_dir))))
+        # Raw copies are named by doc_name since the collision fix; prefer
+        # the recorded raw_path and fall back to the original filename for
+        # pre-upgrade entries.
+        candidates = []
+        if meta.get("raw_path"):
+            candidates.append(kb_dir / meta["raw_path"])
+        candidates.append(raw_dir / name)
+        for candidate in candidates:
+            if candidate.exists():
+                raw_path = candidate
+                actions.append(("DELETE", str(candidate.relative_to(kb_dir))))
+                break
 
     # ----- Print the plan -----
     click.echo(f"Removing '{name}' (doc_name: {doc_name}, type: {doc_type or '?'}).")

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -284,7 +284,6 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
     config = load_config(openkb_dir / "config.yaml")
     _setup_llm_key(kb_dir)
     model: str = config.get("model", DEFAULT_CONFIG["model"])
-    registry = HashRegistry(openkb_dir / "hashes.json")
 
     # 2. Convert document
     click.echo(f"Adding: {file_path.name}")
@@ -347,6 +346,11 @@ def add_single_file(file_path: Path, kb_dir: Path) -> Literal["added", "skipped"
 
     # Register hash only after successful compilation
     if result.file_hash:
+        # Construct the registry NOW, not earlier: convert_document may have
+        # backfilled a legacy entry (doc_name/path) on disk via its own
+        # instance, and an earlier snapshot would clobber that backfill on
+        # the full rewrite in add().
+        registry = HashRegistry(openkb_dir / "hashes.json")
         doc_type = "long_pdf" if result.is_long_doc else file_path.suffix.lstrip(".")
         meta = {
             "name": file_path.name,

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -923,18 +923,18 @@ def remove(ctx, identifier, keep_raw, keep_empty, dry_run, yes):
     raw_path = None
     if not keep_raw:
         raw_dir = kb_dir / "raw"
-        # Raw copies are named by doc_name since the collision fix; prefer
-        # the recorded raw_path and fall back to the original filename for
-        # pre-upgrade entries.
-        candidates = []
+        # Raw copies are named by doc_name since the collision fix: use the
+        # recorded raw_path when present. Only pre-upgrade entries (no
+        # raw_path field) fall back to the original filename — a recorded
+        # path that no longer exists must NOT fall through, or it could
+        # delete a same-named raw file belonging to another document.
         if meta.get("raw_path"):
-            candidates.append(kb_dir / meta["raw_path"])
-        candidates.append(raw_dir / name)
-        for candidate in candidates:
-            if candidate.exists():
-                raw_path = candidate
-                actions.append(("DELETE", str(candidate.relative_to(kb_dir))))
-                break
+            candidate = kb_dir / meta["raw_path"]
+        else:
+            candidate = raw_dir / name
+        if candidate.exists():
+            raw_path = candidate
+            actions.append(("DELETE", str(candidate.relative_to(kb_dir))))
 
     # ----- Print the plan -----
     click.echo(f"Removing '{name}' (doc_name: {doc_name}, type: {doc_type or '?'}).")

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -54,10 +54,15 @@ def _sanitize_stem(stem: str) -> str:
 
 
 def _name_taken(candidate: str, registry: HashRegistry, kb_dir: Path) -> bool:
-    """True when ``candidate`` already names another document's artifacts."""
+    """True when ``candidate`` already names another document's artifacts.
+
+    ``candidate`` is always already NFKC-normalized by :func:`_sanitize_stem`
+    at the call site; registry entry names are normalized here so NFD and NFC
+    forms of the same name compare equal.
+    """
     for meta in registry.all_entries().values():
         entry_name = meta.get("doc_name") or Path(meta.get("name", "")).stem
-        if entry_name == candidate:
+        if unicodedata.normalize("NFKC", entry_name) == candidate:
             return True
     sources_dir = kb_dir / "wiki" / "sources"
     return (sources_dir / f"{candidate}.md").exists() or (

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -27,6 +27,19 @@ class ConvertResult:
     file_hash: str | None = None  # For deferred hash registration
 
 
+def _registry_path(path: Path, kb_dir: Path) -> str:
+    """Portable path string used as the registry's identity key.
+
+    Relative-to-KB posix when the file lives inside the KB (stable across
+    machines/checkouts), absolute posix otherwise.
+    """
+    resolved_path = path.resolve()
+    resolved_kb = kb_dir.resolve()
+    if resolved_path.is_relative_to(resolved_kb):
+        return resolved_path.relative_to(resolved_kb).as_posix()
+    return resolved_path.as_posix()
+
+
 def get_pdf_page_count(path: Path) -> int:
     """Return the number of pages in the PDF at *path* using pymupdf."""
     with pymupdf.open(str(path)) as doc:

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -1,8 +1,11 @@
 """Document conversion pipeline for OpenKB."""
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
 import shutil
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,13 +34,70 @@ def _registry_path(path: Path, kb_dir: Path) -> str:
     """Portable path string used as the registry's identity key.
 
     Relative-to-KB posix when the file lives inside the KB (stable across
-    machines/checkouts), absolute posix otherwise.
+    machines/checkouts), absolute posix otherwise. Both paths are fully
+    resolved (symlinks followed) before comparison.
     """
     resolved_path = path.resolve()
     resolved_kb = kb_dir.resolve()
     if resolved_path.is_relative_to(resolved_kb):
         return resolved_path.relative_to(resolved_kb).as_posix()
     return resolved_path.as_posix()
+
+
+_SAFE_STEM_RE = re.compile(r"[^\w\-]+")
+_SUFFIX_LEN = 8
+
+
+def _sanitize_stem(stem: str) -> str:
+    normalized = unicodedata.normalize("NFKC", stem)
+    return _SAFE_STEM_RE.sub("-", normalized).strip("-") or "document"
+
+
+def _name_taken(candidate: str, registry: HashRegistry, kb_dir: Path) -> bool:
+    """True when ``candidate`` already names another document's artifacts."""
+    for meta in registry.all_entries().values():
+        entry_name = meta.get("doc_name") or Path(meta.get("name", "")).stem
+        if entry_name == candidate:
+            return True
+    sources_dir = kb_dir / "wiki" / "sources"
+    return (sources_dir / f"{candidate}.md").exists() or (
+        sources_dir / f"{candidate}.json"
+    ).exists()
+
+
+def resolve_doc_name(src: Path, kb_dir: Path, registry: HashRegistry) -> str:
+    """Resolve the stable wiki name for ``src`` (Scheme A).
+
+    Identity is keyed by path: a source we've seen before (same path, even
+    with new content) keeps its name so re-ingest overwrites in place.
+    Legacy registry entries (written before the path index) are matched by
+    stem and backfilled with the path. A brand-new source keeps the clean
+    sanitized stem unless another document already owns that name, in which
+    case it gets a deterministic ``-{sha256(path)[:8]}`` suffix.
+    """
+    path_key = _registry_path(src, kb_dir)
+
+    known = registry.get_by_path(path_key)
+    if known is not None:
+        stored = known.get("doc_name") or Path(known.get("name", "")).stem
+        if stored:
+            return stored
+
+    legacy = registry.find_legacy_by_stem(src.stem)
+    if legacy is not None:
+        file_hash, meta = legacy
+        meta = dict(meta)
+        name = meta.get("doc_name") or Path(meta.get("name", "")).stem
+        meta["doc_name"] = name
+        meta["path"] = path_key
+        registry.add(file_hash, meta)  # backfill + persist
+        return name
+
+    candidate = _sanitize_stem(src.stem)
+    if _name_taken(candidate, registry, kb_dir):
+        digest = hashlib.sha256(path_key.encode("utf-8")).hexdigest()[:_SUFFIX_LEN]
+        return f"{candidate}-{digest}"
+    return candidate
 
 
 def get_pdf_page_count(path: Path) -> int:

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -54,21 +54,20 @@ def _sanitize_stem(stem: str) -> str:
     return _SAFE_STEM_RE.sub("-", normalized).strip("-") or "document"
 
 
-def _name_taken(candidate: str, registry: HashRegistry, kb_dir: Path) -> bool:
-    """True when ``candidate`` already names another document's artifacts.
+def _name_taken(candidate: str, registry: HashRegistry) -> bool:
+    """True when ``candidate`` is claimed by another registered document.
 
-    ``candidate`` is always already NFKC-normalized by :func:`_sanitize_stem`
-    at the call site; registry entry names are normalized here so NFD and NFC
-    forms of the same name compare equal.
+    The registry is the single authority on ownership: artifacts on disk
+    without a registry entry are either leftovers of a failed ingest of
+    this same source (must be adoptable so a retry keeps its clean name)
+    or out-of-contract manual drops — both are overwritten, matching
+    pre-collision-fix behaviour for unclaimed files.
     """
     for meta in registry.all_entries().values():
         entry_name = meta.get("doc_name") or Path(meta.get("name", "")).stem
         if unicodedata.normalize("NFKC", entry_name) == candidate:
             return True
-    sources_dir = kb_dir / "wiki" / "sources"
-    return (sources_dir / f"{candidate}.md").exists() or (
-        sources_dir / f"{candidate}.json"
-    ).exists()
+    return False
 
 
 def resolve_doc_name(src: Path, kb_dir: Path, registry: HashRegistry) -> str:
@@ -100,7 +99,7 @@ def resolve_doc_name(src: Path, kb_dir: Path, registry: HashRegistry) -> str:
         return name
 
     candidate = _sanitize_stem(src.stem)
-    if _name_taken(candidate, registry, kb_dir):
+    if _name_taken(candidate, registry):
         digest = hashlib.sha256(path_key.encode("utf-8")).hexdigest()[:_SUFFIX_LEN]
         return f"{candidate}-{digest}"
     return candidate
@@ -135,15 +134,15 @@ def convert_document(src: Path, kb_dir: Path) -> ConvertResult:
     # 1. Hash check + identity resolution
     # ------------------------------------------------------------------
     file_hash = HashRegistry.hash_file(src)
-    doc_name = resolve_doc_name(src, kb_dir, registry)
     if registry.is_known(file_hash):
         logger.info("Skipping already-known file: %s", src.name)
         stored = registry.get(file_hash) or {}
         return ConvertResult(
             skipped=True,
             file_hash=file_hash,
-            doc_name=stored.get("doc_name") or doc_name,
+            doc_name=stored.get("doc_name") or Path(stored.get("name", src.name)).stem,
         )
+    doc_name = resolve_doc_name(src, kb_dir, registry)
 
     # ------------------------------------------------------------------
     # 2. Copy to raw/

--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -28,6 +28,7 @@ class ConvertResult:
     is_long_doc: bool = False
     skipped: bool = False
     file_hash: str | None = None  # For deferred hash registration
+    doc_name: str | None = None  # Stable wiki name (collision-resistant)
 
 
 def _registry_path(path: Path, kb_dir: Path) -> str:
@@ -131,20 +132,29 @@ def convert_document(src: Path, kb_dir: Path) -> ConvertResult:
     registry = HashRegistry(openkb_dir / "hashes.json")
 
     # ------------------------------------------------------------------
-    # 1. Hash check
+    # 1. Hash check + identity resolution
     # ------------------------------------------------------------------
     file_hash = HashRegistry.hash_file(src)
+    doc_name = resolve_doc_name(src, kb_dir, registry)
     if registry.is_known(file_hash):
         logger.info("Skipping already-known file: %s", src.name)
-        return ConvertResult(skipped=True)
+        stored = registry.get(file_hash) or {}
+        return ConvertResult(
+            skipped=True,
+            file_hash=file_hash,
+            doc_name=stored.get("doc_name") or doc_name,
+        )
 
     # ------------------------------------------------------------------
     # 2. Copy to raw/
     # ------------------------------------------------------------------
     raw_dir = kb_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
-    raw_dest = raw_dir / src.name
-    if raw_dest.resolve() != src.resolve():
+    if src.resolve().is_relative_to(raw_dir.resolve()):
+        # Watch mode: the file already lives in raw/ — don't copy/rename.
+        raw_dest = src
+    else:
+        raw_dest = raw_dir / f"{doc_name}{src.suffix.lower()}"
         shutil.copy2(src, raw_dest)
 
     # ------------------------------------------------------------------
@@ -159,17 +169,20 @@ def convert_document(src: Path, kb_dir: Path) -> ConvertResult:
                 threshold,
                 src.name,
             )
-            return ConvertResult(raw_path=raw_dest, is_long_doc=True, file_hash=file_hash)
+            return ConvertResult(
+                raw_path=raw_dest,
+                is_long_doc=True,
+                file_hash=file_hash,
+                doc_name=doc_name,
+            )
 
     # ------------------------------------------------------------------
     # 4/5. Convert to Markdown
     # ------------------------------------------------------------------
     sources_dir = kb_dir / "wiki" / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
-    images_dir = kb_dir / "wiki" / "sources" / "images" / src.stem
+    images_dir = kb_dir / "wiki" / "sources" / "images" / doc_name
     images_dir.mkdir(parents=True, exist_ok=True)
-
-    doc_name = src.stem
 
     if src.suffix.lower() == ".md":
         markdown = src.read_text(encoding="utf-8")
@@ -187,4 +200,9 @@ def convert_document(src: Path, kb_dir: Path) -> ConvertResult:
     dest_md = sources_dir / f"{doc_name}.md"
     dest_md.write_text(markdown, encoding="utf-8")
 
-    return ConvertResult(raw_path=raw_dest, source_path=dest_md, file_hash=file_hash)
+    return ConvertResult(
+        raw_path=raw_dest,
+        source_path=dest_md,
+        file_hash=file_hash,
+        doc_name=doc_name,
+    )

--- a/openkb/indexer.py
+++ b/openkb/indexer.py
@@ -86,8 +86,15 @@ def _convert_pdf_to_pages(pdf_path: Path, doc_name: str, images_dir: Path) -> li
     return convert_pdf_to_pages(pdf_path, doc_name, images_dir)
 
 
-def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
-    """Index a long PDF document using PageIndex and write wiki pages."""
+def index_long_document(
+    pdf_path: Path, kb_dir: Path, doc_name: str | None = None
+) -> IndexResult:
+    """Index a long PDF document using PageIndex and write wiki pages.
+
+    ``doc_name`` is the collision-resistant wiki name used for all written
+    artifacts; defaults to the PDF's stem for backward compatibility.
+    """
+    source_name = doc_name or pdf_path.stem
     openkb_dir = kb_dir / ".openkb"
     config = load_config(openkb_dir / "config.yaml")
 
@@ -123,7 +130,7 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
 
     # Fetch complete document (metadata + structure + text)
     doc = col.get_document(doc_id, include_text=True)
-    doc_name: str = doc.get("doc_name", pdf_path.stem)
+    indexed_doc_name: str = doc.get("doc_name", pdf_path.stem)
     description: str = doc.get("doc_description", "")
     structure: list = doc.get("structure", [])
 
@@ -132,7 +139,7 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
     logger.info("page_count from doc: %s", doc.get("page_count", "NOT PRESENT"))
 
     tree = {
-        "doc_name": doc_name,
+        "doc_name": indexed_doc_name,
         "doc_description": description,
         "structure": structure,
     }
@@ -140,7 +147,7 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
     # Write wiki/sources/ — per-page content
     sources_dir = kb_dir / "wiki" / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
-    images_dir = sources_dir / "images" / pdf_path.stem
+    images_dir = sources_dir / "images" / source_name
 
     all_pages: list[dict[str, Any]] = []
     if pageindex_api_key:
@@ -155,19 +162,19 @@ def index_long_document(pdf_path: Path, kb_dir: Path) -> IndexResult:
     if not all_pages:
         if pageindex_api_key:
             logger.warning("Cloud returned no pages for %s; falling back to local pymupdf", pdf_path.name)
-        all_pages = _normalize_page_content(_convert_pdf_to_pages(pdf_path, pdf_path.stem, images_dir))
+        all_pages = _normalize_page_content(_convert_pdf_to_pages(pdf_path, source_name, images_dir))
 
     if not all_pages:
         raise RuntimeError(f"No page content extracted for {pdf_path.name}")
 
-    (sources_dir / f"{pdf_path.stem}.json").write_text(
+    (sources_dir / f"{source_name}.json").write_text(
         json_mod.dumps(all_pages, ensure_ascii=False, indent=2), encoding="utf-8",
     )
 
     # Write wiki/summaries/ (no images, just summaries)
     summaries_dir = kb_dir / "wiki" / "summaries"
     summaries_dir.mkdir(parents=True, exist_ok=True)
-    summary_md = render_summary_md(tree, pdf_path.stem, doc_id)
-    (summaries_dir / f"{pdf_path.stem}.md").write_text(summary_md, encoding="utf-8")
+    summary_md = render_summary_md(tree, source_name, doc_id)
+    (summaries_dir / f"{source_name}.md").write_text(summary_md, encoding="utf-8")
 
     return IndexResult(doc_id=doc_id, description=description, tree=tree)

--- a/openkb/lint.py
+++ b/openkb/lint.py
@@ -336,15 +336,25 @@ def find_orphans(wiki: Path) -> list[str]:
     return sorted(orphans)
 
 
-def find_missing_entries(raw: Path, wiki: Path) -> list[str]:
+def find_missing_entries(
+    raw: Path, wiki: Path, *, kb_dir: Path | None = None,
+) -> list[str]:
     """Find files in raw/ that have no corresponding wiki entries.
 
-    A file is considered "present" if it has either a sources/ or summaries/
-    page with the same stem.
+    When ``kb_dir`` is provided, each raw file is first resolved through
+    the hash registry (``kb_dir/.openkb/hashes.json``): registered files
+    are checked against their ``doc_name`` artifacts, which can differ
+    from the raw stem (watch-mode/URL ingests keep the original filename
+    in raw/ — e.g. ``2509.11420.pdf`` → ``2509-11420.md`` — and collision
+    suffixes rename artifacts too). Files with no registry entry fall back
+    to the stem heuristic: "present" means a sources/ or summaries/ page
+    with the same stem.
 
     Args:
         raw: Path to the raw documents directory.
         wiki: Path to the wiki root directory.
+        kb_dir: Root of the knowledge base. When None, only the legacy
+            stem heuristic is used.
 
     Returns:
         List of filenames in raw/ with no wiki entry.
@@ -356,10 +366,39 @@ def find_missing_entries(raw: Path, wiki: Path) -> list[str]:
     summary_stems = {p.stem for p in summaries_dir.glob("*.md")} if summaries_dir.exists() else set()
     known_stems = sources_stems | summary_stems
 
+    registry = None
+    if kb_dir is not None:
+        registry_file = kb_dir / ".openkb" / "hashes.json"
+        if registry_file.exists():
+            # Deferred import: converter pulls in pymupdf/markitdown,
+            # which lint doesn't otherwise need at import time.
+            from openkb.converter import _registry_path
+            from openkb.state import HashRegistry
+
+            registry = HashRegistry(registry_file)
+
     missing: list[str] = []
     if raw.exists():
         for f in raw.iterdir():
-            if f.is_file() and f.stem not in known_stems:
+            if not f.is_file():
+                continue
+            if registry is not None:
+                meta = registry.get_by_path(_registry_path(f, kb_dir))
+                if meta is not None:
+                    # Registered file — the registry's doc_name is the
+                    # single source of truth for artifact names.
+                    doc_name = meta.get("doc_name") or Path(
+                        meta.get("name", f.name)
+                    ).stem
+                    present = (
+                        (sources_dir / f"{doc_name}.md").exists()
+                        or (sources_dir / f"{doc_name}.json").exists()
+                        or (summaries_dir / f"{doc_name}.md").exists()
+                    )
+                    if not present:
+                        missing.append(f.name)
+                    continue
+            if f.stem not in known_stems:
                 missing.append(f.name)
 
     return sorted(missing)
@@ -460,7 +499,7 @@ def run_structural_lint(kb_dir: Path) -> str:
 
     broken = find_broken_links(wiki)
     orphans = find_orphans(wiki)
-    missing = find_missing_entries(raw, wiki)
+    missing = find_missing_entries(raw, wiki, kb_dir=kb_dir)
     sync_issues = check_index_sync(wiki)
     bad_frontmatter = find_invalid_frontmatter(wiki)
 

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -49,6 +49,25 @@ class HashRegistry:
                 return metadata
         return None
 
+    def find_legacy_by_stem(self, stem: str) -> tuple[str, dict] | None:
+        """Find a pre-path-index entry matching ``stem``.
+
+        Returns ``(file_hash, metadata)`` for an entry that has no ``path``
+        field and whose ``doc_name`` — or, for even older entries lacking
+        ``doc_name``, the stem of its ``name`` — equals ``stem``. Callers
+        use the hash to backfill ``path`` via :meth:`add`. Returns None
+        when every matching name is already path-indexed.
+        """
+        for file_hash, metadata in self._data.items():
+            if metadata.get("path"):
+                continue
+            entry_name = metadata.get("doc_name") or Path(
+                metadata.get("name", "")
+            ).stem
+            if entry_name == stem:
+                return file_hash, metadata
+        return None
+
     # ------------------------------------------------------------------
     # Mutation
     # ------------------------------------------------------------------

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -32,6 +32,23 @@ class HashRegistry:
         """Return a shallow copy of all hash -> metadata entries."""
         return dict(self._data)
 
+    def get_by_path(self, path: str) -> dict | None:
+        """Return metadata whose path/raw_path/source_path equals ``path``.
+
+        ``path`` is a registry path string (posix, relative to the KB dir
+        when inside it) as produced by ``converter._registry_path``. Entries
+        written before the path index existed carry none of these fields and
+        never match.
+        """
+        for metadata in self._data.values():
+            if path in (
+                metadata.get("path"),
+                metadata.get("raw_path"),
+                metadata.get("source_path"),
+            ):
+                return metadata
+        return None
+
     # ------------------------------------------------------------------
     # Mutation
     # ------------------------------------------------------------------

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import unicodedata
 from pathlib import Path
 
 
@@ -59,7 +60,9 @@ class HashRegistry:
         several legacy entries match (pre-fix registries can hold
         same-named entries), the first in insertion order is returned.
         Callers use the hash to backfill ``path`` via :meth:`add`. Returns
-        None when every matching name is already path-indexed.
+        None when every matching name is already path-indexed. The
+        comparison is NFKC-normalized on both sides, so macOS NFD
+        filenames match their NFC registry entries.
         """
         for file_hash, metadata in self._data.items():
             if metadata.get("path"):
@@ -67,7 +70,9 @@ class HashRegistry:
             entry_name = metadata.get("doc_name") or Path(
                 metadata.get("name", "")
             ).stem
-            if entry_name == stem:
+            if unicodedata.normalize("NFKC", entry_name) == unicodedata.normalize(
+                "NFKC", stem
+            ):
                 return file_hash, metadata
         return None
 

--- a/openkb/state.py
+++ b/openkb/state.py
@@ -52,11 +52,14 @@ class HashRegistry:
     def find_legacy_by_stem(self, stem: str) -> tuple[str, dict] | None:
         """Find a pre-path-index entry matching ``stem``.
 
-        Returns ``(file_hash, metadata)`` for an entry that has no ``path``
-        field and whose ``doc_name`` — or, for even older entries lacking
-        ``doc_name``, the stem of its ``name`` — equals ``stem``. Callers
-        use the hash to backfill ``path`` via :meth:`add`. Returns None
-        when every matching name is already path-indexed.
+        Returns ``(file_hash, metadata)`` for an entry that has no truthy
+        ``path`` (a missing or empty ``path`` is treated as unindexed) and
+        whose ``doc_name`` — or, for even older entries lacking
+        ``doc_name``, the stem of its ``name`` — equals ``stem``. When
+        several legacy entries match (pre-fix registries can hold
+        same-named entries), the first in insertion order is returned.
+        Callers use the hash to backfill ``path`` via :meth:`add`. Returns
+        None when every matching name is already path-indexed.
         """
         for file_hash, metadata in self._data.items():
             if metadata.get("path"):

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -167,3 +167,39 @@ class TestAddCommand:
         assert meta["source_path"] == "wiki/sources/test.md"
         assert "path" in meta
         assert "stale-old-hash" not in hashes
+
+    def test_add_oldest_legacy_entry_converges_to_single_entry(self, tmp_path):
+        """Editing a pre-doc_name-era document must not fork the registry.
+
+        convert_document backfills doc_name/path onto the legacy entry on
+        disk; the cli's registry instance must see that backfill (i.e. be
+        constructed after convert), otherwise its full-file rewrite clobbers
+        the backfill and leaves two entries for one document.
+        """
+        import json as json_mod
+
+        from openkb.state import HashRegistry
+
+        kb_dir = self._setup_kb(tmp_path)
+        # oldest-generation entry: name only, no doc_name, no path
+        HashRegistry(kb_dir / ".openkb" / "hashes.json").add(
+            "old-hash", {"name": "notes.md", "type": "md"}
+        )
+        doc = tmp_path / "notes.md"
+        doc.write_text("# Notes, edited")  # new content hash != "old-hash"
+
+        # Compilation mocked out (asyncio.run), but convert_document REAL so
+        # the legacy backfill actually happens on disk mid-pipeline.
+        runner = CliRunner()
+        with patch("openkb.cli._find_kb_dir", return_value=kb_dir), \
+             patch("openkb.cli.asyncio.run"):
+            result = runner.invoke(cli, ["add", str(doc)])
+            assert "OK" in result.output
+
+        hashes = json_mod.loads(
+            (kb_dir / ".openkb" / "hashes.json").read_text(encoding="utf-8")
+        )
+        assert "old-hash" not in hashes          # stale entry replaced…
+        new_entries = [m for m in hashes.values() if m.get("doc_name") == "notes"]
+        assert len(new_entries) == 1             # …exactly one entry survives
+        assert new_entries[0]["path"]            # with path identity persisted

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -138,6 +138,15 @@ class TestAddCommand:
             raw_path=kb_dir / "raw" / "test.md",
             source_path=source_path,
             is_long_doc=False,
+            file_hash="deadbeef00" * 8,
+            doc_name="test",
+        )
+
+        # An edited doc arrives with a new content hash; the stale entry
+        # for the same doc_name must be replaced, leaving exactly ONE entry.
+        from openkb.state import HashRegistry
+        HashRegistry(kb_dir / ".openkb" / "hashes.json").add(
+            "stale-old-hash", {"name": "test.md", "doc_name": "test", "type": "md"}
         )
 
         runner = CliRunner()
@@ -147,3 +156,14 @@ class TestAddCommand:
             result = runner.invoke(cli, ["add", str(doc)])
             mock_arun.assert_called_once()
             assert "OK" in result.output
+
+        import json as json_mod
+        hashes = json_mod.loads(
+            (kb_dir / ".openkb" / "hashes.json").read_text(encoding="utf-8")
+        )
+        meta = hashes[mock_result.file_hash]
+        assert meta["doc_name"] == "test"
+        assert meta["raw_path"] == "raw/test.md"
+        assert meta["source_path"] == "wiki/sources/test.md"
+        assert "path" in meta
+        assert "stale-old-hash" not in hashes

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -128,3 +128,22 @@ class TestConvertDocumentPdfLong:
         assert result.source_path is None
         assert result.skipped is False
         assert result.raw_path is not None
+
+
+# ---------------------------------------------------------------------------
+# _registry_path
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPath:
+    def test_inside_kb_is_relative_posix(self, kb_dir):
+        from openkb.converter import _registry_path
+        p = kb_dir / "raw" / "sub" / "doc.md"
+        assert _registry_path(p, kb_dir) == "raw/sub/doc.md"
+
+    def test_outside_kb_is_absolute_posix(self, kb_dir, tmp_path_factory):
+        from openkb.converter import _registry_path
+        outside = tmp_path_factory.mktemp("elsewhere") / "doc.md"
+        result = _registry_path(outside, kb_dir)
+        assert result == outside.resolve().as_posix()
+        assert result.startswith("/")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -190,16 +190,16 @@ class TestResolveDocName:
         ).hexdigest()[:8]
         assert resolve_doc_name(src, kb_dir, reg) == f"report-{expected_suffix}"
 
-    def test_collision_with_on_disk_source_file(self, kb_dir):
-        # Pre-upgrade docs may exist on disk without any registry entry.
+    def test_unclaimed_on_disk_artifact_is_adopted(self, kb_dir):
+        # An on-disk sources file with NO registry entry is a leftover of a
+        # failed ingest (or an out-of-contract manual drop): the registry is
+        # the authority, so the clean name is reused and the artifact will
+        # be overwritten — this is what keeps retry-after-failure stable.
         from openkb.converter import resolve_doc_name
         (kb_dir / "wiki" / "sources" / "report.md").write_text("old", encoding="utf-8")
         src = kb_dir / "raw" / "report.md"
-        src.write_text("new other doc", encoding="utf-8")
-        # With an empty registry there is no legacy entry to claim the name,
-        # so the on-disk file makes this a genuine collision: suffix expected.
-        name = resolve_doc_name(src, kb_dir, self._registry(kb_dir))
-        assert name.startswith("report-") and len(name) == len("report-") + 8
+        src.write_text("new attempt", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "report"
 
     def test_legacy_entry_is_reused_and_backfilled(self, kb_dir):
         from openkb.converter import _registry_path, resolve_doc_name
@@ -255,14 +255,14 @@ class TestResolveDocName:
         name = resolve_doc_name(second, kb_dir, reg)
         assert name.startswith("document-") and len(name) == len("document-") + 8
 
-    def test_collision_with_on_disk_long_doc_json(self, kb_dir):
-        # Long docs leave wiki/sources/{name}.json — also counts as taken.
+    def test_unclaimed_on_disk_long_doc_json_is_adopted(self, kb_dir):
+        # Long docs leave wiki/sources/{name}.json — without a registry
+        # entry it is likewise an unclaimed leftover: clean name is reused.
         from openkb.converter import resolve_doc_name
         (kb_dir / "wiki" / "sources" / "report.json").write_text("[]", encoding="utf-8")
         src = kb_dir / "raw" / "report.md"
         src.write_text("x", encoding="utf-8")
-        name = resolve_doc_name(src, kb_dir, self._registry(kb_dir))
-        assert name.startswith("report-") and name != "report"
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "report"
 
 
 # ---------------------------------------------------------------------------
@@ -323,3 +323,43 @@ class TestConvertDocumentCollision:
         assert result.doc_name == "my-report-final"
         assert result.source_path.name == "my-report-final.md"
         assert (kb_dir / "wiki" / "sources" / "images" / "my-report-final").is_dir()
+        assert result.raw_path == src  # watch mode: no copy, no rename
+        assert not (kb_dir / "raw" / "my-report-final.md").exists()
+
+    def test_retry_after_failed_compile_keeps_clean_name(self, kb_dir):
+        # convert succeeded but compile failed → nothing registered. The
+        # retry must resolve to the SAME clean name, not a suffixed one.
+        from openkb.converter import convert_document
+        src = kb_dir / "inputs" / "report.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("# R", encoding="utf-8")
+        first = convert_document(src, kb_dir)   # artifacts written, no registration
+        retry = convert_document(src, kb_dir)
+        assert first.doc_name == "report"
+        assert retry.doc_name == "report"
+        assert retry.source_path == first.source_path
+
+    def test_duplicate_copy_skip_does_not_backfill_path(self, kb_dir):
+        # Re-adding an identical copy from another dir must dedup-skip
+        # WITHOUT poisoning the legacy entry's path with the copy's path.
+        from openkb.converter import convert_document
+        from openkb.state import HashRegistry
+        src_a = kb_dir / "in" / "a" / "notes.md"
+        src_a.parent.mkdir(parents=True)
+        src_a.write_text("# Notes", encoding="utf-8")
+        first = convert_document(src_a, kb_dir)
+        reg = HashRegistry(kb_dir / ".openkb" / "hashes.json")
+        # legacy-shaped entry: no path field (pre-upgrade registry)
+        reg.add(first.file_hash, {"name": "notes.md", "doc_name": "notes", "type": "md"})
+
+        src_b = kb_dir / "in" / "b" / "notes.md"
+        src_b.parent.mkdir(parents=True)
+        src_b.write_text("# Notes", encoding="utf-8")  # identical content
+        again = convert_document(src_b, kb_dir)
+
+        assert again.skipped is True
+        assert again.doc_name == "notes"
+        # re-read from disk: the add() above persisted; convert must not
+        # have backfilled the copy's path onto the legacy entry
+        reg2 = HashRegistry(kb_dir / ".openkb" / "hashes.json")
+        assert "path" not in reg2.get(first.file_hash)  # not poisoned

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -228,3 +228,38 @@ class TestResolveDocName:
         src.write_bytes(b"%PDF-1.4 fake")
         name = resolve_doc_name(src, kb_dir, reg)
         assert name.startswith("report-") and name != "report"
+
+    def test_cjk_stem_with_fullwidth_punctuation(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        src = kb_dir / "raw" / "技术报告（最终版）.md"
+        src.write_text("x", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "技术报告-最终版"
+
+    def test_all_symbol_stem_falls_back_to_document(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        src = kb_dir / "raw" / "!!!.md"
+        src.write_text("x", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "document"
+
+    def test_two_all_symbol_stems_second_gets_suffix(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        reg = self._registry(kb_dir)
+        first = kb_dir / "raw" / "!!!.md"
+        first.write_text("x", encoding="utf-8")
+        assert resolve_doc_name(first, kb_dir, reg) == "document"
+        reg.add("h1", {"name": "!!!.md", "doc_name": "document",
+                       "path": "raw/!!!.md"})
+        second = kb_dir / "inputs" / "###.md"
+        second.parent.mkdir(parents=True)
+        second.write_text("y", encoding="utf-8")
+        name = resolve_doc_name(second, kb_dir, reg)
+        assert name.startswith("document-") and len(name) == len("document-") + 8
+
+    def test_collision_with_on_disk_long_doc_json(self, kb_dir):
+        # Long docs leave wiki/sources/{name}.json — also counts as taken.
+        from openkb.converter import resolve_doc_name
+        (kb_dir / "wiki" / "sources" / "report.json").write_text("[]", encoding="utf-8")
+        src = kb_dir / "raw" / "report.md"
+        src.write_text("x", encoding="utf-8")
+        name = resolve_doc_name(src, kb_dir, self._registry(kb_dir))
+        assert name.startswith("report-") and name != "report"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -263,3 +263,63 @@ class TestResolveDocName:
         src.write_text("x", encoding="utf-8")
         name = resolve_doc_name(src, kb_dir, self._registry(kb_dir))
         assert name.startswith("report-") and name != "report"
+
+
+# ---------------------------------------------------------------------------
+# convert_document — doc_name collision handling
+# ---------------------------------------------------------------------------
+
+
+class TestConvertDocumentCollision:
+    def test_same_basename_different_dirs_get_distinct_outputs(self, kb_dir):
+        from openkb.converter import convert_document
+        from openkb.state import HashRegistry
+        first = kb_dir / "inputs" / "first" / "report.md"
+        second = kb_dir / "inputs" / "second" / "report.md"
+        first.parent.mkdir(parents=True)
+        second.parent.mkdir(parents=True)
+        first.write_text("# First\n\nAlpha.", encoding="utf-8")
+        second.write_text("# Second\n\nBeta.", encoding="utf-8")
+
+        r1 = convert_document(first, kb_dir)
+        # Simulate add_single_file's registration so the second ingest
+        # sees "report" as taken.
+        HashRegistry(kb_dir / ".openkb" / "hashes.json").add(
+            r1.file_hash,
+            {"name": "report.md", "doc_name": r1.doc_name,
+             "path": "inputs/first/report.md"},
+        )
+        r2 = convert_document(second, kb_dir)
+
+        assert r1.doc_name == "report"
+        assert r2.doc_name.startswith("report-") and r2.doc_name != "report"
+        assert r1.source_path != r2.source_path
+        assert r1.source_path.read_text(encoding="utf-8").startswith("# First")
+        assert r2.source_path.read_text(encoding="utf-8").startswith("# Second")
+        assert r1.raw_path != r2.raw_path
+
+    def test_skipped_dedup_carries_stored_doc_name(self, kb_dir):
+        from openkb.converter import convert_document
+        from openkb.state import HashRegistry
+        src = kb_dir / "inputs" / "notes.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("# Notes", encoding="utf-8")
+        first = convert_document(src, kb_dir)
+        HashRegistry(kb_dir / ".openkb" / "hashes.json").add(
+            first.file_hash,
+            {"name": "notes.md", "doc_name": first.doc_name,
+             "path": "inputs/notes.md"},
+        )
+        again = convert_document(src, kb_dir)
+        assert again.skipped is True
+        assert again.doc_name == first.doc_name
+        assert again.file_hash == first.file_hash
+
+    def test_outputs_named_by_doc_name(self, kb_dir):
+        from openkb.converter import convert_document
+        src = kb_dir / "raw" / "my report (final).md"
+        src.write_text("# R", encoding="utf-8")
+        result = convert_document(src, kb_dir)
+        assert result.doc_name == "my-report-final"
+        assert result.source_path.name == "my-report-final.md"
+        assert (kb_dir / "wiki" / "sources" / "images" / "my-report-final").is_dir()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -147,3 +147,84 @@ class TestRegistryPath:
         result = _registry_path(outside, kb_dir)
         assert result == outside.resolve().as_posix()
         assert result.startswith("/")
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDocName:
+    def _registry(self, kb_dir):
+        from openkb.state import HashRegistry
+        return HashRegistry(kb_dir / ".openkb" / "hashes.json")
+
+    def test_unique_name_stays_clean(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        src = kb_dir / "raw" / "report.md"
+        src.write_text("x", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "report"
+
+    def test_known_path_reuses_stored_doc_name(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        reg = self._registry(kb_dir)
+        reg.add("h1", {"name": "report.md", "doc_name": "report-x1",
+                       "path": "inputs/report.md"})
+        src = kb_dir / "inputs" / "report.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("edited", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, reg) == "report-x1"
+
+    def test_collision_gets_deterministic_suffix(self, kb_dir):
+        from openkb.converter import _registry_path, resolve_doc_name
+        import hashlib
+        reg = self._registry(kb_dir)
+        # "report" already taken by a different, path-indexed source
+        reg.add("h1", {"name": "report.md", "doc_name": "report",
+                       "path": "inputs/first/report.md"})
+        src = kb_dir / "inputs" / "second" / "report.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("y", encoding="utf-8")
+        expected_suffix = hashlib.sha256(
+            _registry_path(src, kb_dir).encode("utf-8")
+        ).hexdigest()[:8]
+        assert resolve_doc_name(src, kb_dir, reg) == f"report-{expected_suffix}"
+
+    def test_collision_with_on_disk_source_file(self, kb_dir):
+        # Pre-upgrade docs may exist on disk without any registry entry.
+        from openkb.converter import resolve_doc_name
+        (kb_dir / "wiki" / "sources" / "report.md").write_text("old", encoding="utf-8")
+        src = kb_dir / "raw" / "report.md"
+        src.write_text("new other doc", encoding="utf-8")
+        # With an empty registry there is no legacy entry to claim the name,
+        # so the on-disk file makes this a genuine collision: suffix expected.
+        name = resolve_doc_name(src, kb_dir, self._registry(kb_dir))
+        assert name.startswith("report-") and len(name) == len("report-") + 8
+
+    def test_legacy_entry_is_reused_and_backfilled(self, kb_dir):
+        from openkb.converter import _registry_path, resolve_doc_name
+        reg = self._registry(kb_dir)
+        reg.add("h_old", {"name": "notes.md", "doc_name": "notes", "type": "md"})
+        src = kb_dir / "raw" / "notes.md"
+        src.write_text("edited content", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, reg) == "notes"
+        # path backfilled onto the legacy entry
+        assert reg.get("h_old")["path"] == _registry_path(src, kb_dir)
+
+    def test_stem_is_sanitized(self, kb_dir):
+        from openkb.converter import resolve_doc_name
+        src = kb_dir / "raw" / "my report (final).md"
+        src.write_text("x", encoding="utf-8")
+        assert resolve_doc_name(src, kb_dir, self._registry(kb_dir)) == "my-report-final"
+
+    def test_same_stem_different_extension_collides(self, kb_dir):
+        # report.pdf vs an existing "report" (from report.md) — extension
+        # does not disambiguate; the second source gets a suffix.
+        from openkb.converter import resolve_doc_name
+        reg = self._registry(kb_dir)
+        reg.add("h1", {"name": "report.md", "doc_name": "report",
+                       "path": "inputs/report.md"})
+        src = kb_dir / "raw" / "report.pdf"
+        src.write_bytes(b"%PDF-1.4 fake")
+        name = resolve_doc_name(src, kb_dir, reg)
+        assert name.startswith("report-") and name != "report"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -240,7 +240,7 @@ def test_index_long_document_uses_explicit_doc_name(kb_dir, monkeypatch):
     with patch("openkb.indexer.PageIndexClient", return_value=fake_client), \
          patch("openkb.indexer._get_pdf_page_count", return_value=30), \
          patch("openkb.indexer._convert_pdf_to_pages",
-               return_value=[{"page": 1, "text": "p1"}]):
+               return_value=[{"page": 1, "text": "p1"}]) as mock_convert:
         result = index_long_document(pdf, kb_dir, doc_name="original-abc12345")
 
     assert result.doc_id == "doc-123"
@@ -249,3 +249,9 @@ def test_index_long_document_uses_explicit_doc_name(kb_dir, monkeypatch):
     # nothing written under the raw stem
     assert not (kb_dir / "wiki" / "sources" / "original.json").exists()
     assert not (kb_dir / "wiki" / "summaries" / "original.md").exists()
+    # the page extractor receives the explicit doc_name and its images dir
+    expected_images = kb_dir / "wiki" / "sources" / "images" / "original-abc12345"
+    mock_convert.assert_called_once_with(pdf, "original-abc12345", expected_images)
+    # summary frontmatter points full_text at the doc_name artifact
+    summary_text = (kb_dir / "wiki" / "summaries" / "original-abc12345.md").read_text(encoding="utf-8")
+    assert "original-abc12345" in summary_text

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -219,3 +219,33 @@ class TestIndexLongDocument:
                 assert "No page content extracted" in str(exc)
             else:
                 raise AssertionError("expected RuntimeError")
+
+
+def test_index_long_document_uses_explicit_doc_name(kb_dir, monkeypatch):
+    monkeypatch.delenv("PAGEINDEX_API_KEY", raising=False)
+
+    fake_col = MagicMock()
+    fake_col.add.return_value = "doc-123"
+    fake_col.get_document.return_value = {
+        "doc_name": "original.pdf",
+        "doc_description": "desc",
+        "structure": [],
+    }
+    fake_client = MagicMock()
+    fake_client.collection.return_value = fake_col
+
+    pdf = kb_dir / "raw" / "original.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    with patch("openkb.indexer.PageIndexClient", return_value=fake_client), \
+         patch("openkb.indexer._get_pdf_page_count", return_value=30), \
+         patch("openkb.indexer._convert_pdf_to_pages",
+               return_value=[{"page": 1, "text": "p1"}]):
+        result = index_long_document(pdf, kb_dir, doc_name="original-abc12345")
+
+    assert result.doc_id == "doc-123"
+    assert (kb_dir / "wiki" / "sources" / "original-abc12345.json").exists()
+    assert (kb_dir / "wiki" / "summaries" / "original-abc12345.md").exists()
+    # nothing written under the raw stem
+    assert not (kb_dir / "wiki" / "sources" / "original.json").exists()
+    assert not (kb_dir / "wiki" / "summaries" / "original.md").exists()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -16,6 +16,7 @@ from openkb.lint import (
     run_structural_lint,
     strip_ghost_wikilinks,
 )
+from openkb.state import HashRegistry
 
 
 def _make_wiki(tmp_path: Path) -> Path:
@@ -152,6 +153,129 @@ class TestFindMissingEntries:
         result = find_missing_entries(raw, wiki)
 
         assert result == []
+
+
+class TestFindMissingEntriesRegistry:
+    """With ``kb_dir``, raw files resolve through the hash registry first.
+
+    Watch-mode/URL-ingested files keep their original filename in raw/
+    (e.g. arXiv ``2509.11420.pdf``) while artifacts are named by the
+    sanitized ``doc_name`` (``2509-11420.md``) — a pure stem comparison
+    false-positives those as missing. The registry maps one to the other.
+    """
+
+    def _add_entry(self, kb: Path, file_hash: str, metadata: dict) -> None:
+        HashRegistry(kb / ".openkb" / "hashes.json").add(file_hash, metadata)
+
+    def test_registry_doc_name_resolves_renamed_artifacts(self, tmp_path):
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "2509.11420.pdf").write_bytes(b"%PDF-1.4 fake")
+        (wiki / "sources" / "2509-11420.md").write_text("x", encoding="utf-8")
+        (wiki / "summaries" / "2509-11420.md").write_text("x", encoding="utf-8")
+        self._add_entry(
+            tmp_path,
+            "h1",
+            {
+                "name": "2509.11420.pdf",
+                "doc_name": "2509-11420",
+                "type": "long_pdf",
+                "raw_path": "raw/2509.11420.pdf",
+            },
+        )
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert "2509.11420.pdf" not in result
+
+    def test_registry_doc_name_resolves_collision_suffix(self, tmp_path):
+        # raw/paper.pdf whose artifacts got a collision suffix
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "paper.pdf").write_bytes(b"%PDF-1.4 fake")
+        (wiki / "sources" / "paper-ab12cd34.md").write_text("x", encoding="utf-8")
+        self._add_entry(
+            tmp_path,
+            "h2",
+            {
+                "name": "paper.pdf",
+                "doc_name": "paper-ab12cd34",
+                "type": "pdf",
+                "raw_path": "raw/paper.pdf",
+            },
+        )
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert result == []
+
+    def test_registry_doc_name_json_source_counts_as_entry(self, tmp_path):
+        # Long docs store sources/{doc_name}.json instead of .md
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "2509.11420.pdf").write_bytes(b"%PDF-1.4 fake")
+        (wiki / "sources" / "2509-11420.json").write_text("{}", encoding="utf-8")
+        self._add_entry(
+            tmp_path,
+            "h3",
+            {
+                "name": "2509.11420.pdf",
+                "doc_name": "2509-11420",
+                "type": "long_pdf",
+                "raw_path": "raw/2509.11420.pdf",
+            },
+        )
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert result == []
+
+    def test_unregistered_file_without_artifacts_still_missing(self, tmp_path):
+        # No registry entry, no artifacts → stays reported missing
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "unprocessed.pdf").write_bytes(b"PDF content")
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert "unprocessed.pdf" in result
+
+    def test_legacy_stem_match_without_registry_not_missing(self, tmp_path):
+        # No registry entry but artifacts share the raw stem → old behavior
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "legacy.pdf").write_bytes(b"PDF content")
+        (wiki / "sources" / "legacy.md").write_text("# Legacy", encoding="utf-8")
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert result == []
+
+    def test_registered_file_with_no_artifacts_is_missing(self, tmp_path):
+        # Registry entry exists but its doc_name artifacts were deleted
+        wiki = _make_wiki(tmp_path)
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "2509.11420.pdf").write_bytes(b"%PDF-1.4 fake")
+        self._add_entry(
+            tmp_path,
+            "h4",
+            {
+                "name": "2509.11420.pdf",
+                "doc_name": "2509-11420",
+                "type": "long_pdf",
+                "raw_path": "raw/2509.11420.pdf",
+            },
+        )
+
+        result = find_missing_entries(raw, wiki, kb_dir=tmp_path)
+
+        assert "2509.11420.pdf" in result
 
 
 class TestCheckIndexSync:

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1193,3 +1193,30 @@ def test_cli_remove_retry_after_pageindex_failure_completes(kb_dir):
     # Registry now empty; wiki cleanup remains complete.
     assert json.loads((kb_dir / ".openkb" / "hashes.json").read_text()) == {}
     assert not (kb_dir / "wiki" / "summaries" / "paper.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Regression: doc-name collision fix — raw copies are renamed to doc_name
+# on copy (raw/{doc_name}{suffix}), so remove must locate them via the
+# recorded `raw_path` in registry meta, not `raw_dir / name`.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_remove_deletes_renamed_raw_copy(kb_dir):
+    """Raw copies are now named by doc_name; remove must use meta raw_path."""
+    # Collided doc: original filename report.md, doc_name report-aabbccdd
+    raw_file = kb_dir / "raw" / "report-aabbccdd.md"
+    raw_file.write_text("# R", encoding="utf-8")
+    (kb_dir / "wiki" / "sources" / "report-aabbccdd.md").write_text("# R", encoding="utf-8")
+    HashRegistry(kb_dir / ".openkb" / "hashes.json").add(
+        "h-collide",
+        {"name": "report.md", "doc_name": "report-aabbccdd", "type": "md",
+         "path": "inputs/second/report.md",
+         "raw_path": "raw/report-aabbccdd.md",
+         "source_path": "wiki/sources/report-aabbccdd.md"},
+    )
+
+    result = _invoke(kb_dir, ["remove", "report-aabbccdd", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not raw_file.exists()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -106,3 +106,34 @@ def test_get_by_path_legacy_entry_without_path_fields_is_not_matched(tmp_path):
     reg = HashRegistry(tmp_path / "hashes.json")
     reg.add("h1", {"name": "old.md", "doc_name": "old"})
     assert reg.get_by_path("raw/old.md") is None
+
+
+def test_find_legacy_by_stem_matches_doc_name_entry_without_path(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {"name": "report.md", "doc_name": "report", "type": "md"})
+    hit = reg.find_legacy_by_stem("report")
+    assert hit is not None
+    file_hash, meta = hit
+    assert file_hash == "h1"
+    assert meta["doc_name"] == "report"
+
+
+def test_find_legacy_by_stem_matches_pre_doc_name_entry_by_filename_stem(tmp_path):
+    # Entries written before doc_name existed carry only {name, type}.
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {"name": "notes.md", "type": "md"})
+    hit = reg.find_legacy_by_stem("notes")
+    assert hit is not None
+    assert hit[0] == "h1"
+
+
+def test_find_legacy_by_stem_entry_with_path_is_not_legacy(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {"name": "report.md", "doc_name": "report",
+                   "path": "inputs/report.md"})
+    assert reg.find_legacy_by_stem("report") is None
+
+
+def test_find_legacy_by_stem_miss_returns_none(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    assert reg.find_legacy_by_stem("anything") is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -80,3 +80,29 @@ def test_load_existing_json(tmp_path):
     registry = HashRegistry(path)
     assert registry.is_known("existinghash") is True
     assert registry.get("existinghash") == {"file": "pre.pdf"}
+
+
+def test_get_by_path_matches_path_raw_path_and_source_path(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {
+        "name": "report.md",
+        "doc_name": "report",
+        "path": "inputs/report.md",
+        "raw_path": "raw/report.md",
+        "source_path": "wiki/sources/report.md",
+    })
+    assert reg.get_by_path("inputs/report.md")["doc_name"] == "report"
+    assert reg.get_by_path("raw/report.md")["doc_name"] == "report"
+    assert reg.get_by_path("wiki/sources/report.md")["doc_name"] == "report"
+
+
+def test_get_by_path_miss_returns_none(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {"name": "a.md", "doc_name": "a", "path": "a.md"})
+    assert reg.get_by_path("elsewhere/a.md") is None
+
+
+def test_get_by_path_legacy_entry_without_path_fields_is_not_matched(tmp_path):
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h1", {"name": "old.md", "doc_name": "old"})
+    assert reg.get_by_path("raw/old.md") is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -137,3 +137,14 @@ def test_find_legacy_by_stem_entry_with_path_is_not_legacy(tmp_path):
 def test_find_legacy_by_stem_miss_returns_none(tmp_path):
     reg = HashRegistry(tmp_path / "hashes.json")
     assert reg.find_legacy_by_stem("anything") is None
+
+
+def test_find_legacy_by_stem_first_match_wins_on_duplicates(tmp_path):
+    # Pre-fix registries can hold two same-named legacy entries (the
+    # collision bug); the resolver backfills the first in insertion order.
+    reg = HashRegistry(tmp_path / "hashes.json")
+    reg.add("h_first", {"name": "report.md", "doc_name": "report", "type": "md"})
+    reg.add("h_second", {"name": "report.md", "doc_name": "report", "type": "md"})
+    hit = reg.find_legacy_by_stem("report")
+    assert hit is not None
+    assert hit[0] == "h_first"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -148,3 +148,14 @@ def test_find_legacy_by_stem_first_match_wins_on_duplicates(tmp_path):
     hit = reg.find_legacy_by_stem("report")
     assert hit is not None
     assert hit[0] == "h_first"
+
+
+def test_find_legacy_by_stem_nfkc_normalizes_both_sides(tmp_path):
+    # macOS hands back NFD filenames; registry may hold NFC. Both must match.
+    import unicodedata
+    reg = HashRegistry(tmp_path / "hashes.json")
+    nfc = unicodedata.normalize("NFC", "café")
+    nfd = unicodedata.normalize("NFD", "café")
+    reg.add("h1", {"name": f"{nfc}.md", "doc_name": nfc, "type": "md"})
+    hit = reg.find_legacy_by_stem(nfd)
+    assert hit is not None and hit[0] == "h1"


### PR DESCRIPTION
## Problem

`doc_name` is the filename stem, and it names every artifact (`wiki/sources/{doc_name}.md|json`, `images/{doc_name}/`, `wiki/summaries/{doc_name}.md`, `[[summaries/{doc_name}]]`). Two different files with the same stem — `a/report.md` vs `b/report.md`, or `report.md` vs `report.pdf` — silently overwrite each other's pages.

## Approach (Scheme A: clean names by default, suffix only on collision)

- `doc_name` stays the sanitized stem (NFKC + `[^\w\-]+` → `-`); only when that name is already claimed by a *different registered* document does it get a deterministic `-{sha256(path)[:8]}` suffix. Unique names — the overwhelmingly common case — are unchanged, and **existing KBs need zero migration**.
- Identity is anchored by a registry path index (`get_by_path` over new `path`/`raw_path`/`source_path` metadata): re-ingesting an edited file or a watch-mode edit maps back to the same `doc_name` and overwrites in place, replacing the stale content-hash entry.
- Legacy entries (no `path` field) are matched by stem (NFKC-normalized both sides — macOS NFD filenames match NFC entries) and backfilled, so editing a pre-upgrade document does not fork a duplicate.
- The registry is the **single authority** on name ownership: unclaimed on-disk artifacts are adopted, so a retry after a failed compile keeps its clean name instead of drifting to a suffixed one.
- `index_long_document` takes an explicit `doc_name`; `openkb remove` locates raw copies via the recorded `raw_path` (raw copies are now named by `doc_name`); `lint`'s missing-entry check resolves raw files through the registry before stem matching (fixes false positives for dotted names like arXiv `2509.11420.pdf`).

## Hardening found during implementation

- dedup early-return is read-only (a duplicate copy can no longer backfill its path onto the original entry)
- the CLI constructs its registry instance *after* conversion, so converter-side legacy backfills aren't clobbered by a stale in-memory snapshot (regression test reproduces the lost-update)
- remove's raw-name fallback is restricted to legacy entries without `raw_path`, eliminating a cross-deletion edge

## Relation to #30

Supersedes #30, which pioneered this fix (thank you @saccharin98!) but used an unconditional `stem-<hash12>` name for every document (uglier names + a mixed-naming migration for existing KBs) and predates the current `add_single_file` (Literal return codes, long-PDF `doc_id` persistence). Core ideas are carried over and credited via Co-authored-by.

## Tests

New coverage (24 new tests): unique name stays clean; same basename in different dirs; same stem different extension; CJK/full-width punctuation sanitization; all-symbol stems; edited re-ingest keeps identity and replaces the stale hash entry; retry-after-failed-compile keeps its name; duplicate-copy skip doesn't poison paths; legacy entry reuse + NFKC path backfill; oldest-generation (`{name, type}`-only) entries converge to a single registry entry; registry path index; lint registry resolution; remove with renamed raw copies. Full suite: 716 passed (the 4 `test_url_ingest` failures are pre-existing — missing optional `trafilatura` in this env — and reproduce on clean `main`).