### PR TITLE
refactor(locks): delegate cross-platform file locking to portalocker

### DIFF
--- a/openkb/locks.py
+++ b/openkb/locks.py
@@ -2,82 +2,37 @@
 
 The lock protocol is advisory and intended for local filesystem access by
 OpenKB processes. It does not guarantee cross-host coordination on networked
-or synced filesystems where ``fcntl.flock`` may be unavailable or inconsistent.
+or synced filesystems where the underlying OS lock may be unavailable or
+inconsistent.
 """
 from __future__ import annotations
 
 import contextlib
 import json
-import logging
 import os
 import tempfile
 import threading
-import time
 from pathlib import Path
 from typing import IO, Iterator
 
-logger = logging.getLogger(__name__)
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - Windows has no fcntl (simulated in tests)
-    fcntl = None
-
-# Upper bound (seconds) on the Windows lock-acquire wait. fcntl.flock blocks in
-# the kernel indefinitely; the msvcrt fallback polls, so without a cap a genuine
-# error (or a never-released lock) would hang the process forever. Generous by
-# default so it never trips on a lock legitimately held through a long compile;
-# override via OPENKB_LOCK_TIMEOUT for constrained environments.
-_WINDOWS_LOCK_TIMEOUT = float(os.getenv("OPENKB_LOCK_TIMEOUT", "3600"))
+import portalocker
 
 
 def flock(fh: IO, *, exclusive: bool) -> None:
     """Acquire an advisory lock on an open file handle (cross-platform).
 
-    Uses ``fcntl.flock`` on POSIX. On Windows (no ``fcntl``) it falls back to
-    ``msvcrt.locking``, which provides only **exclusive** byte-range locks: a
-    shared (``exclusive=False``) request is taken exclusively. Over-locking is
-    safe for correctness but does not allow concurrent readers on Windows — and
-    because the in-process :class:`_LocalRwLock` admits multiple readers, truly
-    concurrent in-process readers serialise (and wait) on Windows. The blocking
-    acquire of ``fcntl.flock`` is emulated by retrying the non-blocking lock
-    with backoff, bounded by ``_WINDOWS_LOCK_TIMEOUT`` so a stuck lock raises
-    instead of hanging forever.
+    Delegates to :mod:`portalocker`, which is fcntl-backed on POSIX and
+    msvcrt/Win32-backed on Windows. The call blocks until the lock is acquired,
+    matching ``fcntl.flock``. Shared (``exclusive=False``) locks are honoured
+    where the platform supports them; on Windows they may be taken exclusively
+    (portalocker handles the platform differences).
     """
-    if fcntl is not None:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
-        return
-    import msvcrt
-    fh.seek(0)
-    start = time.monotonic()
-    delay = 0.05
-    warned = False
-    while True:
-        try:
-            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-            return
-        except OSError:
-            elapsed = time.monotonic() - start
-            if elapsed >= _WINDOWS_LOCK_TIMEOUT:
-                raise  # surface a stuck/never-released lock instead of hanging
-            if not warned and elapsed >= 5:
-                logger.warning(
-                    "Still waiting for file lock on %s ...",
-                    getattr(fh, "name", "<lock>"),
-                )
-                warned = True
-            time.sleep(delay)
-            delay = min(delay * 2, 1.0)
+    portalocker.lock(fh, portalocker.LOCK_EX if exclusive else portalocker.LOCK_SH)
 
 
 def funlock(fh: IO) -> None:
     """Release a lock previously acquired with :func:`flock`."""
-    if fcntl is not None:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-        return
-    import msvcrt
-    fh.seek(0)
-    msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+    portalocker.unlock(fh)
 
 
 _LOCKS_GUARD = threading.Lock()

--- a/openkb/locks.py
+++ b/openkb/locks.py
@@ -21,11 +21,16 @@ import portalocker
 def flock(fh: IO, *, exclusive: bool) -> None:
     """Acquire an advisory lock on an open file handle (cross-platform).
 
-    Delegates to :mod:`portalocker`, which is fcntl-backed on POSIX and
-    msvcrt/Win32-backed on Windows. The call blocks until the lock is acquired,
-    matching ``fcntl.flock``. Shared (``exclusive=False``) locks are honoured
-    where the platform supports them; on Windows they may be taken exclusively
-    (portalocker handles the platform differences).
+    Delegates to :mod:`portalocker`:
+
+    - **POSIX** — ``fcntl.flock``; the call blocks indefinitely until acquired.
+    - **Windows** — shared locks use the Win32 ``LockFileEx`` API (``pywin32``,
+      which portalocker pulls in automatically on Windows), so concurrent
+      readers are honoured; exclusive locks use ``msvcrt.locking``, which
+      retries for ~10s and then raises rather than blocking indefinitely.
+
+    On failure portalocker raises :class:`portalocker.LockException` — note this
+    is *not* an ``OSError`` (e.g. on filesystems without working lock support).
     """
     portalocker.lock(fh, portalocker.LOCK_EX if exclusive else portalocker.LOCK_SH)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "json-repair==0.59.10",
     "prompt_toolkit==3.0.52",
     "rich==15.0.0",
+    "portalocker==3.2.0",
 ]
 
 [project.urls]

--- a/tests/test_cross_platform_locks.py
+++ b/tests/test_cross_platform_locks.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import openkb
 from openkb import locks
 
 
@@ -31,7 +30,7 @@ def _module_level_imports_fcntl(path: Path) -> bool:
 
 def test_openkb_modules_do_not_hard_import_fcntl():
     """Guards issue #93: OpenKB's own modules must import on Windows (no bare fcntl)."""
-    pkg_dir = Path(openkb.__file__).parent
+    pkg_dir = Path(locks.__file__).parent  # locks.py lives in the openkb package
     offenders = [
         str(py.relative_to(pkg_dir))
         for py in pkg_dir.rglob("*.py")

--- a/tests/test_cross_platform_locks.py
+++ b/tests/test_cross_platform_locks.py
@@ -3,19 +3,41 @@
 File locking is delegated to :mod:`portalocker` (fcntl on POSIX, msvcrt/Win32
 on Windows), so OpenKB no longer hard-imports the Unix-only ``fcntl``. The
 atomic-write path still special-cases the Unix-only ``os.fchmod`` and directory
-``os.fsync``. These tests pin the platform-neutral behaviour that is verifiable
-on POSIX; portalocker carries its own Windows test coverage.
+``os.fsync``. These tests pin the platform-neutral behaviour verifiable on
+POSIX; portalocker carries its own Windows test coverage.
 """
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
+from pathlib import Path
 
-import portalocker
-import pytest
-
+import openkb
 from openkb import locks
+
+
+def _module_level_imports_fcntl(path: Path) -> bool:
+    """True if the module has a top-level ``import fcntl`` / ``from fcntl import``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:  # module-level statements only (import-time crash risk)
+        if isinstance(node, ast.Import) and any(a.name == "fcntl" for a in node.names):
+            return True
+        if isinstance(node, ast.ImportFrom) and node.module == "fcntl":
+            return True
+    return False
+
+
+def test_openkb_modules_do_not_hard_import_fcntl():
+    """Guards issue #93: OpenKB's own modules must import on Windows (no bare fcntl)."""
+    pkg_dir = Path(openkb.__file__).parent
+    offenders = [
+        str(py.relative_to(pkg_dir))
+        for py in pkg_dir.rglob("*.py")
+        if _module_level_imports_fcntl(py)
+    ]
+    assert not offenders, f"Unix-only fcntl hard-imported at module level in: {offenders}"
 
 
 def test_flock_funlock_roundtrip(tmp_path):
@@ -28,28 +50,35 @@ def test_flock_funlock_roundtrip(tmp_path):
         locks.funlock(fh)  # must not raise
 
 
-def test_flock_exclusive_blocks_other_process(tmp_path):
-    """An exclusive flock is a real OS lock that excludes another process."""
+def test_flock_exclusive_excludes_other_process(tmp_path):
+    """An exclusive flock is a real OS lock: it excludes another process while
+    held, and the lock is acquirable again once released."""
     lock_path = tmp_path / "test.lock"
-    fh = lock_path.open("a+", encoding="utf-8")
-    locks.flock(fh, exclusive=True)
-    try:
-        probe = (
-            "import portalocker\n"
-            f"fh = open({str(lock_path)!r}, 'a+')\n"
-            "try:\n"
-            "    portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)\n"
-            "    print('ACQUIRED')\n"
-            "except portalocker.LockException:\n"
-            "    print('BLOCKED')\n"
-        )
+    probe = (
+        "import portalocker\n"
+        f"fh = open({str(lock_path)!r}, 'a+')\n"
+        "try:\n"
+        "    portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)\n"
+        "    print('ACQUIRED')\n"
+        "except portalocker.LockException:\n"
+        "    print('BLOCKED')\n"
+    )
+
+    def run_probe() -> str:
         result = subprocess.run(
             [sys.executable, "-c", probe], capture_output=True, text=True
         )
-        assert "BLOCKED" in result.stdout, result.stdout + result.stderr
+        assert result.returncode == 0, result.stderr  # probe itself ran cleanly
+        return result.stdout.strip()
+
+    fh = lock_path.open("a+", encoding="utf-8")
+    locks.flock(fh, exclusive=True)
+    try:
+        assert run_probe() == "BLOCKED"  # held → other process is excluded
     finally:
         locks.funlock(fh)
         fh.close()
+    assert run_probe() == "ACQUIRED"  # released → other process can acquire
 
 
 def test_atomic_write_bytes_without_fchmod(monkeypatch, tmp_path):

--- a/tests/test_cross_platform_locks.py
+++ b/tests/test_cross_platform_locks.py
@@ -1,104 +1,55 @@
 """Cross-platform behaviour for openkb.locks / openkb.config.
 
-The locking layer (#86) originally hard-imported ``fcntl`` and called
-``os.fchmod`` / directory ``os.fsync`` unconditionally — all Unix-only — which
-crashed OpenKB at import time on Windows (``ModuleNotFoundError: No module
-named 'fcntl'``, reported in VectifyAI/OpenKB#93). These tests pin the
-platform-neutral behaviour and simulate the Windows path on this host.
+File locking is delegated to :mod:`portalocker` (fcntl on POSIX, msvcrt/Win32
+on Windows), so OpenKB no longer hard-imports the Unix-only ``fcntl``. The
+atomic-write path still special-cases the Unix-only ``os.fchmod`` and directory
+``os.fsync``. These tests pin the platform-neutral behaviour that is verifiable
+on POSIX; portalocker carries its own Windows test coverage.
 """
 from __future__ import annotations
 
 import os
 import subprocess
 import sys
-import types
 
+import portalocker
 import pytest
 
 from openkb import locks
 
 
-def test_config_and_locks_import_without_fcntl():
-    """openkb.config / openkb.locks must import on a host without fcntl (Windows)."""
-    code = (
-        "import sys\n"
-        "sys.modules['fcntl'] = None\n"  # make `import fcntl` raise ImportError
-        "import openkb.locks, openkb.config\n"
-        "assert openkb.locks.fcntl is None\n"
-        "print('OK')\n"
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True
-    )
-    assert result.returncode == 0, result.stderr
-    assert "OK" in result.stdout
-
-
 def test_flock_funlock_roundtrip(tmp_path):
-    """flock/funlock acquire and release an advisory lock on the real platform."""
-    lock_path = tmp_path / "test.lock"
-    with lock_path.open("a+", encoding="utf-8") as fh:
-        locks.flock(fh, exclusive=True)
-        locks.funlock(fh)  # must not raise
-
-
-def test_flock_uses_msvcrt_when_fcntl_absent(monkeypatch, tmp_path):
-    """When fcntl is unavailable (Windows), locking is delegated to msvcrt."""
-    calls = []
-    fake_msvcrt = types.SimpleNamespace(
-        LK_LOCK=1, LK_NBLCK=2, LK_UNLCK=0,
-        locking=lambda fd, mode, nbytes: calls.append((mode, nbytes)),
-    )
-    monkeypatch.setattr(locks, "fcntl", None)
-    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
-
+    """flock/funlock acquire and release both exclusive and shared locks."""
     lock_path = tmp_path / "test.lock"
     with lock_path.open("a+", encoding="utf-8") as fh:
         locks.flock(fh, exclusive=True)
         locks.funlock(fh)
-
-    modes = [mode for mode, _ in calls]
-    assert fake_msvcrt.LK_NBLCK in modes  # acquire used the non-blocking lock
-    assert fake_msvcrt.LK_UNLCK in modes  # release unlocked
+        locks.flock(fh, exclusive=False)
+        locks.funlock(fh)  # must not raise
 
 
-def test_flock_retries_until_lock_available(monkeypatch, tmp_path):
-    """The Windows fallback retries the non-blocking lock until it succeeds."""
-    attempts = {"n": 0}
-
-    def fake_locking(fd, mode, nbytes):
-        attempts["n"] += 1
-        if attempts["n"] < 3:
-            raise OSError("locked")  # contention on the first two tries
-
-    fake_msvcrt = types.SimpleNamespace(
-        LK_LOCK=1, LK_NBLCK=2, LK_UNLCK=0, locking=fake_locking
-    )
-    monkeypatch.setattr(locks, "fcntl", None)
-    monkeypatch.setattr(locks, "_WINDOWS_LOCK_TIMEOUT", 5.0)
-    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
-
-    with (tmp_path / "test.lock").open("a+", encoding="utf-8") as fh:
-        locks.flock(fh, exclusive=True)
-
-    assert attempts["n"] == 3  # retried twice, succeeded on the third
-
-
-def test_flock_raises_after_timeout(monkeypatch, tmp_path):
-    """A never-released Windows lock surfaces an error instead of hanging forever."""
-    def always_locked(fd, mode, nbytes):
-        raise OSError("locked")
-
-    fake_msvcrt = types.SimpleNamespace(
-        LK_LOCK=1, LK_NBLCK=2, LK_UNLCK=0, locking=always_locked
-    )
-    monkeypatch.setattr(locks, "fcntl", None)
-    monkeypatch.setattr(locks, "_WINDOWS_LOCK_TIMEOUT", 0.2)
-    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
-
-    with (tmp_path / "test.lock").open("a+", encoding="utf-8") as fh:
-        with pytest.raises(OSError):
-            locks.flock(fh, exclusive=True)
+def test_flock_exclusive_blocks_other_process(tmp_path):
+    """An exclusive flock is a real OS lock that excludes another process."""
+    lock_path = tmp_path / "test.lock"
+    fh = lock_path.open("a+", encoding="utf-8")
+    locks.flock(fh, exclusive=True)
+    try:
+        probe = (
+            "import portalocker\n"
+            f"fh = open({str(lock_path)!r}, 'a+')\n"
+            "try:\n"
+            "    portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)\n"
+            "    print('ACQUIRED')\n"
+            "except portalocker.LockException:\n"
+            "    print('BLOCKED')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True
+        )
+        assert "BLOCKED" in result.stdout, result.stdout + result.stderr
+    finally:
+        locks.funlock(fh)
+        fh.close()
 
 
 def test_atomic_write_bytes_without_fchmod(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1902,6 +1902,7 @@ dependencies = [
     { name = "markitdown", extra = ["docx", "pptx", "xls", "xlsx"] },
     { name = "openai-agents" },
     { name = "pageindex" },
+    { name = "portalocker" },
     { name = "prompt-toolkit" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -1924,6 +1925,7 @@ requires-dist = [
     { name = "markitdown", extras = ["docx", "pptx", "xls", "xlsx"], specifier = "==0.1.5" },
     { name = "openai-agents", specifier = "==0.17.3" },
     { name = "pageindex", specifier = "==0.3.0.dev1" },
+    { name = "portalocker", specifier = "==3.2.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
@@ -2215,6 +2217,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the hand-rolled `fcntl`/`msvcrt` `flock`/`funlock` added in #99 with [`portalocker`](https://pypi.org/project/portalocker/) — fcntl-backed on POSIX, msvcrt/Win32-backed on Windows, with maintained, cross-platform-tested behaviour.

Motivation: the #99 Windows fallback was hand-written `msvcrt` logic (retry loop, timeout, byte-range locking) that **could not be exercised on POSIX**, so its Windows behaviour was unverified. Delegating to a vetted library moves the untestable platform path to code its maintainers test on Windows.

## Changes

- `flock`/`funlock` now call `portalocker.lock` / `portalocker.unlock`.
- Drop the guarded `import fcntl`, the `msvcrt` fallback, and `_WINDOWS_LOCK_TIMEOUT` / retry loop.
- Keep the `os.fchmod` guard and the Windows directory-`fsync` skip (atomic writes — not covered by portalocker).
- Pin `portalocker==3.2.0` (BSD-3) to match the exact-pin dependency policy. `portalocker` declares `pywin32` under `sys_platform == 'win32'`, so it is installed automatically on Windows (no transitive dep on POSIX).

## Windows behaviour (verified against portalocker 3.2.0 source)

- **Shared (reader) locks ARE honoured on Windows** — portalocker uses the Win32 `LockFileEx` API (via the auto-installed `pywin32`) for shared locks, so concurrent readers work. (Correcting an earlier draft of this PR that wrongly said shared locks need a manual pywin32 add.)
- **Exclusive** locks on Windows use `msvcrt.locking`, which retries ~10s then raises rather than blocking indefinitely. A concurrent exclusive waiter contending with a long-held lock fails fast (`LockException`) instead of queueing — acceptable for OpenKB's usage; documented in the `flock` docstring.
- Lock-acquire failures raise `portalocker.LockException` (**not** `OSError`).

## Testing

- **Cross-process exclusion test**: spawns a second process whose non-blocking `portalocker.lock` is `BLOCKED` while the parent holds the lock and `ACQUIRED` after release (both directions), asserting the probe's exit code so an env/import error surfaces clearly.
- **Issue #93 import guard**: asserts no `openkb` module hard-imports the Unix-only `fcntl` at module level (so a future regression re-breaking Windows import is caught).
- Retained atomic-write / dir-fsync-skip guards. `tests/test_locks.py` (#86 `kb_lock` behaviour) still passes — delegation preserves the lock semantics.
- Full suite: **750 passed** locally (macOS).

Supersedes the hand-rolled approach in #99. Refs #93.