### PR TITLE
fix(compiler): preserve frontmatter when closing "---" has no trailing newline

### DIFF
--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -940,12 +940,15 @@ def _prepend_source_to_frontmatter(text: str, source_file: str) -> str:
         return text
 
     fm_block, body = parts
-    # Split the fm_block into lines for per-line manipulation. fm_block ends
-    # with "\n---\n"; strip the trailing closing delimiter + newline to get
-    # the prefix lines (opening "---" + content lines), then re-append after.
-    fm_prefix, _, _ = fm_block.rpartition("\n---\n")
+    # Strip the trailing closing delimiter to get the prefix lines (opening
+    # "---" + content lines), then re-append it. `frontmatter.split` leaves the
+    # closing at the end of fm_block as either "\n---\n" or a bare "\n---" (when
+    # the page ends at the delimiter with no trailing newline). Assuming only
+    # "\n---\n" would, for the bare form, make the strip below collapse the
+    # whole block and drop every existing frontmatter key.
+    closing = "\n---\n" if fm_block.endswith("\n---\n") else "\n---"
+    fm_prefix = fm_block[: -len(closing)]
     fm_lines = fm_prefix.split("\n")
-    closing = "\n---\n"
 
     for i, line in enumerate(fm_lines):
         if not line.lstrip().startswith("sources:"):
@@ -981,9 +984,12 @@ def _remove_source_from_frontmatter(text: str, source_file: str) -> tuple[str, b
         return text, False
 
     fm_block, body = parts
-    fm_prefix, _, _ = fm_block.rpartition("\n---\n")
+    # See _prepend_source_to_frontmatter: the closing delimiter may be "\n---\n"
+    # or a bare "\n---" (no trailing newline); strip whichever is present so the
+    # existing frontmatter lines (and the sources: line we need) are preserved.
+    closing = "\n---\n" if fm_block.endswith("\n---\n") else "\n---"
+    fm_prefix = fm_block[: -len(closing)]
     fm_lines = fm_prefix.split("\n")
-    closing = "\n---\n"
 
     for i, line in enumerate(fm_lines):
         if not line.lstrip().startswith("sources:"):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -35,7 +35,7 @@ from openkb.config import resolve_entity_types
 
 
 class TestFrontmatterSourceMutation:
-    """``_prepend``/``_remove_source_from_frontmatter`` must preserve existing
+    """``_prepend_source_to_frontmatter``/``_remove_source_from_frontmatter`` must preserve existing
     frontmatter even when the page ends at the closing ``---`` with no trailing
     newline — ``frontmatter.split`` then returns a block ending in a bare
     ``\\n---`` rather than ``\\n---\\n``.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -27,9 +27,42 @@ from openkb.agent.compiler import (
     _parse_entities_plan,
     _filter_entity_items,
     _ENTITY_TYPE_LIST,
+    _prepend_source_to_frontmatter,
+    _remove_source_from_frontmatter,
     remove_doc_from_entity_pages,
 )
 from openkb.config import resolve_entity_types
+
+
+class TestFrontmatterSourceMutation:
+    """``_prepend``/``_remove_source_from_frontmatter`` must preserve existing
+    frontmatter even when the page ends at the closing ``---`` with no trailing
+    newline — ``frontmatter.split`` then returns a block ending in a bare
+    ``\\n---`` rather than ``\\n---\\n``.
+    """
+
+    def test_prepend_preserves_keys_without_trailing_newline(self):
+        text = '---\nsources: ["summaries/p1.md"]\ntype: "Concept"\ndescription: "Focus"\n---'
+        out = _prepend_source_to_frontmatter(text, "summaries/p2.md")
+        assert out.startswith("---\n")            # opening delimiter kept
+        assert 'type: "Concept"' in out           # other keys kept
+        assert 'description: "Focus"' in out
+        assert "summaries/p1.md" in out           # existing source kept
+        assert "summaries/p2.md" in out           # new source prepended
+
+    def test_remove_preserves_keys_without_trailing_newline(self):
+        text = '---\ntype: "Organization"\nsources: ["summaries/doc.md"]\n---'
+        out, now_empty = _remove_source_from_frontmatter(text, "summaries/doc.md")
+        assert now_empty is True                  # it was the only source
+        assert 'type: "Organization"' in out      # other key preserved
+        assert "summaries/doc.md" not in out      # source removed
+
+    def test_prepend_with_body_is_unchanged(self):
+        text = '---\nsources: ["a.md"]\ntype: "Concept"\n---\n\nBody.\n'
+        out = _prepend_source_to_frontmatter(text, "b.md")
+        assert out.startswith("---\n")
+        assert "b.md" in out and "a.md" in out
+        assert out.endswith("\n\nBody.\n")         # body + closing untouched
 
 
 class TestParseJson:


### PR DESCRIPTION
## Summary

A frontmatter-only concept/entity page that ends right at the closing `---`
with **no trailing newline** gets its frontmatter silently destroyed when a
source is added or removed: the opening `---`, the `type` / `description`
keys, and the existing `sources:` list are all dropped — corrupting the page
and losing source provenance.

## Root cause

`frontmatter.split` is lossless and, for a page with no trailing newline after
the closing delimiter, returns a block ending in a bare `\n---` (not
`\n---\n`):

```python
# openkb/frontmatter.py — split()
after = text.find("\n", nl + 1)   # newline ending the closing '---' line
if after == -1:
    return text, ""               # closing '---' has no trailing newline
```

But both `_prepend_source_to_frontmatter` and `_remove_source_from_frontmatter`
located the closing delimiter with `fm_block.rpartition("\n---\n")`, which
matches nothing in that case — so `fm_prefix` becomes `""`, every frontmatter
line is lost, and the block is rebuilt from nothing:

```python
fm_prefix, _, _ = fm_block.rpartition("\n---\n")   # -> ("", "", fm_block)
fm_lines = fm_prefix.split("\n")                   # -> [""]
```

Concrete trace (`_prepend_source_to_frontmatter`):

```
in : '---\nsources: ["summaries/p1.md"]\ntype: "Concept"\ndescription: "Focus"\n---'
out: '\nsources: ["summaries/p2.md"]\n---\n'     # type, description, p1.md, opening --- all gone
```

This is reached during normal use via `_add_related_link` (run for every
related concept/entity at compile time) and the `openkb remove` flow
(`remove_doc_from_{concept,entity}_pages`).

## Fix

Strip whichever closing form is actually present and re-append the same one:

```python
closing = "\n---\n" if fm_block.endswith("\n---\n") else "\n---"
fm_prefix = fm_block[: -len(closing)]
```

With the fix the same input yields
`---\nsources: ["summaries/p2.md", "summaries/p1.md"]\ntype: "Concept"\ndescription: "Focus"\n---`
— all keys and the prior source preserved. Pages that have a body (the common
case) are byte-for-byte unaffected.

## Testing

```text
$ pytest tests/test_compiler.py::TestFrontmatterSourceMutation -q
3 passed
$ ruff check openkb/agent/compiler.py
All checks passed!
```

Adds `TestFrontmatterSourceMutation` (prepend + remove on a no-trailing-newline
page, plus a with-body regression guard). The existing `_add_related_link` /
`remove_doc_from_entity_pages` tests only used pages **with** a body, so this
path was uncovered.

> Note: the rest of `tests/test_compiler.py` has some pre-existing failures
> in the LLM-mock suites that are unrelated to this change (they reproduce on
> `main` without this patch); the frontmatter tests above pass.
