### PR TITLE
fix(images): don't overwrite relative images that share a basename

### DIFF
--- a/openkb/images.py
+++ b/openkb/images.py
@@ -229,7 +229,12 @@ def copy_relative_images(
     # ``b/logo.png``) don't overwrite each other and collapse both links onto a
     # single image.
     assigned: dict[Path, str] = {}
-    taken: set[str] = set()
+    # Seed taken names from any files already in images_dir so a re-convert into
+    # an existing per-doc directory disambiguates against them instead of
+    # overwriting a previously-copied image with a same-basename source.
+    taken: set[str] = (
+        {p.name for p in images_dir.iterdir()} if images_dir.is_dir() else set()
+    )
 
     for match in _RELATIVE_RE.finditer(markdown):
         alt, rel_path = match.group(1), match.group(2)

--- a/openkb/images.py
+++ b/openkb/images.py
@@ -223,6 +223,13 @@ def copy_relative_images(
     - Missing source file: log a warning and leave the original text unchanged.
     """
     result = markdown
+    # Track the destination chosen for each already-copied source so the same
+    # image referenced twice isn't duplicated, plus the set of taken names so
+    # two *different* sources that share a basename (e.g. ``a/logo.png`` and
+    # ``b/logo.png``) don't overwrite each other and collapse both links onto a
+    # single image.
+    assigned: dict[Path, str] = {}
+    taken: set[str] = set()
 
     for match in _RELATIVE_RE.finditer(markdown):
         alt, rel_path = match.group(1), match.group(2)
@@ -236,10 +243,17 @@ def copy_relative_images(
             )
             continue
 
-        filename = src.name
-        dest = images_dir / filename
-        images_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
+        filename = assigned.get(src)
+        if filename is None:
+            filename = src.name
+            n = 1
+            while filename in taken:
+                filename = f"{src.stem}_{n}{src.suffix}"
+                n += 1
+            assigned[src] = filename
+            taken.add(filename)
+            images_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, images_dir / filename)
 
         new_ref = f"![{alt}](sources/images/{doc_name}/{filename})"
         result = result.replace(match.group(0), new_ref, 1)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -201,3 +201,23 @@ class TestCopyRelativeImages:
 
         assert [p.name for p in images_dir.iterdir()] == ["logo.png"]
         assert result.count("sources/images/doc/logo.png") == 2
+
+    def test_does_not_overwrite_preexisting_file_in_images_dir(self, tmp_path):
+        # A file already in images_dir (e.g. from a prior conversion) with a
+        # colliding basename must not be silently overwritten.
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        (source_dir / "logo.png").write_bytes(FAKE_JPG)  # new image
+        images_dir = tmp_path / "images" / "doc"
+        images_dir.mkdir(parents=True)
+        (images_dir / "logo.png").write_bytes(FAKE_PNG)  # pre-existing image
+
+        result = copy_relative_images("![a](logo.png)", source_dir, "doc", images_dir)
+
+        # Pre-existing file kept intact; the new image lands under a fresh name.
+        assert (images_dir / "logo.png").read_bytes() == FAKE_PNG
+        names = sorted(p.name for p in images_dir.iterdir())
+        assert len(names) == 2
+        new_name = next(n for n in names if n != "logo.png")
+        assert (images_dir / new_name).read_bytes() == FAKE_JPG
+        assert f"sources/images/doc/{new_name}" in result

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -164,3 +164,40 @@ class TestCopyRelativeImages:
         assert "![b](sources/images/doc/b.jpg)" in result
         assert (images_dir / "a.png").exists()
         assert (images_dir / "b.jpg").exists()
+
+    def test_same_basename_different_dirs_no_overwrite(self, tmp_path):
+        # Two distinct images sharing a basename must not overwrite each other
+        # (which would lose one image and point both links at the survivor).
+        source_dir = tmp_path / "source"
+        (source_dir / "a").mkdir(parents=True)
+        (source_dir / "b").mkdir(parents=True)
+        (source_dir / "a" / "logo.png").write_bytes(FAKE_PNG)
+        (source_dir / "b" / "logo.png").write_bytes(FAKE_JPG)
+
+        images_dir = tmp_path / "images" / "doc"
+        images_dir.mkdir(parents=True)
+
+        md = "![a](a/logo.png)\n![b](b/logo.png)"
+        result = copy_relative_images(md, source_dir, "doc", images_dir)
+
+        saved = sorted(p.name for p in images_dir.iterdir())
+        assert len(saved) == 2  # both copied, neither overwritten
+        assert {(images_dir / n).read_bytes() for n in saved} == {FAKE_PNG, FAKE_JPG}
+        links = sorted(
+            line.split("](")[1].rstrip(")") for line in result.strip().splitlines()
+        )
+        assert links[0] != links[1]  # links point at different files
+
+    def test_same_image_referenced_twice_is_copied_once(self, tmp_path):
+        # Identical source referenced twice: copy once, both links agree.
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        (source_dir / "logo.png").write_bytes(FAKE_PNG)
+        images_dir = tmp_path / "images" / "doc"
+        images_dir.mkdir(parents=True)
+
+        md = "![x](logo.png)\n![y](logo.png)"
+        result = copy_relative_images(md, source_dir, "doc", images_dir)
+
+        assert [p.name for p in images_dir.iterdir()] == ["logo.png"]
+        assert result.count("sources/images/doc/logo.png") == 2


### PR DESCRIPTION
## Summary

`copy_relative_images` could **silently lose an image** and render the wrong
one. It named every destination after `src.name` (the basename only), so two
references to *different* files that happen to share a basename collide.

## Root cause

```python
filename = src.name          # basename only
dest = images_dir / filename
shutil.copy2(src, dest)      # second same-basename source overwrites the first
```

For `![a](a/logo.png)` + `![b](b/logo.png)`:
- both copy to `images_dir/logo.png` → the second `copy2` overwrites the first
  (image A's bytes are gone), and
- both links are rewritten to `sources/images/<doc>/logo.png`, so the rendered
  document shows the **same** image in both places.

`extract_base64_images` already avoids this by numbering destinations
(`img_{counter:03d}`); only the relative-image path was affected.

| input | before | after |
|---|---|---|
| `a/logo.png` + `b/logo.png` (distinct) | 1 file, both links → it, A lost | 2 files (`logo.png`, `logo_1.png`), distinct links |
| `logo.png` referenced twice (same file) | 1 file | 1 file (deduped, both links agree) |

## Fix

Track the destination assigned to each source: reuse it when the **identical**
source is referenced more than once (no duplicate copy), and disambiguate with
a `{stem}_{n}{suffix}` suffix when a **different** source would collide on a
name already taken.

## Testing

```text
$ pytest tests/test_images.py -q
12 passed
$ ruff check openkb/images.py tests/test_images.py
All checks passed!
```

Adds `test_same_basename_different_dirs_no_overwrite` (both images preserved,
links distinct) and `test_same_image_referenced_twice_is_copied_once` (dedup).
