### PR TITLE
feat(config): configurable LLM request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ OpenKB settings are initialized by `openkb init` and stored in `.openkb/config.y
 model: gpt-5.4                   # LLM model (any LiteLLM-supported provider)
 language: en                     # Wiki output language
 pageindex_threshold: 20          # PDF pages threshold for PageIndex
-timeout: 1200                    # (optional) per-request LLM timeout in seconds; defaults to LiteLLM's 600s
 ```
 
 Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/providers) (OpenAI models can omit the prefix):

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ extra_headers:
   Copilot-Integration-Id: vscode-chat
 ```
 
-`timeout` (optional): the per-request LLM timeout in seconds, forwarded to LiteLLM. Defaults to LiteLLM's own 600s; raise it for slow local backends (e.g. Ollama on large inputs) that would otherwise hit `litellm.Timeout`:
+`timeout` (optional): the per-request LLM timeout in seconds, forwarded to LiteLLM on all of OpenKB's own calls (compile, query, chat, lint, skill). Defaults to LiteLLM's own 600s; raise it for slow local backends (e.g. Ollama on large inputs) that would otherwise hit `litellm.Timeout`. (PageIndex long-document indexing manages its own timeout and is not affected.)
 
 ```yaml
 timeout: 1200

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/p
 | Gemini | `gemini/gemini-3.1-pro-preview` |
 
 <details>
-<summary><i>Advanced options (<code>entity_types</code>, <code>extra_headers</code>, OAuth):</i></summary>
+<summary><i>Advanced options (<code>entity_types</code>, <code>extra_headers</code>, <code>timeout</code>, OAuth):</i></summary>
 <br>
 
 `entity_types` (optional): a YAML list overriding the entity-type vocabulary used for entity pages; omit it to use the default `person`, `organization`, `place`, `product`, `work`, `event`, `other`.
@@ -380,6 +380,12 @@ Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/p
 extra_headers:
   Editor-Version: vscode/1.95.0
   Copilot-Integration-Id: vscode-chat
+```
+
+`timeout` (optional): the per-request LLM timeout in seconds, forwarded to LiteLLM. Defaults to LiteLLM's own 600s; raise it for slow local backends (e.g. Ollama on large inputs) that would otherwise hit `litellm.Timeout`:
+
+```yaml
+timeout: 1200
 ```
 
 Subscription-based providers that authenticate via OAuth device flow (e.g. `chatgpt/*`, `github_copilot/*`) need no API key; OpenKB skips the missing-key warning for them.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ OpenKB settings are initialized by `openkb init` and stored in `.openkb/config.y
 model: gpt-5.4                   # LLM model (any LiteLLM-supported provider)
 language: en                     # Wiki output language
 pageindex_threshold: 20          # PDF pages threshold for PageIndex
+timeout: 1200                    # (optional) per-request LLM timeout in seconds; defaults to LiteLLM's 600s
 ```
 
 Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/providers) (OpenAI models can omit the prefix):
@@ -369,7 +370,7 @@ Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/p
 | Gemini | `gemini/gemini-3.1-pro-preview` |
 
 <details>
-<summary><i>Advanced options (<code>entity_types</code>, <code>extra_headers</code>, <code>timeout</code>, OAuth):</i></summary>
+<summary><i>Advanced options (<code>entity_types</code>, <code>extra_headers</code>, OAuth):</i></summary>
 <br>
 
 `entity_types` (optional): a YAML list overriding the entity-type vocabulary used for entity pages; omit it to use the default `person`, `organization`, `place`, `product`, `work`, `event`, `other`.
@@ -380,12 +381,6 @@ Model names use `provider/model` LiteLLM [format](https://docs.litellm.ai/docs/p
 extra_headers:
   Editor-Version: vscode/1.95.0
   Copilot-Integration-Id: vscode-chat
-```
-
-`timeout` (optional): the per-request LLM timeout in seconds, forwarded to LiteLLM on all of OpenKB's own calls (compile, query, chat, lint, skill). Defaults to LiteLLM's own 600s; raise it for slow local backends (e.g. Ollama on large inputs) that would otherwise hit `litellm.Timeout`. (PageIndex long-document indexing manages its own timeout and is not affected.)
-
-```yaml
-timeout: 1200
 ```
 
 Subscription-based providers that authenticate via OAuth device flow (e.g. `chatgpt/*`, `github_copilot/*`) need no API key; OpenKB skips the missing-key warning for them.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,3 +17,7 @@ pageindex_threshold: 20          # PDF pages threshold for PageIndex
 #   - organization
 #   - dataset
 #   - model
+
+# Optional: per-request LLM timeout in seconds, forwarded to LiteLLM.
+# Defaults to LiteLLM's 600s; raise it for slow local backends (e.g. Ollama).
+# timeout: 1200

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -29,7 +29,12 @@ from pathlib import Path
 import litellm
 
 from openkb import frontmatter
-from openkb.config import DEFAULT_ENTITY_TYPES, get_extra_headers, resolve_entity_types
+from openkb.config import (
+    DEFAULT_ENTITY_TYPES,
+    get_extra_headers,
+    get_timeout,
+    resolve_entity_types,
+)
 from openkb.lint import list_existing_wiki_targets, strip_ghost_wikilinks
 from openkb.schema import INDEX_SEED, get_agents_md
 
@@ -326,6 +331,9 @@ def _llm_call(model: str, messages: list[dict], step_name: str, **kwargs) -> str
     extra_headers = get_extra_headers()
     if extra_headers:
         kwargs.setdefault("extra_headers", extra_headers)
+    timeout = get_timeout()
+    if timeout is not None:
+        kwargs.setdefault("timeout", timeout)
     logger.debug("LLM request [%s]:\n%s", step_name, _fmt_messages(messages))
     if kwargs:
         logger.debug("LLM kwargs [%s]: %s", step_name, kwargs)
@@ -348,6 +356,9 @@ async def _llm_call_async(model: str, messages: list[dict], step_name: str, **kw
     extra_headers = get_extra_headers()
     if extra_headers:
         kwargs.setdefault("extra_headers", extra_headers)
+    timeout = get_timeout()
+    if timeout is not None:
+        kwargs.setdefault("timeout", timeout)
     logger.debug("LLM request [%s]:\n%s", step_name, _fmt_messages(messages))
     if kwargs:
         logger.debug("LLM kwargs [%s]: %s", step_name, kwargs)

--- a/openkb/agent/linter.py
+++ b/openkb/agent/linter.py
@@ -7,7 +7,7 @@ from agents import Agent, Runner, function_tool
 from agents.model_settings import ModelSettings
 
 from openkb.agent.tools import list_wiki_files, read_wiki_file
-from openkb.config import get_extra_headers
+from openkb.config import get_extra_headers, get_timeout_extra_args
 
 MAX_TURNS = 50
 from openkb.schema import get_agents_md
@@ -81,7 +81,10 @@ def build_lint_agent(wiki_root: str, model: str, language: str = "en") -> Agent:
         instructions=instructions,
         tools=[list_files, read_file],
         model=f"litellm/{model}",
-        model_settings=ModelSettings(extra_headers=get_extra_headers() or None),
+        model_settings=ModelSettings(
+            extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
+        ),
     )
 
 

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from agents import Agent, Runner, function_tool
 
 from agents import ToolOutputImage, ToolOutputText
-from openkb.config import get_extra_headers
+from openkb.config import get_extra_headers, get_timeout_extra_args
 from openkb.agent.tools import (
     get_wiki_page_content,
     read_wiki_file,
@@ -98,6 +98,7 @@ def build_query_agent(wiki_root: str, model: str, language: str = "en") -> Agent
         model_settings=ModelSettings(
             parallel_tool_calls=False,
             extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
         ),
     )
 

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -43,7 +43,7 @@ from dotenv import load_dotenv
 
 from openkb.config import (
     DEFAULT_CONFIG, load_config, save_config, load_global_config, register_kb,
-    resolve_extra_headers, set_extra_headers,
+    resolve_extra_headers, set_extra_headers, resolve_timeout, set_timeout,
 )
 from openkb.converter import _registry_path, convert_document
 from openkb.locks import atomic_write_json, atomic_write_text, kb_ingest_lock, kb_read_lock
@@ -108,9 +108,11 @@ def _setup_llm_key(kb_dir: Path | None = None) -> None:
 
     api_key = os.environ.get("LLM_API_KEY", "")
 
-    # Try to resolve the active provider and extra headers from the KB config
+    # Try to resolve the active provider, extra headers, and request timeout
+    # from the KB config
     provider: str | None = None
     extra_headers: dict[str, str] = {}
+    timeout: float | None = None
     if kb_dir is not None:
         config_path = kb_dir / ".openkb" / "config.yaml"
         if config_path.exists():
@@ -118,7 +120,9 @@ def _setup_llm_key(kb_dir: Path | None = None) -> None:
             model = config.get("model", "")
             provider = _extract_provider(str(model))
             extra_headers = resolve_extra_headers(config)
+            timeout = resolve_timeout(config)
     set_extra_headers(extra_headers)
+    set_timeout(timeout)
 
     if not api_key:
         # Check if any provider key is already set. OAuth-based providers

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import math
 import re
 from pathlib import Path
 from typing import Any, Iterator
@@ -147,7 +148,8 @@ def resolve_timeout(config: dict) -> float | None:
     Accepts an int or float number of seconds (a numeric string is coerced).
     Returns ``None`` — meaning "use LiteLLM's default" — when the key is
     absent, and logs a warning and returns ``None`` when it is present but not
-    a positive number. Booleans are rejected (``True``/``False`` aren't durations).
+    a finite positive number. Booleans are rejected (``True``/``False`` aren't
+    durations), as are ``nan``/``inf`` (which YAML's ``.nan``/``.inf`` produce).
     """
     raw = config.get("timeout")
     if raw is None:
@@ -168,10 +170,10 @@ def resolve_timeout(config: dict) -> float | None:
             raw,
         )
         return None
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         logger.warning(
-            "config: 'timeout' must be a positive number of seconds, got %s — "
-            "ignoring it.",
+            "config: 'timeout' must be a finite positive number of seconds, got "
+            "%s — ignoring it.",
             value,
         )
         return None
@@ -214,6 +216,19 @@ def set_timeout(timeout: float | None) -> None:
 def get_timeout() -> float | None:
     """Return the process-wide LLM request timeout in seconds, or ``None``."""
     return _runtime_timeout
+
+
+def get_timeout_extra_args() -> dict[str, float] | None:
+    """Return ``{"timeout": <seconds>}`` for the Agents SDK, or ``None``.
+
+    The openai-agents ``ModelSettings`` has no ``timeout`` field, so the
+    configured timeout reaches the agent paths (query/chat/lint/skill) via
+    ``ModelSettings(extra_args=...)``, which the LiteLLM provider forwards to
+    the underlying completion call — keeping those calls consistent with the
+    compiler's direct ``litellm`` calls. ``None`` when no timeout is configured.
+    """
+    timeout = _runtime_timeout
+    return {"timeout": timeout} if timeout is not None else None
 
 
 def load_config(config_path: Path) -> dict[str, Any]:

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -136,6 +136,48 @@ def resolve_extra_headers(config: dict) -> dict[str, str]:
     return headers
 
 
+def resolve_timeout(config: dict) -> float | None:
+    """Resolve the optional ``timeout:`` config key into a positive float of seconds.
+
+    LiteLLM applies a 600-second per-request timeout by default, which can be
+    too short for slow local backends (e.g. Ollama on large inputs). Users
+    raise it via a ``timeout:`` value in config.yaml; the result is forwarded
+    to LiteLLM's ``timeout`` parameter on OpenKB's own LLM calls.
+
+    Accepts an int or float number of seconds (a numeric string is coerced).
+    Returns ``None`` — meaning "use LiteLLM's default" — when the key is
+    absent, and logs a warning and returns ``None`` when it is present but not
+    a positive number. Booleans are rejected (``True``/``False`` aren't durations).
+    """
+    raw = config.get("timeout")
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
+        logger.warning(
+            "config: 'timeout' must be a positive number of seconds, got %s — "
+            "ignoring it.",
+            type(raw).__name__,
+        )
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "config: 'timeout' must be a positive number of seconds, got %r — "
+            "ignoring it.",
+            raw,
+        )
+        return None
+    if value <= 0:
+        logger.warning(
+            "config: 'timeout' must be a positive number of seconds, got %s — "
+            "ignoring it.",
+            value,
+        )
+        return None
+    return value
+
+
 # Process-wide extra headers for LLM requests, resolved from the active KB's
 # config by the CLI entry points (cli._setup_llm_key). LLM call sites read it
 # via get_extra_headers() so the value doesn't have to be threaded through
@@ -153,6 +195,25 @@ def set_extra_headers(headers: dict[str, str]) -> None:
 def get_extra_headers() -> dict[str, str]:
     """Return a copy of the process-wide extra headers for LLM requests."""
     return dict(_runtime_extra_headers)
+
+
+# Process-wide LLM request timeout in seconds, resolved from the active KB's
+# config by the CLI entry points (cli._setup_llm_key). LLM call sites read it
+# via get_timeout() so the value doesn't have to be threaded through every
+# compile/agent call chain — mirroring extra headers above. ``None`` means
+# "use LiteLLM's built-in default".
+_runtime_timeout: float | None = None
+
+
+def set_timeout(timeout: float | None) -> None:
+    """Set the process-wide LLM request timeout in seconds; ``None`` clears it."""
+    global _runtime_timeout
+    _runtime_timeout = timeout
+
+
+def get_timeout() -> float | None:
+    """Return the process-wide LLM request timeout in seconds, or ``None``."""
+    return _runtime_timeout
 
 
 def load_config(config_path: Path) -> dict[str, Any]:

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -138,18 +138,10 @@ def resolve_extra_headers(config: dict) -> dict[str, str]:
 
 
 def resolve_timeout(config: dict) -> float | None:
-    """Resolve the optional ``timeout:`` config key into a positive float of seconds.
+    """Resolve the optional ``timeout:`` key to a finite positive number of seconds.
 
-    LiteLLM applies a 600-second per-request timeout by default, which can be
-    too short for slow local backends (e.g. Ollama on large inputs). Users
-    raise it via a ``timeout:`` value in config.yaml; the result is forwarded
-    to LiteLLM's ``timeout`` parameter on OpenKB's own LLM calls.
-
-    Accepts an int or float number of seconds (a numeric string is coerced).
-    Returns ``None`` — meaning "use LiteLLM's default" — when the key is
-    absent, and logs a warning and returns ``None`` when it is present but not
-    a finite positive number. Booleans are rejected (``True``/``False`` aren't
-    durations), as are ``nan``/``inf`` (which YAML's ``.nan``/``.inf`` produce).
+    Returns ``None`` (use LiteLLM's default) when absent or invalid; rejects
+    bools and ``nan``/``inf``, warning when present but unusable.
     """
     raw = config.get("timeout")
     if raw is None:
@@ -199,11 +191,8 @@ def get_extra_headers() -> dict[str, str]:
     return dict(_runtime_extra_headers)
 
 
-# Process-wide LLM request timeout in seconds, resolved from the active KB's
-# config by the CLI entry points (cli._setup_llm_key). LLM call sites read it
-# via get_timeout() so the value doesn't have to be threaded through every
-# compile/agent call chain — mirroring extra headers above. ``None`` means
-# "use LiteLLM's built-in default".
+# Process-wide LLM request timeout (seconds), set from config by the CLI and
+# read at the call sites via get_timeout(). None = use LiteLLM's default.
 _runtime_timeout: float | None = None
 
 
@@ -219,16 +208,10 @@ def get_timeout() -> float | None:
 
 
 def get_timeout_extra_args() -> dict[str, float] | None:
-    """Return ``{"timeout": <seconds>}`` for the Agents SDK, or ``None``.
-
-    The openai-agents ``ModelSettings`` has no ``timeout`` field, so the
-    configured timeout reaches the agent paths (query/chat/lint/skill) via
-    ``ModelSettings(extra_args=...)``, which the LiteLLM provider forwards to
-    the underlying completion call — keeping those calls consistent with the
-    compiler's direct ``litellm`` calls. ``None`` when no timeout is configured.
+    """Timeout as Agents-SDK ``ModelSettings.extra_args`` (it has no ``timeout``
+    field), or ``None``. The LiteLLM provider forwards it to the completion call.
     """
-    timeout = _runtime_timeout
-    return {"timeout": timeout} if timeout is not None else None
+    return {"timeout": _runtime_timeout} if _runtime_timeout is not None else None
 
 
 def load_config(config_path: Path) -> dict[str, Any]:

--- a/openkb/skill/creator.py
+++ b/openkb/skill/creator.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from agents import Agent, Runner, ToolOutputImage, ToolOutputText, function_tool
 from agents.model_settings import ModelSettings
 
-from openkb.config import get_extra_headers
+from openkb.config import get_extra_headers, get_timeout_extra_args
 from openkb.skill import skill_dir
 from openkb.skill.tools import (
     get_skill_page_content as _get_page_content_impl,
@@ -154,6 +154,7 @@ def build_skill_create_agent(
         model_settings=ModelSettings(
             parallel_tool_calls=True,
             extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
         ),
     )
 

--- a/openkb/skill/evaluator.py
+++ b/openkb/skill/evaluator.py
@@ -46,7 +46,7 @@ from agents import Agent, Runner
 from agents.exceptions import MaxTurnsExceeded
 from agents.model_settings import ModelSettings
 
-from openkb.config import get_extra_headers
+from openkb.config import get_extra_headers, get_timeout_extra_args
 from openkb.skill import extract_body, extract_frontmatter
 
 
@@ -243,7 +243,10 @@ async def generate_eval_set(
         name="eval-set-generator",
         instructions=instructions,
         model=f"litellm/{model}",
-        model_settings=ModelSettings(extra_headers=get_extra_headers() or None),
+        model_settings=ModelSettings(
+            extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
+        ),
     )
     try:
         result = await Runner.run(agent, "Generate the eval set now.", max_turns=3)
@@ -302,7 +305,10 @@ async def grade_one(
         name="trigger-grader",
         instructions=instructions,
         model=f"litellm/{model}",
-        model_settings=ModelSettings(extra_headers=get_extra_headers() or None),
+        model_settings=ModelSettings(
+            extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
+        ),
     )
     try:
         result = await Runner.run(agent, f"Question: {question}", max_turns=2)
@@ -351,7 +357,10 @@ async def grade_coverage(
         name="coverage-grader",
         instructions=instructions,
         model=f"litellm/{model}",
-        model_settings=ModelSettings(extra_headers=get_extra_headers() or None),
+        model_settings=ModelSettings(
+            extra_headers=get_extra_headers() or None,
+            extra_args=get_timeout_extra_args(),
+        ),
     )
     try:
         result = await Runner.run(agent, f"Question: {question}", max_turns=2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,11 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _reset_extra_headers():
-    """Keep the process-wide LLM extra-headers stash from leaking across tests."""
-    from openkb.config import set_extra_headers
+    """Keep the process-wide LLM extra-headers / timeout stashes from leaking across tests."""
+    from openkb.config import set_extra_headers, set_timeout
     yield
     set_extra_headers({})
+    set_timeout(None)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,12 +373,14 @@ class TestSetupLlmKey:
     """_setup_llm_key: OAuth-provider warning skip + extra-headers stash."""
 
     @staticmethod
-    def _make_kb(tmp_path, model, extra_headers=None):
+    def _make_kb(tmp_path, model, extra_headers=None, timeout=None):
         openkb_dir = tmp_path / ".openkb"
         openkb_dir.mkdir()
         config = {"model": model}
         if extra_headers is not None:
             config["extra_headers"] = extra_headers
+        if timeout is not None:
+            config["timeout"] = timeout
         (openkb_dir / "config.yaml").write_text(
             yaml.safe_dump(config), encoding="utf-8"
         )
@@ -445,3 +447,20 @@ class TestSetupLlmKey:
         kb = self._make_kb(tmp_path, "gpt-5.4-mini")
         _setup_llm_key(kb)
         assert get_extra_headers() == {}
+
+    def test_timeout_stashed_from_config(self, tmp_path):
+        from openkb.cli import _setup_llm_key
+        from openkb.config import get_timeout
+
+        kb = self._make_kb(tmp_path, "gpt-5.4-mini", timeout=1200)
+        _setup_llm_key(kb)
+        assert get_timeout() == 1200.0
+
+    def test_timeout_reset_when_config_has_none(self, tmp_path):
+        from openkb.cli import _setup_llm_key
+        from openkb.config import get_timeout, set_timeout
+
+        set_timeout(999.0)
+        kb = self._make_kb(tmp_path, "gpt-5.4-mini")
+        _setup_llm_key(kb)
+        assert get_timeout() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,13 @@
 from openkb.config import (
     DEFAULT_CONFIG,
     get_extra_headers,
+    get_timeout,
     load_config,
     resolve_extra_headers,
+    resolve_timeout,
     save_config,
     set_extra_headers,
+    set_timeout,
 )
 
 
@@ -102,3 +105,40 @@ def test_extra_headers_stash_roundtrip_and_isolation():
     assert get_extra_headers() == {"A": "1"}
     set_extra_headers({})
     assert get_extra_headers() == {}
+
+
+# --- timeout -----------------------------------------------------------------
+
+def test_resolve_timeout_absent_returns_none():
+    assert resolve_timeout({}) is None
+
+
+def test_resolve_timeout_int_and_float():
+    assert resolve_timeout({"timeout": 1200}) == 1200.0
+    assert resolve_timeout({"timeout": 0.5}) == 0.5
+
+
+def test_resolve_timeout_numeric_string_coerced():
+    assert resolve_timeout({"timeout": "1200"}) == 1200.0
+
+
+def test_resolve_timeout_rejects_non_positive():
+    assert resolve_timeout({"timeout": 0}) is None
+    assert resolve_timeout({"timeout": -10}) is None
+
+
+def test_resolve_timeout_rejects_bool():
+    # bool is a subclass of int; True/False are not durations.
+    assert resolve_timeout({"timeout": True}) is None
+
+
+def test_resolve_timeout_rejects_non_numeric():
+    assert resolve_timeout({"timeout": "soon"}) is None
+    assert resolve_timeout({"timeout": [1200]}) is None
+
+
+def test_timeout_stash_roundtrip_and_reset():
+    set_timeout(1200.0)
+    assert get_timeout() == 1200.0
+    set_timeout(None)
+    assert get_timeout() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,6 +137,14 @@ def test_resolve_timeout_rejects_non_numeric():
     assert resolve_timeout({"timeout": [1200]}) is None
 
 
+def test_resolve_timeout_rejects_nan_and_inf():
+    # nan/inf pass a naive `<= 0` check; YAML's .nan/.inf yield real floats.
+    assert resolve_timeout({"timeout": float("inf")}) is None
+    assert resolve_timeout({"timeout": float("nan")}) is None
+    assert resolve_timeout({"timeout": "inf"}) is None
+    assert resolve_timeout({"timeout": "nan"}) is None
+
+
 def test_timeout_stash_roundtrip_and_reset():
     set_timeout(1200.0)
     assert get_timeout() == 1200.0

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -57,3 +57,24 @@ def test_llm_call_async_forwards_configured_timeout():
             _llm_call_async("gpt-4o", [{"role": "user", "content": "hi"}], "step")
         )
     assert acompletion.call_args.kwargs["timeout"] == 900.0
+
+
+def test_llm_call_async_omits_timeout_when_unset():
+    set_timeout(None)
+    with patch("openkb.agent.compiler.litellm.acompletion",
+               new_callable=AsyncMock, return_value=_fake_response()) as acompletion:
+        asyncio.run(
+            _llm_call_async("gpt-4o", [{"role": "user", "content": "hi"}], "step")
+        )
+    assert "timeout" not in acompletion.call_args.kwargs
+
+
+def test_llm_call_async_does_not_override_explicit_timeout():
+    set_timeout(900.0)
+    with patch("openkb.agent.compiler.litellm.acompletion",
+               new_callable=AsyncMock, return_value=_fake_response()) as acompletion:
+        asyncio.run(
+            _llm_call_async("gpt-4o", [{"role": "user", "content": "hi"}], "step",
+                            timeout=30)
+        )
+    assert acompletion.call_args.kwargs["timeout"] == 30

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -1,0 +1,59 @@
+"""The configurable LLM request timeout is forwarded to LiteLLM.
+
+`timeout:` in config.yaml is resolved into a process-wide stash (see
+test_config.py) and read at the LiteLLM call sites in openkb.agent.compiler.
+These tests pin the call-site behavior: a configured timeout is forwarded to
+`litellm.(a)completion`, and nothing is forwarded when it is unset (so LiteLLM
+keeps applying its own default).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from openkb.agent.compiler import _llm_call, _llm_call_async
+from openkb.config import set_timeout
+
+
+def _fake_response():
+    choice = MagicMock()
+    choice.message.content = "ok"
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def test_llm_call_forwards_configured_timeout():
+    set_timeout(1200.0)
+    with patch("openkb.agent.compiler.litellm.completion",
+               return_value=_fake_response()) as completion:
+        _llm_call("gpt-4o", [{"role": "user", "content": "hi"}], "step")
+    assert completion.call_args.kwargs["timeout"] == 1200.0
+
+
+def test_llm_call_omits_timeout_when_unset():
+    set_timeout(None)
+    with patch("openkb.agent.compiler.litellm.completion",
+               return_value=_fake_response()) as completion:
+        _llm_call("gpt-4o", [{"role": "user", "content": "hi"}], "step")
+    assert "timeout" not in completion.call_args.kwargs
+
+
+def test_llm_call_does_not_override_explicit_timeout():
+    # An explicit per-call timeout kwarg wins over the configured default.
+    set_timeout(1200.0)
+    with patch("openkb.agent.compiler.litellm.completion",
+               return_value=_fake_response()) as completion:
+        _llm_call("gpt-4o", [{"role": "user", "content": "hi"}], "step", timeout=30)
+    assert completion.call_args.kwargs["timeout"] == 30
+
+
+def test_llm_call_async_forwards_configured_timeout():
+    set_timeout(900.0)
+    with patch("openkb.agent.compiler.litellm.acompletion",
+               new_callable=AsyncMock, return_value=_fake_response()) as acompletion:
+        asyncio.run(
+            _llm_call_async("gpt-4o", [{"role": "user", "content": "hi"}], "step")
+        )
+    assert acompletion.call_args.kwargs["timeout"] == 900.0

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -163,3 +163,22 @@ class TestQueryAgentExtraHeaders:
     def test_no_extra_headers_by_default(self, tmp_path):
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
         assert agent.model_settings.extra_headers is None
+
+
+class TestQueryAgentTimeout:
+    """Config-driven timeout reaches the agents-SDK model settings via extra_args.
+
+    ModelSettings has no ``timeout`` field, so it is forwarded through
+    ``extra_args`` (which the LiteLLM provider passes on to the completion call).
+    """
+
+    def test_timeout_applied_from_stash(self, tmp_path):
+        from openkb.config import set_timeout
+
+        set_timeout(1200.0)
+        agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
+        assert agent.model_settings.extra_args == {"timeout": 1200.0}
+
+    def test_no_timeout_by_default(self, tmp_path):
+        agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
+        assert agent.model_settings.extra_args is None


### PR DESCRIPTION
## Summary

Adds an optional `timeout:` config key (seconds), forwarded to LiteLLM's `timeout` on all of OpenKB's own LLM calls. LiteLLM applies a 600s per-request timeout by default, which slow local backends (e.g. Ollama on large inputs) exceed, raising `litellm.Timeout` — see #132.

```yaml
# .openkb/config.yaml
timeout: 1200
```

## What changed

- **config**: `resolve_timeout()` validates a finite positive number of seconds (rejects bool / `nan` / `inf` / non-numeric); `set_timeout()` / `get_timeout()` stash it process-wide, mirroring the existing `extra_headers` mechanism.
- **compile path**: `_llm_call` / `_llm_call_async` forward the timeout, without overriding an explicit per-call value.
- **agent paths** (query, chat, lint, skill): forwarded via `ModelSettings(extra_args={"timeout": ...})`, the way `extra_headers` already reaches them.
- **cli**: `_setup_llm_key` resolves + applies it from `.openkb/config.yaml`.
- **docs**: README documents the key and notes that PageIndex long-document indexing manages its own timeout and is not affected.

## Test plan

- `tests/test_config.py` — resolver cases incl. `nan`/`inf`/bool/non-numeric rejection.
- `tests/test_llm_timeout.py` — timeout forwarded / omitted / not-overridden, sync **and** async.
- `tests/test_cli.py` — config → stash wiring + reset-when-absent.
- `tests/test_query.py` — agent-path `extra_args` coverage.
- Full suite: **824 passed**. (The 4 `tests/test_url_ingest.py` failures are a pre-existing local-env issue — `trafilatura` not installed — and are unrelated to this change.)

Refs #132. Covers OpenKB's own calls; PageIndex's internal LLM calls hardcode their request and would need an upstream change to honor this.
