### PR TITLE
fix(converter): move keep_data_uris to convert call and fix lint

### DIFF
--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -231,8 +231,8 @@ def convert_document(
             markdown = convert_pdf_with_images(src, doc_name, images_dir)
         else:
             # Non-PDF, non-MD: use markitdown (docx, pptx, html, etc.)
-            mid = MarkItDown(keep_data_uris=True)
-            result = mid.convert(str(src))
+            mid = MarkItDown()
+            result = mid.convert(str(src), keep_data_uris=True)
             markdown = result.text_content
             markdown = extract_base64_images(markdown, doc_name, images_dir)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -146,14 +146,17 @@ class TestConvertDocumentMarkItDown:
 
         with (
             patch("openkb.converter.MarkItDown") as mock_markitdown,
-            patch("openkb.converter.extract_base64_images", return_value="converted markdown") as mock_extract,
+            patch(
+                "openkb.converter.extract_base64_images",
+                return_value="converted markdown",
+            ) as mock_extract,
         ):
             mock_markitdown.return_value.convert.return_value = mock_result
 
             result = convert_document(src, kb_dir)
 
-        mock_markitdown.assert_called_once_with(keep_data_uris=True)
-        mock_markitdown.return_value.convert.assert_called_once_with(str(src))
+        mock_markitdown.assert_called_once_with()
+        mock_markitdown.return_value.convert.assert_called_once_with(str(src), keep_data_uris=True)
         mock_extract.assert_called_once()
         assert result.skipped is False
         assert result.is_long_doc is False


### PR DESCRIPTION
Sorry about that. In PR #163, the code I verified locally did not match what I actually committed, and I also had not run the test locally. This follow-up fixes the incorrect change and the leftover lint issue.