### PR TITLE
edit-readme-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,6 @@ Inside `openkb chat`, type `/` for slash commands (Tab to complete):
 | `/list` | List all documents |
 | `/add <path>` | Add a document or directory without leaving the chat |
 | `/save [name]` | Export the transcript to `wiki/explorations/` |
-| `/skill new <name> "<intent>"` | Compile a skill from this chat |
-| `/deck new <name> "<intent>"` | Generate a slide deck (`--skill` picks a theme, `--critique` runs a quality pass) |
-| `/critique <path>` | Run a quality critique pass on a generated deck |
 | `/lint` | Run knowledge base lint |
 | `/clear` | Start a fresh session (the current one stays on disk) |
 | `/exit` | Exit (`/quit` or Ctrl-D also work) |

--- a/README.md
+++ b/README.md
@@ -191,22 +191,21 @@ A "generator" reads from the compiled wiki and produces something usable: an ans
 
 `openkb query "..."` answers a single question with a grounded, cited answer from your wiki. `openkb chat` is interactive, an ongoing multi-turn session over the same wiki (`--resume`, `--list`, `--delete` to manage sessions). → Walked through with real saved output in **[`examples/commands/`](examples/commands/)** (query) and **[`examples/chat/`](examples/chat/)** (chat).
 
-Inside `openkb chat`, type `/` for slash commands (Tab to complete):
+Inside a chat, type `/` to access slash commands (Tab to complete).
 
 <details>
-<summary><i>Slash commands:</i></summary>
+<summary><i>More slash commands:</i></summary>
 <br>
 
-| Command | Does |
-|---|---|
-| `/help` | List available commands |
-| `/status` | Show knowledge base status |
-| `/list` | List all documents |
-| `/add <path>` | Add a document or directory without leaving the chat |
-| `/save [name]` | Export the transcript to `wiki/explorations/` |
-| `/lint` | Run knowledge base lint |
-| `/clear` | Start a fresh session (the current one stays on disk) |
-| `/exit` | Exit (`/quit` or Ctrl-D also work) |
+- `/help`: list available commands
+- `/status`: show knowledge base status
+- `/list`: list all documents
+- `/add <path>`: add a document or directory without leaving the chat
+- `/skill new <skill-name> "<intent>"`: compile a skill from this chat (see below)
+- `/save [name]`: export the transcript to `wiki/explorations/`
+- `/clear`: start a fresh session (the current one stays on disk)
+- `/lint`: run knowledge base lint
+- `/exit`: exit (Ctrl-D also works)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ A "generator" reads from the compiled wiki and produces something usable: an ans
 | <code>openkb&nbsp;skill&nbsp;new&nbsp;&lt;skill-name&gt;&nbsp;"&lt;intent&gt;"</code> | Distill a redistributable agent skill from your wiki (see [Skill Factory](#skill-factory) below) | [skills](examples/skills/) |
 | <code>openkb&nbsp;deck&nbsp;new&nbsp;&lt;name&gt;&nbsp;"&lt;intent&gt;"</code> | Generate a single-file HTML slide deck (`--skill` picks a theme, `--critique` runs a quality pass) | [slides](examples/slides/) |
 
-### 💬 Query & Chat — *ask the wiki*
+### (i) 💬 Query & Chat — *ask the wiki*
 
 `openkb query "..."` answers a single question with a grounded, cited answer from your wiki. `openkb chat` is interactive, an ongoing multi-turn session over the same wiki (`--resume`, `--list`, `--delete` to manage sessions). → Walked through with real saved output in **[`examples/commands/`](examples/commands/)** (query) and **[`examples/chat/`](examples/chat/)** (chat).
 
@@ -213,7 +213,7 @@ Inside a chat, type `/` to access slash commands (Tab to complete).
 
 <a id="skill-factory"></a>
 
-### 🛠 Skill Factory — *drop in a book; out comes a digital expert.*
+### (ii) 🛠 Skill Factory — *drop in a book; out comes a digital expert.*
 
 `openkb skill new` distills a portable [agent skill](https://docs.claude.com/en/docs/build-with-claude/skills) from your wiki that Claude Code, Codex, and Gemini can install and load natively. Drop in a book's worth of papers; out comes a specialist other agents can call on. → A real generated skill, plus install / share / `eval` / rollback, is walked through in **[`examples/skills/`](examples/skills/)**.
 
@@ -233,7 +233,7 @@ Inside a chat, type `/` to access slash commands (Tab to complete).
 
 ### Settings
 
-`openkb init` writes `.openkb/config.yaml`:
+OpenKB settings are initialized by `openkb init` and stored in `.openkb/config.yaml`:
 
 ```yaml
 model: gpt-5.4                   # LLM model (any LiteLLM-supported provider)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ openkb deck new my-deck "An intro deck on <your-topic>"              # slides â€
 
 OpenKB supports [multiple LLM providers](https://docs.litellm.ai/docs/providers) (OpenAI, Claude, Gemini, etc.) via [LiteLLM](https://github.com/BerriAI/litellm) (pinned to a [safe version](https://docs.litellm.ai/blog/security-update-march-2026)).
 
-Set your model during `openkb init` or in [`.openkb/config.yaml`](#configuration) using the `provider/model` LiteLLM format (e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-3.1-pro-preview`). OpenAI models can omit the prefix (e.g. `gpt-5.4`).
+Set your model during `openkb init` or in [`.openkb/config.yaml`](#configuration) using the `provider/model` LiteLLM format (e.g. `anthropic/claude-sonnet-4-6`). OpenAI models can omit the prefix (e.g. `gpt-5.4`).
 
 Create a `.env` file with your LLM API key:
 
@@ -204,6 +204,8 @@ Inside a chat, type `/` to access slash commands (Tab to complete).
 - `/list`: list all documents
 - `/add <path>`: add a document or directory without leaving the chat
 - `/skill new <skill-name> "<intent>"`: compile a skill from this chat (see below)
+- `/deck new <name> "<intent>"`: generate an HTML slide deck from the wiki
+- `/critique <path>`: run the HTML critic over an existing deck
 - `/save [name]`: export the transcript to `wiki/explorations/`
 - `/clear`: start a fresh session (the current one stays on disk)
 - `/lint`: run knowledge base lint

--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ openkb deck new my-deck "An intro deck on <your-topic>"              # slides â€
 
 OpenKB supports [multiple LLM providers](https://docs.litellm.ai/docs/providers) (OpenAI, Claude, Gemini, etc.) via [LiteLLM](https://github.com/BerriAI/litellm) (pinned to a [safe version](https://docs.litellm.ai/blog/security-update-march-2026)).
 
-Set your model during `openkb init` or in [`.openkb/config.yaml`](#configuration) using the `provider/model` LiteLLM format (e.g. `anthropic/claude-sonnet-4-6`). OpenAI models can omit the prefix (e.g. `gpt-5.4`).
+Set your model during `openkb init` or in [`.openkb/config.yaml`](#configuration) using the `provider/model` LiteLLM format (e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-3.1-pro-preview`). OpenAI models can omit the prefix (e.g. `gpt-5.4`).
 
 Create a `.env` file with your LLM API key:
 
 ```bash
 LLM_API_KEY=your_llm_api_key
 ```
+
+Subscription-based providers that authenticate via OAuth device flow (e.g. `chatgpt/*`, `github_copilot/*`) need no API key; OpenKB skips the missing-key warning for them.
 
 # ðŸ§© How OpenKB Works
 


### PR DESCRIPTION
Small README fidelity pass against the pre-refactor version, plus slash-command completeness.

- Restore the chat slash-commands block to its pre-refactor `<details>` list format (re-add `/skill new`; colon separator instead of an em dash), and complete it with the newer `/deck new` and `/critique` commands so the list matches what chat actually registers.
- Restore the OAuth no-key note (`chatgpt/*`, `github_copilot/*` need no API key).
- Restore the `(i)`/`(ii)` subsection numbering and the original 'Settings' intro wording.