### PR TITLE
feat(workbench): content management — delete KB, delete/edit wiki pages

### DIFF
--- a/frontend/src/api/kb.ts
+++ b/frontend/src/api/kb.ts
@@ -41,6 +41,13 @@ export function createKb(body: InitRequest): Promise<InitResponse> {
   return apiFetch<InitResponse>("/api/v1/init", { method: "POST", body })
 }
 
+/** Permanently delete a knowledge base (physical removal + unregister).
+ *  `confirmName` must equal `kb` (re-checked server-side); the caller collects
+ *  the type-the-name confirmation. */
+export function deleteKb(kb: string, confirmName: string): Promise<{ deleted: boolean; kb: string; path: string }> {
+  return apiFetch("/api/v1/kb/delete", { body: { kb, confirm_name: confirmName } })
+}
+
 export type ConfigSource = "kb" | "global" | "default"
 
 export interface KbConfig {

--- a/frontend/src/api/wiki.ts
+++ b/frontend/src/api/wiki.ts
@@ -52,3 +52,45 @@ export function getPage(kb: string, path: string): Promise<{ path: string; conte
 export function getKbInventory(kb: string): Promise<KbInventory> {
   return apiFetch<KbInventory>("/api/v1/list", { body: { kb } })
 }
+
+/** Result of `/api/v1/page/delete`. `backlinks` are 'section/stem' refs whose
+ *  inbound [[links]] will be / were demoted to plain text. */
+export interface PageDeleteResult {
+  status: string
+  target: string
+  backlinks: string[]
+  files_changed?: number | null
+  ghosts_stripped?: number | null
+}
+
+/** Delete a concept/entity page. With `dryRun`, only reports the impact
+ *  (backlinks) without changing anything — used for the confirm preview. */
+export function deletePage(kb: string, path: string, dryRun = false): Promise<PageDeleteResult> {
+  return apiFetch<PageDeleteResult>("/api/v1/page/delete", { body: { kb, path, dry_run: dryRun } })
+}
+
+/** Outbound + inbound links for a page (`/api/v1/page/links`) — the edit panel. */
+export interface PageLinks {
+  status: string
+  target: string
+  outlinks: string[]
+  backlinks: string[]
+}
+
+export function getPageLinks(kb: string, path: string): Promise<PageLinks> {
+  return apiFetch<PageLinks>("/api/v1/page/links", { body: { kb, path } })
+}
+
+/** Result of editing a page (`PUT /api/v1/page`). `ghosts_stripped` are the
+ *  dead [[links]] demoted to plain text on save. */
+export interface PageEditResult {
+  status: string
+  target: string
+  ghosts_stripped: string[]
+  content: string | null
+}
+
+/** Save new BODY for a concept/entity page (frontmatter preserved server-side). */
+export function editPage(kb: string, path: string, content: string): Promise<PageEditResult> {
+  return apiFetch<PageEditResult>("/api/v1/page", { method: "PUT", body: { kb, path, content } })
+}

--- a/frontend/src/components/KbSettingsSheet.tsx
+++ b/frontend/src/components/KbSettingsSheet.tsx
@@ -8,7 +8,7 @@ import {
   ShieldCheck, Clock, Radio,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import { getKbConfig, patchKbConfig, type KbConfig, type ConfigSource } from '@/api/kb'
+import { deleteKb, getKbConfig, patchKbConfig, type KbConfig, type ConfigSource } from '@/api/kb'
 import {
   watchStart, watchStop, watchStatus, runRecompile, runLint, type WatchStatus,
 } from '@/api/maintenance'
@@ -28,12 +28,14 @@ export default function KbSettingsSheet({
   onClose,
   docCount,
   onChanged,
+  onDeleted,
 }: {
   kb: string
   open: boolean
   onClose: () => void
   docCount: number
   onChanged?: () => void
+  onDeleted?: () => void
 }) {
   const { t } = useTranslation(['kbSettings', 'common'])
   const reduce = useReducedMotion()
@@ -114,6 +116,7 @@ export default function KbSettingsSheet({
                 <div className="flex-1 min-h-0 overflow-y-auto scroll-edge-top px-4 py-4 space-y-6">
                   <KbConfigSection kb={kb} />
                   <KbMaintenanceSection kb={kb} open={open} docCount={docCount} onChanged={onChanged} />
+                  <KbDangerSection kb={kb} onDeleted={onDeleted} />
                 </div>
               </motion.aside>
             </Dialog.Content>
@@ -729,6 +732,87 @@ function KbMaintenanceSection({
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+/** Danger zone: permanently delete this KB. A type-the-name confirmation gates
+ *  POST /api/v1/kb/delete; on success the parent (KbDetail) navigates away. */
+function KbDangerSection({ kb, onDeleted }: { kb: string; onDeleted?: () => void }) {
+  const { t } = useTranslation(['kbSettings', 'common'])
+  const [confirming, setConfirming] = useState(false)
+  const [typed, setTyped] = useState('')
+  const [busy, setBusy] = useState(false)
+  const matches = typed.trim() === kb
+
+  const doDelete = useCallback(async () => {
+    if (!matches || busy) return
+    setBusy(true)
+    try {
+      await deleteKb(kb, kb)
+      toast.success(t('kbSettings:dangerDeletedToast', { kb }))
+      onDeleted?.()
+    } catch (e) {
+      toast.error(t('kbSettings:dangerDeleteError', { error: errMsg(e) }))
+      setBusy(false)
+    }
+  }, [kb, matches, busy, onDeleted, t])
+
+  return (
+    <div className="space-y-3 pt-2">
+      <h3 className="text-[12px] font-semibold text-red-600 dark:text-red-400 tracking-wide">
+        {t('kbSettings:dangerHeading')}
+      </h3>
+      <div className="rounded-2xl border border-red-200/70 dark:border-red-500/25 bg-red-50/50 dark:bg-red-500/5 px-4 py-3.5 space-y-3">
+        <p className="text-[12.5px] text-muted-foreground">{t('kbSettings:dangerDesc')}</p>
+        {!confirming ? (
+          <button
+            onClick={() => setConfirming(true)}
+            className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg border border-red-300 dark:border-red-500/40 text-[12.5px] font-medium text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-500/10 transition-colors"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            {t('kbSettings:dangerDeleteButton')}
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <label className="block text-[12px] text-muted-foreground">
+              {t('kbSettings:dangerConfirmPrompt', { kb })}
+            </label>
+            <input
+              autoFocus
+              value={typed}
+              disabled={busy}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={kb}
+              className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-[13px] font-mono2 outline-none focus-visible:ring-2 focus-visible:ring-ring focus:border-red-400"
+            />
+            <div className="flex items-center gap-2">
+              <button
+                onClick={doDelete}
+                disabled={busy || !matches}
+                className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg bg-red-600 text-white text-[12.5px] font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
+              >
+                {busy ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="w-3.5 h-3.5" />
+                )}
+                {t('kbSettings:dangerConfirmDelete')}
+              </button>
+              <button
+                onClick={() => {
+                  setConfirming(false)
+                  setTyped('')
+                }}
+                disabled={busy}
+                className="inline-flex items-center h-8 px-3 rounded-lg border border-[hsl(var(--glass-border))] text-[12.5px] font-medium text-muted-foreground hover:bg-accent transition-colors disabled:opacity-60"
+              >
+                {t('common:actions.cancel')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -7,7 +7,8 @@
   "actions": {
     "newKb": "New knowledge base",
     "close": "Close",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "cancel": "Cancel"
   },
   "fields": {
     "model": "Model",

--- a/frontend/src/locales/en/kb.json
+++ b/frontend/src/locales/en/kb.json
@@ -46,6 +46,30 @@
       "multiple": "Delete failed: {{message}} (candidates: {{names}})"
     }
   },
+  "pageOps": {
+    "edit": "Edit",
+    "delete": "Delete",
+    "editorAria": "Page source (Markdown)",
+    "deletePrompt": "Delete {{title}}?",
+    "deleteImpact_one": "{{count}} page links here — its link will become plain text",
+    "deleteImpact_other": "{{count}} pages link here — their links will become plain text",
+    "deleteNoBacklinks": "No other pages link here",
+    "deleteConfirm": "Delete page",
+    "deleteSuccess": "Deleted {{title}}",
+    "deleteError": "Delete failed: {{error}}",
+    "save": "Save",
+    "saveSuccess": "Page saved",
+    "saveError": "Save failed: {{error}}",
+    "ghostsDemoted": "These links didn't resolve and became plain text: {{links}}",
+    "editRecompileNote": "Manual edits may be overwritten the next time this KB is recompiled.",
+    "links": {
+      "heading": "Page links",
+      "outlinks": "This page links to",
+      "backlinks": "Pages linking here",
+      "none": "None",
+      "error": "Failed to load links: {{error}}"
+    }
+  },
   "remote": {
     "heading": "Remote data sources",
     "note": "Cloud connectors are in development and not yet available · want one? Click a card to vote on GitHub"

--- a/frontend/src/locales/en/kbSettings.json
+++ b/frontend/src/locales/en/kbSettings.json
@@ -38,5 +38,12 @@
   "lint": "Structure check",
   "recompileHeading": "Recompile",
   "recompileSummary": "· {{total}} total · {{recompiled}} compiled · {{skipped}} skipped",
-  "preparing": "Preparing…"
+  "preparing": "Preparing…",
+  "dangerHeading": "Danger zone",
+  "dangerDesc": "Permanently delete this knowledge base — its raw documents and compiled wiki. This cannot be undone.",
+  "dangerDeleteButton": "Delete this knowledge base",
+  "dangerConfirmPrompt": "Type the KB name ({{kb}}) to confirm",
+  "dangerConfirmDelete": "Delete permanently",
+  "dangerDeletedToast": "Deleted knowledge base “{{kb}}”",
+  "dangerDeleteError": "Delete failed: {{error}}"
 }

--- a/frontend/src/locales/zh/common.json
+++ b/frontend/src/locales/zh/common.json
@@ -7,7 +7,8 @@
   "actions": {
     "newKb": "新建知识库",
     "close": "关闭",
-    "refresh": "刷新"
+    "refresh": "刷新",
+    "cancel": "取消"
   },
   "fields": {
     "model": "模型",

--- a/frontend/src/locales/zh/kb.json
+++ b/frontend/src/locales/zh/kb.json
@@ -46,6 +46,30 @@
       "multiple": "删除失败：{{message}}（候选：{{names}}）"
     }
   },
+  "pageOps": {
+    "edit": "编辑",
+    "delete": "删除",
+    "editorAria": "页面源码（Markdown）",
+    "deletePrompt": "确认删除 {{title}}？",
+    "deleteImpact_one": "{{count}} 个页面链接到此页 — 删除后这些链接将变为纯文本",
+    "deleteImpact_other": "{{count}} 个页面链接到此页 — 删除后这些链接将变为纯文本",
+    "deleteNoBacklinks": "没有其他页面链接到此页",
+    "deleteConfirm": "删除页面",
+    "deleteSuccess": "已删除 {{title}}",
+    "deleteError": "删除失败：{{error}}",
+    "save": "保存",
+    "saveSuccess": "页面已保存",
+    "saveError": "保存失败：{{error}}",
+    "ghostsDemoted": "以下链接无法解析，已变为纯文本：{{links}}",
+    "editRecompileNote": "手动修改在下次重新编译该库时可能被覆盖。",
+    "links": {
+      "heading": "页面链接",
+      "outlinks": "此页链接到",
+      "backlinks": "链接到此页的页面",
+      "none": "无",
+      "error": "链接加载失败：{{error}}"
+    }
+  },
   "remote": {
     "heading": "远程数据源",
     "note": "云端连接器开发中，尚不可用 · 想要它？点卡片去 GitHub 投票"

--- a/frontend/src/locales/zh/kbSettings.json
+++ b/frontend/src/locales/zh/kbSettings.json
@@ -38,5 +38,12 @@
   "lint": "结构检查",
   "recompileHeading": "重新编译",
   "recompileSummary": "· 共 {{total}} · 编译 {{recompiled}} · 跳过 {{skipped}}",
-  "preparing": "正在准备…"
+  "preparing": "正在准备…",
+  "dangerHeading": "危险操作",
+  "dangerDesc": "永久删除这个知识库(原始文档 + 已编译的 wiki),不可撤销。",
+  "dangerDeleteButton": "删除此知识库",
+  "dangerConfirmPrompt": "输入知识库名称({{kb}})以确认",
+  "dangerConfirmDelete": "永久删除",
+  "dangerDeletedToast": "已删除知识库「{{kb}}」",
+  "dangerDeleteError": "删除失败:{{error}}"
 }

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -123,9 +123,6 @@ export default function KbDetail() {
   // response never renders under a newly selected page.
   const [page, setPage] = useState<{ path: string; content: string } | null>(null)
   const [pageError, setPageError] = useState<{ path: string; message: string } | null>(null)
-  // Bumped to re-run the page-load effect for the SAME path (used after a page
-  // edit when the backend did not return the saved content).
-  const [pageReloadSeq, setPageReloadSeq] = useState(0)
 
   // Documents section: upload state. `uploadFiles` tracks per-file progress
   // for the current/most-recent streaming upload; it is reset at the start of
@@ -182,8 +179,7 @@ export default function KbDetail() {
     }
   }, [id])
 
-  // Fetch the selected page's Markdown from the real endpoint. `pageReloadSeq`
-  // re-runs it for the same path after a save that returned no content.
+  // Fetch the selected page's Markdown from the real endpoint.
   useEffect(() => {
     if (!selectedPath) return
     const path = selectedPath
@@ -200,7 +196,7 @@ export default function KbDetail() {
     return () => {
       cancelled = true
     }
-  }, [id, selectedPath, pageReloadSeq])
+  }, [id, selectedPath])
 
   /** Re-fetch the inventory (after an upload / recompile that changed docs). */
   const refreshInventory = useCallback(async () => {
@@ -228,10 +224,12 @@ export default function KbDetail() {
    *  DIFFERENT selection while the save was in flight. */
   const onPageSaved = useCallback(
     (path: string, content: string | null) => {
+      // editPage always returns the saved content on 200 (PageEditResponse), so
+      // adopt it directly — frontmatter stripped exactly like the load effect.
+      // The functional set never clobbers a page loaded for a DIFFERENT
+      // selection while the save was in flight.
       if (content != null) {
         setPage((prev) => (prev && prev.path !== path ? prev : { path, content: stripFrontmatter(content) }))
-      } else {
-        setPageReloadSeq((n) => n + 1)
       }
       void refreshInventory()
     },
@@ -499,6 +497,9 @@ export default function KbDetail() {
         onChanged={refreshInventory}
         onDeleted={() => {
           setSettingsOpen(false)
+          // Refresh the sidebar's KB list (same event CreateKbDialog fires) so
+          // the just-deleted KB disappears without a manual reload.
+          window.dispatchEvent(new CustomEvent('openkb:reload-kbs'))
           navigate('/kb')
         }}
       />

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { motion, useReducedMotion } from 'motion/react'
 import { FileText, Loader2, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle } from 'lucide-react'
@@ -103,6 +103,7 @@ const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e))
 
 export default function KbDetail() {
   const { id = '' } = useParams()
+  const navigate = useNavigate()
   const { t } = useTranslation(['kb', 'common'])
 
   const [inv, setInv] = useState<KbInventory | null>(null)
@@ -453,6 +454,10 @@ export default function KbDetail() {
         onClose={() => setSettingsOpen(false)}
         docCount={docCount}
         onChanged={refreshInventory}
+        onDeleted={() => {
+          setSettingsOpen(false)
+          navigate('/kb')
+        }}
       />
     </div>
   )

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -574,9 +574,15 @@ function ReaderBody({ kb, selected, page, pageError, selectedPath, hasPages, inv
     )
   }
 
-  // Only compiled concept/entity pages are user-editable; summaries, reports
-  // and index.md are generated artifacts the backend refuses to mutate.
-  const editable = selected.group === 'concepts/' || selected.group === 'entities/'
+  // Editable: concept/entity synthesis + per-document summaries (all compiled
+  // markdown a recompile can regenerate). Deletable is narrower — a summary is
+  // removed by deleting its source document, never on its own. reports/index.md
+  // are generated artifacts the backend refuses to mutate either way.
+  const canEdit =
+    selected.group === 'concepts/' ||
+    selected.group === 'entities/' ||
+    selected.group === 'summaries/'
+  const canDelete = selected.group === 'concepts/' || selected.group === 'entities/'
   const confirmActive = deleteImpact !== null && deleteImpact.path === selected.path
   const linksReady = links && links.path === selected.path
   const linksFailed = linksError && linksError.path === selected.path
@@ -650,23 +656,27 @@ function ReaderBody({ kb, selected, page, pageError, selectedPath, hasPages, inv
           wiki/{selected.group}
           {selected.title}
         </span>
-        {editable && pageReady && !editing && !confirmActive && (
+        {(canEdit || canDelete) && pageReady && !editing && !confirmActive && (
           <div className="ml-auto flex items-center gap-1.5">
-            <button
-              onClick={startEdit}
-              className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-            >
-              <Pencil className="w-3 h-3" />
-              {t('kb:pageOps.edit')}
-            </button>
-            <button
-              onClick={startDelete}
-              disabled={checkingDelete}
-              className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors disabled:opacity-60"
-            >
-              {checkingDelete ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
-              {t('kb:pageOps.delete')}
-            </button>
+            {canEdit && (
+              <button
+                onClick={startEdit}
+                className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                <Pencil className="w-3 h-3" />
+                {t('kb:pageOps.edit')}
+              </button>
+            )}
+            {canDelete && (
+              <button
+                onClick={startDelete}
+                disabled={checkingDelete}
+                className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors disabled:opacity-60"
+              >
+                {checkingDelete ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+                {t('kb:pageOps.delete')}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } fro
 import { useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { motion, useReducedMotion } from 'motion/react'
-import { FileText, Loader2, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle } from 'lucide-react'
+import { FileText, Link2, Loader2, Pencil, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle } from 'lucide-react'
 import { toast } from 'sonner'
-import { getKbInventory, getPage, type KbInventory, type WikiDocument } from '@/api/wiki'
+import { deletePage, editPage, getKbInventory, getPage, getPageLinks, type KbInventory, type WikiDocument } from '@/api/wiki'
 import { streamUpload, removeDocument, type AddResult } from '@/api/maintenance'
 import { ApiError } from '@/api/client'
 import MarkdownView from '@/components/MarkdownView'
@@ -123,6 +123,9 @@ export default function KbDetail() {
   // response never renders under a newly selected page.
   const [page, setPage] = useState<{ path: string; content: string } | null>(null)
   const [pageError, setPageError] = useState<{ path: string; message: string } | null>(null)
+  // Bumped to re-run the page-load effect for the SAME path (used after a page
+  // edit when the backend did not return the saved content).
+  const [pageReloadSeq, setPageReloadSeq] = useState(0)
 
   // Documents section: upload state. `uploadFiles` tracks per-file progress
   // for the current/most-recent streaming upload; it is reset at the start of
@@ -179,7 +182,8 @@ export default function KbDetail() {
     }
   }, [id])
 
-  // Fetch the selected page's Markdown from the real endpoint.
+  // Fetch the selected page's Markdown from the real endpoint. `pageReloadSeq`
+  // re-runs it for the same path after a save that returned no content.
   useEffect(() => {
     if (!selectedPath) return
     const path = selectedPath
@@ -196,7 +200,7 @@ export default function KbDetail() {
     return () => {
       cancelled = true
     }
-  }, [id, selectedPath])
+  }, [id, selectedPath, pageReloadSeq])
 
   /** Re-fetch the inventory (after an upload / recompile that changed docs). */
   const refreshInventory = useCallback(async () => {
@@ -208,6 +212,31 @@ export default function KbDetail() {
       setInvError(errMsg(e))
     }
   }, [id])
+
+  /** The open page was deleted (F2): close the now-gone page and refresh the
+   *  inventory — backlink pages changed on disk too (their [[links]] were
+   *  demoted to plain text). */
+  const onPageDeleted = useCallback(() => {
+    setSelectedPath(null)
+    void refreshInventory()
+  }, [refreshInventory])
+
+  /** The open page was saved (F3): adopt the returned file content (stripping
+   *  frontmatter exactly like the load effect) or re-fetch when the backend
+   *  didn't return it, then refresh the inventory (edits can change the link
+   *  graph). The functional set never clobbers a page that loaded for a
+   *  DIFFERENT selection while the save was in flight. */
+  const onPageSaved = useCallback(
+    (path: string, content: string | null) => {
+      if (content != null) {
+        setPage((prev) => (prev && prev.path !== path ? prev : { path, content: stripFrontmatter(content) }))
+      } else {
+        setPageReloadSeq((n) => n + 1)
+      }
+      void refreshInventory()
+    },
+    [refreshInventory],
+  )
 
   const doUpload = useCallback(
     async (files: File[]) => {
@@ -404,6 +433,7 @@ export default function KbDetail() {
       >
         {section === 'index' ? (
           <IndexReader
+            kb={id}
             selected={selected}
             page={page}
             pageError={pageError}
@@ -411,6 +441,8 @@ export default function KbDetail() {
             hasPages={hasPages}
             inv={inv}
             onWikiLink={onWikiLink}
+            onDeleted={onPageDeleted}
+            onSaved={onPageSaved}
           />
         ) : section === 'documents' ? (
           <DocumentsPane
@@ -443,7 +475,18 @@ export default function KbDetail() {
                 {t('kb:wikiNote')}
               </div>
             </div>
-            <Reader selected={selected} page={page} pageError={pageError} selectedPath={selectedPath} hasPages={hasPages} inv={inv} onWikiLink={onWikiLink} />
+            <Reader
+              kb={id}
+              selected={selected}
+              page={page}
+              pageError={pageError}
+              selectedPath={selectedPath}
+              hasPages={hasPages}
+              inv={inv}
+              onWikiLink={onWikiLink}
+              onDeleted={onPageDeleted}
+              onSaved={onPageSaved}
+            />
           </div>
         )}
       </motion.section>
@@ -466,6 +509,8 @@ export default function KbDetail() {
 /** Shared props for the page-content column, whether it renders full-width
  *  (Index) or beside the 300px `PageList` sidebar (a type card). */
 interface ReaderProps {
+  /** KB name — the `kb` param for the page edit/delete/links endpoints. */
+  kb: string
   selected: SelectedPage | null
   page: { path: string; content: string } | null
   pageError: { path: string; message: string } | null
@@ -474,13 +519,49 @@ interface ReaderProps {
   inv: KbInventory | null
   /** Navigate to a `[[wikilink]]` target clicked inside the rendered page. */
   onWikiLink: (target: string) => void
+  /** The open page was deleted: close it and refresh the inventory. */
+  onDeleted: () => void
+  /** The open page was saved: adopt `content` (the saved file, frontmatter and
+   *  all) or re-fetch when null, then refresh the inventory. */
+  onSaved: (path: string, content: string | null) => void
 }
 
 /** The actual page body: breadcrumb + Markdown, or an empty/loading state.
  *  Shared verbatim by `Reader` (Browse) and `IndexReader` (Index, full width) —
- *  they differ only in their outer scroll container. */
-function ReaderBody({ selected, page, pageError, selectedPath, hasPages, inv, onWikiLink }: ReaderProps) {
+ *  they differ only in their outer scroll container. Concept/entity pages also
+ *  carry inline Edit/Delete controls (F2/F3): delete previews its backlink
+ *  impact via a dry-run before the destructive call; edit swaps the rendered
+ *  Markdown for a body-only textarea plus a read-only outlink/backlink panel. */
+function ReaderBody({ kb, selected, page, pageError, selectedPath, hasPages, inv, onWikiLink, onDeleted, onSaved }: ReaderProps) {
   const { t } = useTranslation(['kb', 'common'])
+
+  // Edit mode (F3). `links`/`linksError` are tagged with the path they belong
+  // to (same discipline as `page`/`pageError` in KbDetail) so a slow response
+  // never renders under a different page.
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [links, setLinks] = useState<{ path: string; outlinks: string[]; backlinks: string[] } | null>(null)
+  const [linksError, setLinksError] = useState<{ path: string; message: string } | null>(null)
+
+  // Delete confirm (F2): `deleteImpact` holds the dry-run backlink preview for
+  // the page awaiting confirmation (path-tagged like the edit state above).
+  const [checkingDelete, setCheckingDelete] = useState(false)
+  const [deleteImpact, setDeleteImpact] = useState<{ path: string; backlinks: string[] } | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  // Switching pages must never leak edit/confirm state into the next page.
+  useEffect(() => {
+    setEditing(false)
+    setDraft('')
+    setSaving(false)
+    setLinks(null)
+    setLinksError(null)
+    setCheckingDelete(false)
+    setDeleteImpact(null)
+    setDeleting(false)
+  }, [selectedPath])
+
   const pageReady = page && page.path === selectedPath
   const pageFailed = pageError && pageError.path === selectedPath
 
@@ -492,6 +573,75 @@ function ReaderBody({ selected, page, pageError, selectedPath, hasPages, inv, on
     )
   }
 
+  // Only compiled concept/entity pages are user-editable; summaries, reports
+  // and index.md are generated artifacts the backend refuses to mutate.
+  const editable = selected.group === 'concepts/' || selected.group === 'entities/'
+  const confirmActive = deleteImpact !== null && deleteImpact.path === selected.path
+  const linksReady = links && links.path === selected.path
+  const linksFailed = linksError && linksError.path === selected.path
+
+  const startEdit = () => {
+    if (!page || page.path !== selected.path) return
+    setDraft(page.content)
+    setEditing(true)
+    const path = selected.path
+    setLinks(null)
+    setLinksError(null)
+    getPageLinks(kb, path)
+      .then((r) => setLinks({ path, outlinks: r.outlinks, backlinks: r.backlinks }))
+      .catch((e) => setLinksError({ path, message: errMsg(e) }))
+  }
+
+  const doSave = async () => {
+    if (saving) return
+    setSaving(true)
+    try {
+      const res = await editPage(kb, selected.path, draft)
+      const ghosts = res.ghosts_stripped ?? []
+      if (ghosts.length > 0) {
+        toast.warning(t('kb:pageOps.ghostsDemoted', { links: ghosts.join(', ') }))
+      } else {
+        toast.success(t('kb:pageOps.saveSuccess'))
+      }
+      onSaved(selected.path, res.content)
+      setEditing(false)
+      setDraft('')
+    } catch (e) {
+      // Keep edit mode (and the draft) so a transient failure loses nothing.
+      toast.error(t('kb:pageOps.saveError', { error: errMsg(e) }))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const startDelete = async () => {
+    if (checkingDelete) return
+    setCheckingDelete(true)
+    const path = selected.path
+    try {
+      const res = await deletePage(kb, path, true)
+      setDeleteImpact({ path, backlinks: res.backlinks ?? [] })
+    } catch (e) {
+      toast.error(t('kb:pageOps.deleteError', { error: errMsg(e) }))
+    } finally {
+      setCheckingDelete(false)
+    }
+  }
+
+  const doDelete = async () => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await deletePage(kb, selected.path)
+      toast.success(t('kb:pageOps.deleteSuccess', { title: selected.title }))
+      onDeleted()
+    } catch (e) {
+      toast.error(t('kb:pageOps.deleteError', { error: errMsg(e) }))
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   return (
     <div className="w-full max-w-[1600px] mx-auto px-8 lg:px-12 py-7 anim-fade-up" key={selected.path}>
       <div className="flex items-center gap-2 text-[11.5px] text-muted-foreground mb-4">
@@ -499,16 +649,150 @@ function ReaderBody({ selected, page, pageError, selectedPath, hasPages, inv, on
           wiki/{selected.group}
           {selected.title}
         </span>
+        {editable && pageReady && !editing && !confirmActive && (
+          <div className="ml-auto flex items-center gap-1.5">
+            <button
+              onClick={startEdit}
+              className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            >
+              <Pencil className="w-3 h-3" />
+              {t('kb:pageOps.edit')}
+            </button>
+            <button
+              onClick={startDelete}
+              disabled={checkingDelete}
+              className="inline-flex items-center gap-1 h-7 px-2 rounded-lg text-[12px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors disabled:opacity-60"
+            >
+              {checkingDelete ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+              {t('kb:pageOps.delete')}
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* Delete confirm (F2): dry-run impact preview + Confirm/Cancel. */}
+      {confirmActive && (
+        <div className="mb-4 rounded-2xl border border-red-200/70 dark:border-red-500/25 bg-red-50/50 dark:bg-red-500/5 px-4 py-3.5 space-y-2">
+          <p className="text-[13px] font-medium text-foreground">{t('kb:pageOps.deletePrompt', { title: selected.title })}</p>
+          <p className="text-[12px] text-muted-foreground">
+            {deleteImpact.backlinks.length > 0
+              ? t('kb:pageOps.deleteImpact', { count: deleteImpact.backlinks.length })
+              : t('kb:pageOps.deleteNoBacklinks')}
+          </p>
+          {deleteImpact.backlinks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {deleteImpact.backlinks.map((b) => (
+                <span key={b} className="font-mono2 text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">
+                  {b}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              onClick={doDelete}
+              disabled={deleting}
+              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg bg-red-600 text-white text-[12.5px] font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
+            >
+              {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+              {t('kb:pageOps.deleteConfirm')}
+            </button>
+            <button
+              onClick={() => setDeleteImpact(null)}
+              disabled={deleting}
+              className="inline-flex items-center h-8 px-3 rounded-lg border border-[hsl(var(--glass-border))] text-[12.5px] font-medium text-muted-foreground hover:bg-accent transition-colors disabled:opacity-60"
+            >
+              {t('common:actions.cancel')}
+            </button>
+          </div>
+        </div>
+      )}
+
       {pageFailed ? (
         <div className="rounded-lg bg-red-50 dark:bg-red-500/10 border border-red-200/70 dark:border-red-500/25 px-3 py-2 text-[13px] text-red-600 dark:text-red-400">
           {t('common:pageLoadError', { error: pageError.message })}
+        </div>
+      ) : editing && pageReady ? (
+        /* Edit mode (F3): body-only textarea + save/cancel + links panel. */
+        <div className="space-y-3">
+          <textarea
+            value={draft}
+            disabled={saving}
+            spellCheck={false}
+            onChange={(e) => setDraft(e.target.value)}
+            aria-label={t('kb:pageOps.editorAria')}
+            className="w-full min-h-[420px] rounded-xl border border-input bg-transparent px-4 py-3 text-[13px] leading-relaxed font-mono2 outline-none focus-visible:ring-2 focus-visible:ring-ring focus:border-accent-brand resize-y"
+          />
+          <p className="text-[11.5px] text-muted-foreground">{t('kb:pageOps.editRecompileNote')}</p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={doSave}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg bg-accent-brand text-white text-[12.5px] font-medium hover:bg-accent-brand/90 transition-colors disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+              {t('kb:pageOps.save')}
+            </button>
+            <button
+              onClick={() => {
+                setEditing(false)
+                setDraft('')
+              }}
+              disabled={saving}
+              className="inline-flex items-center h-8 px-3 rounded-lg border border-[hsl(var(--glass-border))] text-[12.5px] font-medium text-muted-foreground hover:bg-accent transition-colors disabled:opacity-60"
+            >
+              {t('common:actions.cancel')}
+            </button>
+          </div>
+          <div className="rounded-2xl border border-[hsl(var(--glass-border))] glass-2 px-4 py-3.5">
+            <h3 className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground tracking-wide">
+              <Link2 className="w-3.5 h-3.5" />
+              {t('kb:pageOps.links.heading')}
+            </h3>
+            {linksFailed ? (
+              <div className="mt-2 text-[12px] text-red-600 dark:text-red-400">
+                {t('kb:pageOps.links.error', { error: linksError.message })}
+              </div>
+            ) : linksReady ? (
+              <div className="mt-2.5 grid gap-3 sm:grid-cols-2">
+                <LinkRefList label={t('kb:pageOps.links.outlinks')} refs={links.outlinks} />
+                <LinkRefList label={t('kb:pageOps.links.backlinks')} refs={links.backlinks} />
+              </div>
+            ) : (
+              <div className="mt-2 flex items-center gap-2 text-[12px] text-muted-foreground">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                {t('common:loading')}
+              </div>
+            )}
+          </div>
         </div>
       ) : pageReady ? (
         <MarkdownView source={page.content} onWikiLink={onWikiLink} />
       ) : (
         <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
           <Loader2 className="w-3.5 h-3.5 animate-spin" />{t('common:loading')}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** One read-only column of `section/stem` page refs (outlinks or backlinks)
+ *  in the edit-mode links panel. */
+function LinkRefList({ label, refs }: { label: string; refs: string[] }) {
+  const { t } = useTranslation(['kb'])
+  return (
+    <div>
+      <div className="text-[11.5px] font-medium text-muted-foreground">{label}</div>
+      {refs.length === 0 ? (
+        <div className="mt-1 text-[12px] text-muted-foreground/70">{t('kb:pageOps.links.none')}</div>
+      ) : (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {refs.map((r) => (
+            <span key={r} className="font-mono2 text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">
+              {r}
+            </span>
+          ))}
         </div>
       )}
     </div>

--- a/openkb/api.py
+++ b/openkb/api.py
@@ -56,6 +56,7 @@ from openkb.api_helpers import (
     require_bearer_token,
 )
 from openkb.api_kbs import _list_knowledge_bases
+from openkb.api_kbs_router import kbs_router
 from openkb.api_models import (
     AddResponse,
     ChatRequest,
@@ -165,6 +166,7 @@ def create_app() -> FastAPI:
     app.include_router(graph_router)
     app.include_router(output_router)
     app.include_router(config_router)
+    app.include_router(kbs_router)
 
     @app.get("/api/v1/kbs", response_model=KbListResponse)
     async def list_kbs_endpoint(

--- a/openkb/api.py
+++ b/openkb/api.py
@@ -80,8 +80,6 @@ from openkb.api_models import (
     LintResponse,
     ListResponse,
     MetaResponse,
-    PageRequest,
-    PageResponse,
     QueryRequest,
     QueryResponse,
     RecompileRequest,
@@ -96,6 +94,7 @@ from openkb.api_models import (
     WatchStatusResponse,
 )
 from openkb.api_output import output_router
+from openkb.api_pages_router import pages_router
 from openkb.cli import (
     get_kb_list,
     get_kb_status,
@@ -167,6 +166,7 @@ def create_app() -> FastAPI:
     app.include_router(output_router)
     app.include_router(config_router)
     app.include_router(kbs_router)
+    app.include_router(pages_router)
 
     @app.get("/api/v1/kbs", response_model=KbListResponse)
     async def list_kbs_endpoint(
@@ -419,22 +419,6 @@ def create_app() -> FastAPI:
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"List failed: {exc}",
             ) from exc
-
-    @app.post("/api/v1/page", response_model=PageResponse)
-    async def page_endpoint(
-        request: PageRequest,
-        _: None = Depends(require_bearer_token),
-    ) -> PageResponse:
-        kb_dir = _resolve_kb(request.kb)
-        wiki_dir = (kb_dir / "wiki").resolve()
-        rel = request.path if request.path.endswith(".md") else f"{request.path}.md"
-        target = (wiki_dir / rel).resolve()
-        if not target.is_relative_to(wiki_dir):
-            raise HTTPException(status_code=400, detail="Invalid page path.")
-        if not target.is_file():
-            raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
-        content = await run_in_threadpool(target.read_text, encoding="utf-8")
-        return PageResponse(path=request.path, content=content)
 
     @app.post("/api/v1/status", response_model=StatusResponse)
     async def status_endpoint(

--- a/openkb/api_kbs_router.py
+++ b/openkb/api_kbs_router.py
@@ -1,21 +1,20 @@
 """Knowledge-base lifecycle endpoints beyond config (POST /api/v1/kb/delete).
 
-An APIRouter (sibling of api_config_router.py / api_graph.py / api_output.py) so
-api.py stays under the per-file line gate (tests/test_file_size.py). delete_kb
-does its own filesystem removal + global-registry unregister (config.py's lock);
-like /api/v1/remove it needs no create_app closure and extracts cleanly.
+An APIRouter (sibling of api_config_router.py / api_graph.py / api_pages_router.py)
+so api.py stays under the per-file line gate (tests/test_file_size.py). delete_kb
+does its own filesystem removal (under the KB ingest lock) + global-registry
+unregister, so this endpoint needs no create_app closure and extracts cleanly.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastapi import APIRouter, Depends, HTTPException
 from starlette.concurrency import run_in_threadpool
 
-from openkb.api_helpers import _resolve_kb, require_bearer_token
+from openkb.api_helpers import _is_kb_dir, require_bearer_token
 from openkb.api_models import KbDeleteRequest, KbDeleteResponse
-from openkb.config import delete_kb
+from openkb.config import registered_kbs, resolve_kb_alias
+from openkb.kb_admin import delete_kb
 
 kbs_router = APIRouter()
 
@@ -24,14 +23,23 @@ kbs_router = APIRouter()
 async def delete_kb_endpoint(
     request: KbDeleteRequest,
     _: None = Depends(require_bearer_token),
-) -> Any:
+) -> KbDeleteResponse:
     # Type-the-name confirmation, re-checked server-side: this physically
     # removes the whole KB directory (raw docs + wiki) and is irreversible, so
     # it must never fire from a client that skipped the guard.
     if request.confirm_name != request.kb:
         raise HTTPException(status_code=400, detail="confirm_name does not match the KB name.")
-    kb_dir = _resolve_kb(request.kb)  # 400 if the name is not a KB
-    # delete_kb rmtrees the directory and unregisters it from global.yaml;
-    # offload the blocking filesystem work off the event loop.
-    await run_in_threadpool(delete_kb, kb_dir)
+    try:
+        kb_dir = resolve_kb_alias(request.kb)
+    except ValueError as exc:  # malformed name
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # Accept a live KB dir OR a registered name whose directory is already gone
+    # (a ghost entry) — delete_kb cleans up both; reject anything else with 404.
+    registered = any(p == kb_dir for _, p in registered_kbs())
+    if not _is_kb_dir(kb_dir) and not registered:
+        raise HTTPException(status_code=404, detail=f"No knowledge base named {request.kb!r}.")
+    try:
+        await run_in_threadpool(delete_kb, kb_dir)
+    except ValueError as exc:  # resolved to an existing path that is not a KB
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return KbDeleteResponse(deleted=True, kb=request.kb, path=str(kb_dir))

--- a/openkb/api_kbs_router.py
+++ b/openkb/api_kbs_router.py
@@ -42,4 +42,10 @@ async def delete_kb_endpoint(
         await run_in_threadpool(delete_kb, kb_dir)
     except ValueError as exc:  # resolved to an existing path that is not a KB
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError:
+        pass  # a concurrent delete already removed it — idempotent success
+    except OSError as exc:  # rmtree failed (permission/disk; a still-open file on Windows)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to delete the knowledge base: {exc}"
+        ) from exc
     return KbDeleteResponse(deleted=True, kb=request.kb, path=str(kb_dir))

--- a/openkb/api_kbs_router.py
+++ b/openkb/api_kbs_router.py
@@ -1,0 +1,37 @@
+"""Knowledge-base lifecycle endpoints beyond config (POST /api/v1/kb/delete).
+
+An APIRouter (sibling of api_config_router.py / api_graph.py / api_output.py) so
+api.py stays under the per-file line gate (tests/test_file_size.py). delete_kb
+does its own filesystem removal + global-registry unregister (config.py's lock);
+like /api/v1/remove it needs no create_app closure and extracts cleanly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from openkb.api_helpers import _resolve_kb, require_bearer_token
+from openkb.api_models import KbDeleteRequest, KbDeleteResponse
+from openkb.config import delete_kb
+
+kbs_router = APIRouter()
+
+
+@kbs_router.post("/api/v1/kb/delete", response_model=KbDeleteResponse)
+async def delete_kb_endpoint(
+    request: KbDeleteRequest,
+    _: None = Depends(require_bearer_token),
+) -> Any:
+    # Type-the-name confirmation, re-checked server-side: this physically
+    # removes the whole KB directory (raw docs + wiki) and is irreversible, so
+    # it must never fire from a client that skipped the guard.
+    if request.confirm_name != request.kb:
+        raise HTTPException(status_code=400, detail="confirm_name does not match the KB name.")
+    kb_dir = _resolve_kb(request.kb)  # 400 if the name is not a KB
+    # delete_kb rmtrees the directory and unregisters it from global.yaml;
+    # offload the blocking filesystem work off the event loop.
+    await run_in_threadpool(delete_kb, kb_dir)
+    return KbDeleteResponse(deleted=True, kb=request.kb, path=str(kb_dir))

--- a/openkb/api_models.py
+++ b/openkb/api_models.py
@@ -305,6 +305,35 @@ class PageDeleteResponse(BaseModel):
     ghosts_stripped: int | None = None
 
 
+class PageLinksRequest(BaseModel):
+    kb: str = Field(..., min_length=1)
+    path: str = Field(..., min_length=1)
+
+
+class PageLinksResponse(BaseModel):
+    status: str
+    target: str
+    outlinks: list[str] = []  # pages this page links to
+    backlinks: list[str] = []  # pages that link to this page
+
+
+class PageEditRequest(BaseModel):
+    kb: str = Field(..., min_length=1)
+    path: str = Field(..., min_length=1)
+    # New page BODY. The OKF frontmatter (type/description/sources) is
+    # code-managed and preserved server-side; any frontmatter here is dropped.
+    content: str
+
+
+class PageEditResponse(BaseModel):
+    status: str
+    target: str
+    # Dead [[links]] the edit introduced, demoted to plain text on save (so the
+    # UI can tell the user which links didn't resolve).
+    ghosts_stripped: list[str] = []
+    content: str | None = None  # the saved full page (frontmatter + body)
+
+
 class WatchStartRequest(BaseModel):
     kb: str = Field(..., min_length=1)
     debounce: float = Field(default=2.0, gt=0)

--- a/openkb/api_models.py
+++ b/openkb/api_models.py
@@ -285,6 +285,26 @@ class PageResponse(BaseModel):
     content: str
 
 
+class PageDeleteRequest(BaseModel):
+    kb: str = Field(..., min_length=1)
+    # A '<section>/<name>' wiki-page ref, e.g. "concepts/attention". Only
+    # concepts/ and entities/ pages are user-deletable (validated server-side).
+    path: str = Field(..., min_length=1)
+    # dry_run reports the impacted backlink pages without deleting anything, so
+    # the UI can show "these N pages will have their links demoted" + confirm.
+    dry_run: bool = False
+
+
+class PageDeleteResponse(BaseModel):
+    status: str
+    target: str
+    # Content pages whose inbound [[links]] to the target will be / were demoted
+    # to plain text (the deletion's blast radius).
+    backlinks: list[str] = []
+    files_changed: int | None = None
+    ghosts_stripped: int | None = None
+
+
 class WatchStartRequest(BaseModel):
     kb: str = Field(..., min_length=1)
     debounce: float = Field(default=2.0, gt=0)

--- a/openkb/api_models.py
+++ b/openkb/api_models.py
@@ -322,6 +322,19 @@ class KbListResponse(BaseModel):
     knowledge_bases: list[KbSummaryItem]
 
 
+class KbDeleteRequest(BaseModel):
+    kb: str = Field(..., min_length=1)
+    # Must equal `kb`: a type-the-name confirmation, re-checked server-side so
+    # this irreversible delete never fires from a client that skipped the guard.
+    confirm_name: str = Field(..., min_length=1)
+
+
+class KbDeleteResponse(BaseModel):
+    deleted: bool
+    kb: str
+    path: str
+
+
 class MetaResponse(BaseModel):
     version: str
 

--- a/openkb/api_pages_router.py
+++ b/openkb/api_pages_router.py
@@ -1,0 +1,58 @@
+"""Wiki-page REST endpoints: read / delete a page.
+
+An APIRouter (sibling of api_graph.py / api_config_router.py / api_kbs_router.py)
+so api.py stays under the per-file line gate (tests/test_file_size.py). All
+endpoints depend only on module-level helpers (_resolve_kb, require_bearer_token)
+and page_ops — no create_app closure — so they extract cleanly. Page mutations
+serialize via page_ops' own KB ingest lock, not the app's per-KB asyncio lock.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from openkb.api_helpers import _resolve_kb, require_bearer_token
+from openkb.api_models import (
+    PageDeleteRequest,
+    PageDeleteResponse,
+    PageRequest,
+    PageResponse,
+)
+from openkb.page_ops import delete_wiki_page
+
+pages_router = APIRouter()
+
+
+@pages_router.post("/api/v1/page", response_model=PageResponse)
+async def page_endpoint(
+    request: PageRequest,
+    _: None = Depends(require_bearer_token),
+) -> PageResponse:
+    kb_dir = _resolve_kb(request.kb)
+    wiki_dir = (kb_dir / "wiki").resolve()
+    rel = request.path if request.path.endswith(".md") else f"{request.path}.md"
+    target = (wiki_dir / rel).resolve()
+    if not target.is_relative_to(wiki_dir):
+        raise HTTPException(status_code=400, detail="Invalid page path.")
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
+    content = await run_in_threadpool(target.read_text, encoding="utf-8")
+    return PageResponse(path=request.path, content=content)
+
+
+@pages_router.post("/api/v1/page/delete", response_model=PageDeleteResponse)
+async def delete_page_endpoint(
+    request: PageDeleteRequest,
+    _: None = Depends(require_bearer_token),
+) -> PageDeleteResponse:
+    kb_dir = _resolve_kb(request.kb)
+    try:
+        result = await run_in_threadpool(
+            delete_wiki_page, kb_dir, request.path, dry_run=request.dry_run
+        )
+    except ValueError as exc:  # invalid/traversal-unsafe page ref
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if result["status"] == "not_found":
+        raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
+    return PageDeleteResponse(**result)

--- a/openkb/api_pages_router.py
+++ b/openkb/api_pages_router.py
@@ -16,10 +16,14 @@ from openkb.api_helpers import _resolve_kb, require_bearer_token
 from openkb.api_models import (
     PageDeleteRequest,
     PageDeleteResponse,
+    PageEditRequest,
+    PageEditResponse,
+    PageLinksRequest,
+    PageLinksResponse,
     PageRequest,
     PageResponse,
 )
-from openkb.page_ops import delete_wiki_page
+from openkb.page_ops import delete_wiki_page, edit_wiki_page, page_link_context
 
 pages_router = APIRouter()
 
@@ -56,3 +60,33 @@ async def delete_page_endpoint(
     if result["status"] == "not_found":
         raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
     return PageDeleteResponse(**result)
+
+
+@pages_router.post("/api/v1/page/links", response_model=PageLinksResponse)
+async def page_links_endpoint(
+    request: PageLinksRequest,
+    _: None = Depends(require_bearer_token),
+) -> PageLinksResponse:
+    kb_dir = _resolve_kb(request.kb)
+    try:
+        result = await run_in_threadpool(page_link_context, kb_dir, request.path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if result["status"] == "not_found":
+        raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
+    return PageLinksResponse(**result)
+
+
+@pages_router.put("/api/v1/page", response_model=PageEditResponse)
+async def edit_page_endpoint(
+    request: PageEditRequest,
+    _: None = Depends(require_bearer_token),
+) -> PageEditResponse:
+    kb_dir = _resolve_kb(request.kb)
+    try:
+        result = await run_in_threadpool(edit_wiki_page, kb_dir, request.path, request.content)
+    except ValueError as exc:  # invalid/traversal-unsafe page ref
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if result["status"] == "not_found":
+        raise HTTPException(status_code=404, detail=f"Page not found: {request.path}")
+    return PageEditResponse(**result)

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -1831,14 +1831,18 @@ def delete_kb_cmd(name, yes):
     entire KB directory (raw docs + wiki) and unregisters it from the global
     config. There is no undo.
     """
-    from openkb.config import _is_kb_dir, delete_kb, resolve_kb_alias
+    from openkb.config import _is_kb_dir, registered_kbs, resolve_kb_alias
+    from openkb.kb_admin import delete_kb
 
     try:
         kb_dir = resolve_kb_alias(name)
     except ValueError as exc:
         click.echo(f"Invalid KB name: {exc}")
         return
-    if not _is_kb_dir(kb_dir):
+    # Accept a live KB dir OR a registered ghost (directory already removed by
+    # hand) so the stuck registry entry has a cleanup path; reject anything else.
+    registered = any(p == kb_dir for _, p in registered_kbs())
+    if not _is_kb_dir(kb_dir) and not registered:
         click.echo(f"No knowledge base named '{name}' found.")
         return
     click.echo(f"About to PERMANENTLY delete knowledge base '{name}':")

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -1819,6 +1819,40 @@ def _refresh_schema(wiki_dir: Path) -> bool:
     return True
 
 
+@cli.command(name="delete-kb")
+@click.argument("name")
+@click.option(
+    "--yes", "-y", is_flag=True, default=False, help="Skip the type-the-name confirmation."
+)
+def delete_kb_cmd(name, yes):
+    """Permanently delete a knowledge base (physical removal, irreversible).
+
+    NAME is the KB name as addressed by the web UI / registry. Removes the
+    entire KB directory (raw docs + wiki) and unregisters it from the global
+    config. There is no undo.
+    """
+    from openkb.config import _is_kb_dir, delete_kb, resolve_kb_alias
+
+    try:
+        kb_dir = resolve_kb_alias(name)
+    except ValueError as exc:
+        click.echo(f"Invalid KB name: {exc}")
+        return
+    if not _is_kb_dir(kb_dir):
+        click.echo(f"No knowledge base named '{name}' found.")
+        return
+    click.echo(f"About to PERMANENTLY delete knowledge base '{name}':")
+    click.echo(f"  {kb_dir}")
+    click.echo("This removes the entire directory (raw docs + wiki) and cannot be undone.")
+    if not yes:
+        typed = click.prompt("Type the KB name to confirm", default="", show_default=False)
+        if typed.strip() != name:
+            click.echo("Name did not match — aborted.")
+            return
+    delete_kb(kb_dir)
+    click.echo(f"Deleted knowledge base '{name}'.")
+
+
 @cli.command()
 @click.argument("doc_name", required=False)
 @click.option(

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -5,7 +5,6 @@ import logging
 import math
 import os
 import re
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
@@ -749,46 +748,3 @@ def registered_kbs() -> list[tuple[str, Path]]:
             seen_paths.add(str(resolved))
             result.append((name, resolved))
     return result
-
-
-def unregister_kb(kb_path: Path) -> None:
-    """Remove ``kb_path`` from the global registry: its ``known_kbs`` entry, any
-    ``kb_aliases`` pointing at it, and ``default_kb`` if it referenced it. Held
-    under the global-config lock; a no-op for a never-registered path.
-    """
-    resolved = str(kb_path.resolve())
-    with _with_global_config_lock():
-        gc = _load_global_config_unlocked()
-        changed = False
-        known = gc.get("known_kbs")
-        if isinstance(known, list):
-            pruned = [k for k in known if k != resolved]
-            if len(pruned) != len(known):
-                gc["known_kbs"] = pruned
-                changed = True
-        aliases = gc.get("kb_aliases")
-        if isinstance(aliases, dict):
-            pruned_aliases = {a: p for a, p in aliases.items() if p != resolved}
-            if len(pruned_aliases) != len(aliases):
-                gc["kb_aliases"] = pruned_aliases
-                changed = True
-        if gc.get("default_kb") == resolved:
-            del gc["default_kb"]
-            changed = True
-        if changed:
-            _atomic_yaml_dump(GLOBAL_CONFIG_PATH, gc)
-
-
-def delete_kb(kb_dir: Path) -> None:
-    """Physically delete a KB directory and unregister it (irreversible; the
-    CALLER confirms). Guards against deleting an arbitrary path: an existing
-    ``kb_dir`` MUST be a KB (``.openkb`` + ``wiki``) or :class:`ValueError` is
-    raised and nothing is removed. A ghost entry (directory already gone) is
-    tolerated — no ``rmtree``, just unregistered.
-    """
-    kb_dir = kb_dir.resolve()
-    if kb_dir.exists():
-        if not _is_kb_dir(kb_dir):
-            raise ValueError(f"Refusing to delete: not a knowledge base directory: {kb_dir}")
-        shutil.rmtree(kb_dir)
-    unregister_kb(kb_dir)

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -5,6 +5,7 @@ import logging
 import math
 import os
 import re
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
@@ -748,3 +749,46 @@ def registered_kbs() -> list[tuple[str, Path]]:
             seen_paths.add(str(resolved))
             result.append((name, resolved))
     return result
+
+
+def unregister_kb(kb_path: Path) -> None:
+    """Remove ``kb_path`` from the global registry: its ``known_kbs`` entry, any
+    ``kb_aliases`` pointing at it, and ``default_kb`` if it referenced it. Held
+    under the global-config lock; a no-op for a never-registered path.
+    """
+    resolved = str(kb_path.resolve())
+    with _with_global_config_lock():
+        gc = _load_global_config_unlocked()
+        changed = False
+        known = gc.get("known_kbs")
+        if isinstance(known, list):
+            pruned = [k for k in known if k != resolved]
+            if len(pruned) != len(known):
+                gc["known_kbs"] = pruned
+                changed = True
+        aliases = gc.get("kb_aliases")
+        if isinstance(aliases, dict):
+            pruned_aliases = {a: p for a, p in aliases.items() if p != resolved}
+            if len(pruned_aliases) != len(aliases):
+                gc["kb_aliases"] = pruned_aliases
+                changed = True
+        if gc.get("default_kb") == resolved:
+            del gc["default_kb"]
+            changed = True
+        if changed:
+            _atomic_yaml_dump(GLOBAL_CONFIG_PATH, gc)
+
+
+def delete_kb(kb_dir: Path) -> None:
+    """Physically delete a KB directory and unregister it (irreversible; the
+    CALLER confirms). Guards against deleting an arbitrary path: an existing
+    ``kb_dir`` MUST be a KB (``.openkb`` + ``wiki``) or :class:`ValueError` is
+    raised and nothing is removed. A ghost entry (directory already gone) is
+    tolerated — no ``rmtree``, just unregistered.
+    """
+    kb_dir = kb_dir.resolve()
+    if kb_dir.exists():
+        if not _is_kb_dir(kb_dir):
+            raise ValueError(f"Refusing to delete: not a knowledge base directory: {kb_dir}")
+        shutil.rmtree(kb_dir)
+    unregister_kb(kb_dir)

--- a/openkb/kb_admin.py
+++ b/openkb/kb_admin.py
@@ -1,0 +1,64 @@
+"""Knowledge-base admin operations: physically delete a KB + registry cleanup.
+
+Kept out of config.py (which sits near the per-file line gate) because these
+mutate the filesystem (``shutil.rmtree`` under the KB ingest lock) and the
+global registry — side effects the otherwise-pure config-loading module avoids.
+
+Imports the config MODULE (not names) so ``config.GLOBAL_CONFIG_PATH`` is read
+at call time — a test that monkeypatches it (isolated global.yaml) must be
+honored, which a by-value ``from openkb.config import GLOBAL_CONFIG_PATH`` would
+silently break.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from openkb import config
+from openkb.locks import kb_ingest_lock
+
+
+def unregister_kb(kb_path: Path) -> None:
+    """Remove ``kb_path`` from the global registry (its ``known_kbs`` entry, any
+    ``kb_aliases`` pointing at it, ``default_kb`` if it referenced it). Held
+    under the global-config lock; a no-op for a never-registered path."""
+    resolved = str(kb_path.resolve())
+    with config._with_global_config_lock():
+        gc = config._load_global_config_unlocked()
+        changed = False
+        known = gc.get("known_kbs")
+        if isinstance(known, list):
+            pruned = [k for k in known if k != resolved]
+            if len(pruned) != len(known):
+                gc["known_kbs"] = pruned
+                changed = True
+        aliases = gc.get("kb_aliases")
+        if isinstance(aliases, dict):
+            pruned_aliases = {a: p for a, p in aliases.items() if p != resolved}
+            if len(pruned_aliases) != len(aliases):
+                gc["kb_aliases"] = pruned_aliases
+                changed = True
+        if gc.get("default_kb") == resolved:
+            del gc["default_kb"]
+            changed = True
+        if changed:
+            config._atomic_yaml_dump(config.GLOBAL_CONFIG_PATH, gc)
+
+
+def delete_kb(kb_dir: Path) -> None:
+    """Physically delete a KB directory and unregister it (irreversible; the
+    CALLER confirms). An existing ``kb_dir`` MUST be a KB (``.openkb`` + ``wiki``)
+    or :class:`ValueError` is raised and nothing removed; a ghost entry
+    (directory already gone) is tolerated — no ``rmtree``, just unregistered.
+    """
+    kb_dir = kb_dir.resolve()
+    if kb_dir.exists():
+        if not config._is_kb_dir(kb_dir):
+            raise ValueError(f"Refusing to delete: not a knowledge base directory: {kb_dir}")
+        # Serialize against in-flight ingest/recompile on this KB (like `openkb
+        # remove`). POSIX: rmtree unlinks the held lock file, but the open fd
+        # stays valid, so the funlock on context-exit is safe.
+        with kb_ingest_lock(kb_dir / ".openkb"):
+            shutil.rmtree(kb_dir)
+    unregister_kb(kb_dir)

--- a/openkb/kb_admin.py
+++ b/openkb/kb_admin.py
@@ -56,9 +56,14 @@ def delete_kb(kb_dir: Path) -> None:
     if kb_dir.exists():
         if not config._is_kb_dir(kb_dir):
             raise ValueError(f"Refusing to delete: not a knowledge base directory: {kb_dir}")
-        # Serialize against in-flight ingest/recompile on this KB (like `openkb
-        # remove`). POSIX: rmtree unlinks the held lock file, but the open fd
-        # stays valid, so the funlock on context-exit is safe.
+        # Serialize against in-flight ingest/recompile by acquiring the ingest
+        # lock as a BARRIER (it drains pending journals and waits out any active
+        # mutation), then RELEASING it before rmtree. The lock file lives INSIDE
+        # kb_dir and Windows cannot delete a still-open file, so it must not be
+        # held during rmtree. Re-check existence in case a concurrent delete won
+        # the race while we waited on the barrier.
         with kb_ingest_lock(kb_dir / ".openkb"):
+            pass
+        if kb_dir.exists():
             shutil.rmtree(kb_dir)
     unregister_kb(kb_dir)

--- a/openkb/lint.py
+++ b/openkb/lint.py
@@ -236,6 +236,8 @@ def fix_broken_links(
         for raw in restrict_to:
             if not raw.is_file():
                 continue
+            if raw.name in _EXCLUDED_FILES:
+                continue  # never rewrite generated docs (AGENTS/SCHEMA/log.md)
             try:
                 raw.resolve().relative_to(wiki_resolved)
             except ValueError:

--- a/openkb/page_ops.py
+++ b/openkb/page_ops.py
@@ -16,8 +16,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from openkb.lint import _extract_wikilinks, _normalize_target, _read_md, fix_broken_links
-from openkb.locks import kb_ingest_lock
+from openkb import frontmatter
+from openkb.lint import (
+    _extract_wikilinks,
+    _normalize_target,
+    _read_md,
+    fix_broken_links,
+    list_existing_wiki_targets,
+    strip_ghost_wikilinks,
+)
+from openkb.locks import atomic_write_text, kb_ingest_lock
 
 # Only these compiled page types are user-deletable/editable. summaries are
 # per-source-document (managed by add/remove); index/log/reports are generated.
@@ -110,4 +118,66 @@ def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
         "backlinks": backlinks,
         "files_changed": files_changed,
         "ghosts_stripped": ghosts_stripped,
+    }
+
+
+def page_link_context(kb_dir: Path, path: str) -> dict:
+    """Outbound + inbound links for a page — the edit-impact panel.
+
+    ``outlinks`` are the distinct pages this page links to (resolvable
+    ``[[wikilinks]]``); ``backlinks`` are the pages that link to it. Editing the
+    BODY does not break either (links are path-based), so this is context, not a
+    blocker. Returns ``status`` ``not_found`` when the page is absent.
+    """
+    section, stem = validate_page_ref(path)
+    wiki = kb_dir / "wiki"
+    page = wiki / section / f"{stem}.md"
+    target = f"{section}/{stem}"
+    if not page.is_file():
+        return {"status": "not_found", "target": target, "outlinks": [], "backlinks": []}
+
+    target_norm = _normalize_target(target)
+    norm_known = {_normalize_target(t): t for t in list_existing_wiki_targets(wiki)}
+    out: set[str] = set()
+    for raw in _extract_wikilinks(_read_md(page)):
+        canon = norm_known.get(_normalize_target(raw))
+        if canon and _normalize_target(canon) != target_norm:
+            out.add(canon)
+    backlinks = pages_linking_to(wiki, target_norm, exclude=page)
+    return {"status": "ok", "target": target, "outlinks": sorted(out), "backlinks": backlinks}
+
+
+def edit_wiki_page(kb_dir: Path, path: str, content: str) -> dict:
+    """Replace a concept/entity page's BODY, preserving its OKF frontmatter.
+
+    The ``type:``/``description:``/``sources:`` frontmatter is code-managed, so
+    any frontmatter in the incoming ``content`` is discarded and the existing
+    block is re-attached verbatim. Dead ``[[wikilinks]]`` the user typed are
+    demoted to plain text on save (OpenKB keeps the wiki free of broken links);
+    the demoted targets are returned so the UI can warn. Write is atomic, under
+    the KB ingest lock. Returns ``status`` ``not_found`` when the page is absent.
+    """
+    section, stem = validate_page_ref(path)
+    wiki = kb_dir / "wiki"
+    page = wiki / section / f"{stem}.md"
+    target = f"{section}/{stem}"
+    if not page.is_file():
+        return {"status": "not_found", "target": target, "ghosts_stripped": []}
+
+    existing = frontmatter.split(_read_md(page))
+    fm_block = existing[0] if existing else ""
+    # Strip any frontmatter the client sent back (it is code-managed); keep only
+    # the edited body.
+    incoming = frontmatter.split(content)
+    body = incoming[1] if incoming else content
+    cleaned_body, ghosts = strip_ghost_wikilinks(body, list_existing_wiki_targets(wiki))
+
+    with kb_ingest_lock(kb_dir / ".openkb"):
+        atomic_write_text(page, fm_block + cleaned_body)
+
+    return {
+        "status": "saved",
+        "target": target,
+        "ghosts_stripped": sorted(set(ghosts)),
+        "content": fm_block + cleaned_body,
     }

--- a/openkb/page_ops.py
+++ b/openkb/page_ops.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from openkb import frontmatter
 from openkb.lint import (
+    _EXCLUDED_FILES,
     _extract_wikilinks,
     _normalize_target,
     _read_md,
@@ -54,7 +55,10 @@ def pages_linking_to(wiki: Path, target_norm: str, *, exclude: Path) -> list[str
     """Content pages whose ``[[wikilinks]]`` resolve to ``target_norm`` (backlinks).
 
     Excludes ``exclude`` (the target page itself), ``index.md`` (handled by the
-    index-entry removal, not link demotion), and ``reports/`` + ``sources/``.
+    index-entry removal, not link demotion), ``reports/`` + ``sources/``, and
+    :data:`lint._EXCLUDED_FILES` (AGENTS.md/SCHEMA.md/log.md) — the generated
+    docs lint never rewrites; scanning them would list the shipped schema doc as
+    a backlink and then let ``fix_broken_links`` corrupt it.
     Returns relative ``'section/stem'`` refs, sorted, for a stable impact preview.
     """
     hits: set[str] = set()
@@ -63,13 +67,32 @@ def pages_linking_to(wiki: Path, target_norm: str, *, exclude: Path) -> list[str
         rel = md.relative_to(wiki)
         if rel.parts[:1] in (("reports",), ("sources",)):
             continue
-        if md.name == "index.md" or md.resolve() == exclude_resolved:
+        if md.name == "index.md" or md.name in _EXCLUDED_FILES or md.resolve() == exclude_resolved:
             continue
         for raw in _extract_wikilinks(_read_md(md)):
             if _normalize_target(raw) == target_norm:
                 hits.add(str(rel.with_suffix("")).replace("\\", "/"))
                 break
     return sorted(hits)
+
+
+def _on_disk_stem(section_dir: Path, stem: str) -> str:
+    """The actual on-disk stem for ``stem``.
+
+    A case-insensitive filesystem (macOS/Windows) may store the real filename
+    with different case than the ref the caller resolved (e.g. opened via a
+    ``[[concepts/foo]]`` wikilink while the file is ``Foo.md``). index.md entries
+    use the on-disk name, so the exact-match index cleanup needs the real stem.
+    """
+    if not section_dir.is_dir():
+        return stem
+    ci_match = stem
+    for p in section_dir.glob("*.md"):
+        if p.stem == stem:  # exact — prefer it (case-sensitive FS, both variants)
+            return stem
+        if p.stem.lower() == stem.lower():
+            ci_match = p.stem
+    return ci_match
 
 
 def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
@@ -88,8 +111,9 @@ def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
     if not page.is_file():
         return {"status": "not_found", "target": target, "backlinks": []}
 
-    backlinks = pages_linking_to(wiki, _normalize_target(target), exclude=page)
     if dry_run:
+        # Preview only — no mutation, so an unlocked scan is fine.
+        backlinks = pages_linking_to(wiki, _normalize_target(target), exclude=page)
         return {"status": "dry_run", "target": target, "backlinks": backlinks}
 
     # Imported lazily: compiler pulls in the LLM stack, which this pure
@@ -97,19 +121,30 @@ def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
     from openkb.agent.compiler import remove_doc_from_index
 
     with kb_ingest_lock(kb_dir / ".openkb"):
-        page.unlink()
-        # Remove the page's index.md entry (a [[link]] LINE — full removal,
-        # not link demotion). Empty doc_name leaves the Documents section alone.
+        # Re-check under the lock: a concurrent delete/recompile may have removed
+        # the page in the window since the pre-lock is_file() gate.
+        if not page.is_file():
+            return {"status": "not_found", "target": target, "backlinks": []}
+        # Compute backlinks INSIDE the lock so a concurrently-added inbound link
+        # is still demoted (matches run_remove_for_api's plan-inside-the-lock).
+        backlinks = pages_linking_to(wiki, _normalize_target(target), exclude=page)
+        # Remove the page's index.md entry (a [[link]] LINE — full removal, not
+        # link demotion). Empty doc_name leaves the Documents section alone; use
+        # the ACTUAL on-disk stem so the exact-match cleanup works on a
+        # case-insensitive FS where the ref may differ in case.
+        real_stem = _on_disk_stem(wiki / section, stem)
+        page.unlink(missing_ok=True)
         remove_doc_from_index(
             wiki,
             "",
-            concept_slugs_deleted=[stem] if section == "concepts" else [],
-            entity_slugs_deleted=[stem] if section == "entities" else [],
+            concept_slugs_deleted=[real_stem] if section == "concepts" else [],
+            entity_slugs_deleted=[real_stem] if section == "entities" else [],
         )
-        # Demote the now-dangling inbound [[links]] to plain text — surgically,
-        # only in the pages that referenced this one (matches `openkb remove`,
-        # so pre-existing dangling links elsewhere are left untouched).
-        restrict = [wiki / f"{ref}.md" for ref in backlinks]
+        # Demote now-dangling inbound [[links]] to plain text — in the backlink
+        # pages AND in index.md (a [[target]] embedded in another entry's brief;
+        # the page's own entry line was already removed above). Surgical restrict
+        # leaves pre-existing dangling links elsewhere untouched (like remove).
+        restrict = [wiki / f"{ref}.md" for ref in backlinks] + [wiki / "index.md"]
         files_changed, ghosts_stripped = fix_broken_links(wiki, restrict_to=restrict)
 
     return {
@@ -164,15 +199,20 @@ def edit_wiki_page(kb_dir: Path, path: str, content: str) -> dict:
     if not page.is_file():
         return {"status": "not_found", "target": target, "ghosts_stripped": []}
 
-    existing = frontmatter.split(_read_md(page))
-    fm_block = existing[0] if existing else ""
-    # Strip any frontmatter the client sent back (it is code-managed); keep only
-    # the edited body.
-    incoming = frontmatter.split(content)
-    body = incoming[1] if incoming else content
-    cleaned_body, ghosts = strip_ghost_wikilinks(body, list_existing_wiki_targets(wiki))
-
     with kb_ingest_lock(kb_dir / ".openkb"):
+        # Re-check under the lock: never resurrect a page a concurrent
+        # delete/recompile removed in the pre-lock window (atomic_write would
+        # otherwise recreate the file). Read + demote + write all run here so
+        # the op is atomic against its own inputs (no lost-update).
+        if not page.is_file():
+            return {"status": "not_found", "target": target, "ghosts_stripped": []}
+        existing = frontmatter.split(_read_md(page))
+        fm_block = existing[0] if existing else ""
+        # `content` IS the body: the reader strips the code-managed OKF
+        # frontmatter before editing, so it is NEVER re-split here — a body that
+        # legitimately opens with a '---' block must not be mistaken for
+        # frontmatter and silently dropped. The existing block is re-attached.
+        cleaned_body, ghosts = strip_ghost_wikilinks(content, list_existing_wiki_targets(wiki))
         atomic_write_text(page, fm_block + cleaned_body)
 
     return {

--- a/openkb/page_ops.py
+++ b/openkb/page_ops.py
@@ -28,24 +28,32 @@ from openkb.lint import (
 )
 from openkb.locks import atomic_write_text, kb_ingest_lock
 
-# Only these compiled page types are user-deletable/editable. summaries are
-# per-source-document (managed by add/remove); index/log/reports are generated.
-EDITABLE_SECTIONS = ("concepts", "entities")
+# Compiled page types the user may EDIT (a recompile can still regenerate them):
+# concept/entity synthesis PLUS per-document summaries. index/log/reports are
+# generated artifacts and stay read-only.
+EDITABLE_SECTIONS = ("concepts", "entities", "summaries")
+# DELETABLE is narrower: a summary is bound to its source document, so it is
+# removed by deleting the DOCUMENT (/api/v1/remove), never on its own — deleting
+# it alone would leave a doc with no summary.
+DELETABLE_SECTIONS = ("concepts", "entities")
 
 
-def validate_page_ref(path: str) -> tuple[str, str]:
+def validate_page_ref(
+    path: str, *, allowed: tuple[str, ...] = EDITABLE_SECTIONS
+) -> tuple[str, str]:
     """Split a ``'<section>/<name>'`` page ref into ``(section, stem)``.
 
-    Guards against path traversal: ``section`` must be an editable section and
-    ``stem`` a single safe filename segment (no separators, ``..``, or leading
-    dot). Raises :class:`ValueError` otherwise.
+    ``allowed`` is the permitted-section allowlist — defaults to the editable
+    set; delete passes the narrower :data:`DELETABLE_SECTIONS`. Guards against
+    path traversal: ``section`` must be in ``allowed`` and ``stem`` a single safe
+    filename segment (no separators, ``..``, or leading dot). Raises ValueError.
     """
     parts = path.strip().strip("/").split("/")
     if len(parts) != 2:
         raise ValueError("page ref must be '<section>/<name>' (e.g. concepts/attention)")
     section, stem = parts
-    if section not in EDITABLE_SECTIONS:
-        raise ValueError(f"section must be one of {EDITABLE_SECTIONS}, got {section!r}")
+    if section not in allowed:
+        raise ValueError(f"section must be one of {allowed}, got {section!r}")
     if not stem or stem in (".", "..") or stem.startswith(".") or "\\" in stem:
         raise ValueError(f"invalid page name: {stem!r}")
     return section, stem
@@ -101,9 +109,10 @@ def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
     ``path`` is a ``'section/stem'`` ref (e.g. ``'concepts/attention'``). With
     ``dry_run`` it only reports the impacted backlink pages (whose inbound links
     WOULD be demoted). Returns a dict whose ``status`` is one of ``not_found``,
-    ``dry_run``, ``deleted``.
+    ``dry_run``, ``deleted``. Only concept/entity pages are deletable (a summary
+    is removed by deleting its source document, not on its own).
     """
-    section, stem = validate_page_ref(path)
+    section, stem = validate_page_ref(path, allowed=DELETABLE_SECTIONS)
     wiki = kb_dir / "wiki"
     page = wiki / section / f"{stem}.md"
     target = f"{section}/{stem}"

--- a/openkb/page_ops.py
+++ b/openkb/page_ops.py
@@ -1,0 +1,113 @@
+"""Wiki-page mutations for the Workbench: delete a concept/entity page.
+
+Reuses the compile/lint machinery so a deletion degrades cleanly rather than
+leaving dangling references:
+
+- inbound ``[[wikilinks]]`` in other pages are demoted to plain text
+  (``lint.fix_broken_links``), not left pointing at a gone page;
+- the page's ``index.md`` entry (itself a ``[[wikilink]]`` line) is removed
+  outright (``compiler.remove_doc_from_index``).
+
+All writes run under the KB ingest lock (crash-safe serial mutation, matching
+``openkb remove``); the underlying rewrites use ``atomic_write_text``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openkb.lint import _extract_wikilinks, _normalize_target, _read_md, fix_broken_links
+from openkb.locks import kb_ingest_lock
+
+# Only these compiled page types are user-deletable/editable. summaries are
+# per-source-document (managed by add/remove); index/log/reports are generated.
+EDITABLE_SECTIONS = ("concepts", "entities")
+
+
+def validate_page_ref(path: str) -> tuple[str, str]:
+    """Split a ``'<section>/<name>'`` page ref into ``(section, stem)``.
+
+    Guards against path traversal: ``section`` must be an editable section and
+    ``stem`` a single safe filename segment (no separators, ``..``, or leading
+    dot). Raises :class:`ValueError` otherwise.
+    """
+    parts = path.strip().strip("/").split("/")
+    if len(parts) != 2:
+        raise ValueError("page ref must be '<section>/<name>' (e.g. concepts/attention)")
+    section, stem = parts
+    if section not in EDITABLE_SECTIONS:
+        raise ValueError(f"section must be one of {EDITABLE_SECTIONS}, got {section!r}")
+    if not stem or stem in (".", "..") or stem.startswith(".") or "\\" in stem:
+        raise ValueError(f"invalid page name: {stem!r}")
+    return section, stem
+
+
+def pages_linking_to(wiki: Path, target_norm: str, *, exclude: Path) -> list[str]:
+    """Content pages whose ``[[wikilinks]]`` resolve to ``target_norm`` (backlinks).
+
+    Excludes ``exclude`` (the target page itself), ``index.md`` (handled by the
+    index-entry removal, not link demotion), and ``reports/`` + ``sources/``.
+    Returns relative ``'section/stem'`` refs, sorted, for a stable impact preview.
+    """
+    hits: set[str] = set()
+    exclude_resolved = exclude.resolve()
+    for md in wiki.rglob("*.md"):
+        rel = md.relative_to(wiki)
+        if rel.parts[:1] in (("reports",), ("sources",)):
+            continue
+        if md.name == "index.md" or md.resolve() == exclude_resolved:
+            continue
+        for raw in _extract_wikilinks(_read_md(md)):
+            if _normalize_target(raw) == target_norm:
+                hits.add(str(rel.with_suffix("")).replace("\\", "/"))
+                break
+    return sorted(hits)
+
+
+def delete_wiki_page(kb_dir: Path, path: str, *, dry_run: bool = False) -> dict:
+    """Delete a concept/entity page and clean up references to it.
+
+    ``path`` is a ``'section/stem'`` ref (e.g. ``'concepts/attention'``). With
+    ``dry_run`` it only reports the impacted backlink pages (whose inbound links
+    WOULD be demoted). Returns a dict whose ``status`` is one of ``not_found``,
+    ``dry_run``, ``deleted``.
+    """
+    section, stem = validate_page_ref(path)
+    wiki = kb_dir / "wiki"
+    page = wiki / section / f"{stem}.md"
+    target = f"{section}/{stem}"
+
+    if not page.is_file():
+        return {"status": "not_found", "target": target, "backlinks": []}
+
+    backlinks = pages_linking_to(wiki, _normalize_target(target), exclude=page)
+    if dry_run:
+        return {"status": "dry_run", "target": target, "backlinks": backlinks}
+
+    # Imported lazily: compiler pulls in the LLM stack, which this pure
+    # index-editing helper does not otherwise need at module import.
+    from openkb.agent.compiler import remove_doc_from_index
+
+    with kb_ingest_lock(kb_dir / ".openkb"):
+        page.unlink()
+        # Remove the page's index.md entry (a [[link]] LINE — full removal,
+        # not link demotion). Empty doc_name leaves the Documents section alone.
+        remove_doc_from_index(
+            wiki,
+            "",
+            concept_slugs_deleted=[stem] if section == "concepts" else [],
+            entity_slugs_deleted=[stem] if section == "entities" else [],
+        )
+        # Demote the now-dangling inbound [[links]] to plain text — surgically,
+        # only in the pages that referenced this one (matches `openkb remove`,
+        # so pre-existing dangling links elsewhere are left untouched).
+        restrict = [wiki / f"{ref}.md" for ref in backlinks]
+        files_changed, ghosts_stripped = fix_broken_links(wiki, restrict_to=restrict)
+
+    return {
+        "status": "deleted",
+        "target": target,
+        "backlinks": backlinks,
+        "files_changed": files_changed,
+        "ghosts_stripped": ghosts_stripped,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3152,3 +3152,62 @@ def test_delete_page_rejects_unsafe_or_non_editable_ref(monkeypatch, kb_dir):
     for bad in ["summaries/x", "index", "concepts/a/b", "concepts/..", "reports/health"]:
         r = client.post("/api/v1/page/delete", json={"kb": kb, "path": bad}, headers=_auth())
         assert r.status_code == 400, bad
+
+
+# --- PUT /api/v1/page (edit) + POST /api/v1/page/links -----------------------
+
+
+def test_edit_page_preserves_frontmatter_and_demotes_dead_links(monkeypatch, kb_dir):
+    wiki = kb_dir / "wiki"
+    (wiki / "concepts" / "bar.md").write_text("# Bar\n\nbar body\n", encoding="utf-8")
+    (wiki / "concepts" / "foo.md").write_text(
+        "---\ntype: Concept\ndescription: about foo\n---\n# Foo\n\nOriginal body.\n",
+        encoding="utf-8",
+    )
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    new_body = "# Foo\n\nEdited, links [[concepts/bar]] and [[concepts/ghost]].\n"
+    r = client.put(
+        "/api/v1/page",
+        json={"kb": kb, "path": "concepts/foo", "content": new_body},
+        headers=_auth(),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "saved"
+    assert body["ghosts_stripped"] == ["concepts/ghost"]
+
+    saved = (wiki / "concepts" / "foo.md").read_text(encoding="utf-8")
+    assert "type: Concept" in saved  # frontmatter preserved
+    assert "description: about foo" in saved
+    assert "Edited, links [[concepts/bar]]" in saved  # good link kept
+    assert "[[concepts/ghost]]" not in saved  # dead link demoted to text
+    assert "Original body." not in saved  # body replaced
+
+
+def test_edit_page_not_found_returns_404(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    r = client.put(
+        "/api/v1/page",
+        json={"kb": kb, "path": "concepts/nope", "content": "x"},
+        headers=_auth(),
+    )
+    assert r.status_code == 404
+
+
+def test_page_links_reports_out_and_backlinks(monkeypatch, kb_dir):
+    wiki = kb_dir / "wiki"
+    (wiki / "concepts" / "hub.md").write_text(
+        "# Hub\n\nlinks [[concepts/leaf]]\n", encoding="utf-8"
+    )
+    (wiki / "concepts" / "leaf.md").write_text("# Leaf\n\nleaf\n", encoding="utf-8")
+    (wiki / "concepts" / "ref.md").write_text("# Ref\n\nsee [[concepts/hub]]\n", encoding="utf-8")
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    r = client.post("/api/v1/page/links", json={"kb": kb, "path": "concepts/hub"}, headers=_auth())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["outlinks"] == ["concepts/leaf"]  # hub -> leaf
+    assert body["backlinks"] == ["concepts/ref"]  # ref -> hub

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3093,3 +3093,62 @@ def test_delete_kb_rejects_non_kb_target(monkeypatch, tmp_path):
     )
     assert resp.status_code == 400
     assert plain.exists()
+
+
+# --- POST /api/v1/page/delete ------------------------------------------------
+
+
+def test_delete_page_demotes_inbound_links_and_removes_index_entry(monkeypatch, kb_dir):
+    wiki = kb_dir / "wiki"
+    (wiki / "concepts" / "foo.md").write_text("# Foo\n\nAbout foo.\n", encoding="utf-8")
+    (wiki / "concepts" / "bar.md").write_text(
+        "# Bar\n\nSee [[concepts/foo]] for context.\n", encoding="utf-8"
+    )
+    (wiki / "index.md").write_text(
+        "# Index\n\n## Concepts\n- [[concepts/foo]] — foo\n- [[concepts/bar]] — bar\n",
+        encoding="utf-8",
+    )
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    # dry-run reports the impacted backlink page and deletes nothing.
+    r = client.post(
+        "/api/v1/page/delete",
+        json={"kb": kb, "path": "concepts/foo", "dry_run": True},
+        headers=_auth(),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "dry_run"
+    assert "concepts/bar" in r.json()["backlinks"]
+    assert (wiki / "concepts" / "foo.md").exists()
+
+    # execute
+    r = client.post("/api/v1/page/delete", json={"kb": kb, "path": "concepts/foo"}, headers=_auth())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "deleted"
+    assert body["files_changed"] == 1  # bar.md rewritten
+    assert not (wiki / "concepts" / "foo.md").exists()  # page removed
+    bar = (wiki / "concepts" / "bar.md").read_text(encoding="utf-8")
+    assert "[[concepts/foo]]" not in bar  # inbound link demoted...
+    assert "foo" in bar  # ...to plain text, sentence kept
+    idx = (wiki / "index.md").read_text(encoding="utf-8")
+    assert "[[concepts/foo]]" not in idx  # index entry removed outright
+    assert "[[concepts/bar]]" in idx  # sibling entry untouched
+
+
+def test_delete_page_not_found_returns_404(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    r = client.post(
+        "/api/v1/page/delete", json={"kb": kb, "path": "concepts/nope"}, headers=_auth()
+    )
+    assert r.status_code == 404
+
+
+def test_delete_page_rejects_unsafe_or_non_editable_ref(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    for bad in ["summaries/x", "index", "concepts/a/b", "concepts/..", "reports/health"]:
+        r = client.post("/api/v1/page/delete", json={"kb": kb, "path": bad}, headers=_auth())
+        assert r.status_code == 400, bad

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3287,3 +3287,32 @@ def test_delete_kb_ghost_entry_unregisters_via_endpoint(monkeypatch, tmp_path):
     )
     assert r.status_code == 200, r.text
     assert all(n != "ghost-kb" for n, _ in registered_kbs())  # registry cleaned up
+
+
+def test_summary_page_is_editable_but_not_deletable(monkeypatch, kb_dir):
+    # A summary is compiled markdown like a concept, so it is EDITABLE (recompile
+    # can still regenerate it), but NOT independently deletable — it is removed by
+    # deleting its source document.
+    wiki = kb_dir / "wiki"
+    (wiki / "summaries" / "doc.md").write_text(
+        "---\ntype: Summary\n---\n# Doc\n\nold body\n", encoding="utf-8"
+    )
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    # edit is allowed, frontmatter preserved
+    r = client.put(
+        "/api/v1/page",
+        json={"kb": kb, "path": "summaries/doc", "content": "# Doc\n\nnew body\n"},
+        headers=_auth(),
+    )
+    assert r.status_code == 200, r.text
+    saved = (wiki / "summaries" / "doc.md").read_text(encoding="utf-8")
+    assert "type: Summary" in saved
+    assert "new body" in saved and "old body" not in saved
+
+    # delete is refused for a summary (400, not deletable on its own)
+    r = client.post(
+        "/api/v1/page/delete", json={"kb": kb, "path": "summaries/doc"}, headers=_auth()
+    )
+    assert r.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3084,12 +3084,18 @@ def test_delete_kb_confirm_name_mismatch_is_rejected(monkeypatch, tmp_path):
 
 
 def test_delete_kb_rejects_non_kb_target(monkeypatch, tmp_path):
+    # A registered name pointing at a real dir that is NOT a KB: it passes the
+    # endpoint's "registered" gate, but delete_kb refuses to rmtree a non-KB
+    # directory -> 400 (never deletes an arbitrary path).
+    from openkb.config import register_kb_alias
+
+    _isolate_global(monkeypatch, tmp_path)
     plain = tmp_path / "plain"
     plain.mkdir()  # a real directory, but not a KB (no .openkb/wiki)
+    register_kb_alias("ghost-kb", plain)
     client = _client(monkeypatch)
-    name = _use_named_kb(monkeypatch, plain, name="ghost-kb")
     resp = client.post(
-        "/api/v1/kb/delete", json={"kb": name, "confirm_name": name}, headers=_auth()
+        "/api/v1/kb/delete", json={"kb": "ghost-kb", "confirm_name": "ghost-kb"}, headers=_auth()
     )
     assert resp.status_code == 400
     assert plain.exists()
@@ -3211,3 +3217,73 @@ def test_page_links_reports_out_and_backlinks(monkeypatch, kb_dir):
     body = r.json()
     assert body["outlinks"] == ["concepts/leaf"]  # hub -> leaf
     assert body["backlinks"] == ["concepts/ref"]  # ref -> hub
+
+
+# --- review-fix regressions --------------------------------------------------
+
+
+def test_delete_page_leaves_excluded_docs_untouched(monkeypatch, kb_dir):
+    # A concept referenced by a generated doc (AGENTS.md, in lint's _EXCLUDED_FILES)
+    # must be neither listed as a backlink nor rewritten — deleting it leaves
+    # AGENTS.md byte-for-byte, while a real concept backlink is still demoted.
+    wiki = kb_dir / "wiki"
+    (wiki / "concepts" / "attention.md").write_text("# Attention\n", encoding="utf-8")
+    (wiki / "concepts" / "bar.md").write_text("see [[concepts/attention]]\n", encoding="utf-8")
+    agents = wiki / "AGENTS.md"
+    agents.write_text("Use [[wikilink]] e.g. [[concepts/attention]].\n", encoding="utf-8")
+    agents_before = agents.read_text(encoding="utf-8")
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    r = client.post(
+        "/api/v1/page/delete",
+        json={"kb": kb, "path": "concepts/attention", "dry_run": True},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    assert "concepts/bar" in r.json()["backlinks"]
+    assert all("AGENTS" not in b for b in r.json()["backlinks"])  # excluded doc absent
+
+    r = client.post(
+        "/api/v1/page/delete", json={"kb": kb, "path": "concepts/attention"}, headers=_auth()
+    )
+    assert r.status_code == 200
+    assert agents.read_text(encoding="utf-8") == agents_before  # generated doc untouched
+    assert "[[concepts/attention]]" not in (wiki / "concepts" / "bar.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_edit_page_keeps_body_starting_with_dashes(monkeypatch, kb_dir):
+    # A body that legitimately opens with a '---' block must NOT be mistaken for
+    # frontmatter and dropped; the code-managed frontmatter is still preserved.
+    wiki = kb_dir / "wiki"
+    (wiki / "concepts" / "foo.md").write_text("---\ntype: Concept\n---\n# Foo\n", encoding="utf-8")
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    body = "---\nkey: value\n---\nReal content below the fence.\n"
+    r = client.put(
+        "/api/v1/page", json={"kb": kb, "path": "concepts/foo", "content": body}, headers=_auth()
+    )
+    assert r.status_code == 200, r.text
+    saved = (wiki / "concepts" / "foo.md").read_text(encoding="utf-8")
+    assert "type: Concept" in saved  # managed frontmatter preserved
+    assert "key: value" in saved  # the user's leading '---' block was NOT eaten
+    assert "Real content below the fence." in saved
+
+
+def test_delete_kb_ghost_entry_unregisters_via_endpoint(monkeypatch, tmp_path):
+    # A registered name whose directory was removed by hand (a ghost) must be
+    # cleanable via the endpoint (config.delete_kb tolerates it).
+    from openkb.config import register_kb_alias, registered_kbs
+
+    _isolate_global(monkeypatch, tmp_path)
+    ghost = tmp_path / "ghost-kb"  # registered but never created on disk
+    register_kb_alias("ghost-kb", ghost)
+    assert any(n == "ghost-kb" for n, _ in registered_kbs())
+    client = _client(monkeypatch)
+    r = client.post(
+        "/api/v1/kb/delete", json={"kb": "ghost-kb", "confirm_name": "ghost-kb"}, headers=_auth()
+    )
+    assert r.status_code == 200, r.text
+    assert all(n != "ghost-kb" for n, _ in registered_kbs())  # registry cleaned up

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3316,3 +3316,45 @@ def test_summary_page_is_editable_but_not_deletable(monkeypatch, kb_dir):
         "/api/v1/page/delete", json={"kb": kb, "path": "summaries/doc"}, headers=_auth()
     )
     assert r.status_code == 400
+
+
+def test_delete_kb_maps_oserror_to_clean_500(monkeypatch, tmp_path):
+    # An rmtree failure (permission/disk, or a still-open lock file on Windows)
+    # surfaces as a clean 500 with a message, not an uncaught stack trace.
+    from openkb.config import register_kb_alias
+
+    _isolate_global(monkeypatch, tmp_path)
+    kb = _make_kb(tmp_path / "mykb")
+    register_kb_alias("boom-kb", kb)
+
+    def boom(_):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr("openkb.api_kbs_router.delete_kb", boom)
+    client = _client(monkeypatch)
+    r = client.post(
+        "/api/v1/kb/delete", json={"kb": "boom-kb", "confirm_name": "boom-kb"}, headers=_auth()
+    )
+    assert r.status_code == 500
+    assert "Failed to delete" in r.json()["detail"]
+
+
+def test_delete_kb_filenotfound_is_idempotent(monkeypatch, tmp_path):
+    # A concurrent delete that already removed the tree (FileNotFoundError) is a
+    # success, not a 500 — deleting an already-gone KB is idempotent.
+    from openkb.config import register_kb_alias
+
+    _isolate_global(monkeypatch, tmp_path)
+    kb = _make_kb(tmp_path / "mykb")
+    register_kb_alias("gone-kb", kb)
+
+    def already_gone(_):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr("openkb.api_kbs_router.delete_kb", already_gone)
+    client = _client(monkeypatch)
+    r = client.post(
+        "/api/v1/kb/delete", json={"kb": "gone-kb", "confirm_name": "gone-kb"}, headers=_auth()
+    )
+    assert r.status_code == 200
+    assert r.json()["deleted"] is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3030,3 +3030,66 @@ def test_kbs_listing_survives_dangling_summary_symlink(monkeypatch, tmp_path):
     assert set(items) == {"bad-kb", "good-kb"}
     # The bad KB lists with no last_compile rather than throwing out of the scan.
     assert items["bad-kb"]["last_compile"] is None
+
+
+# --- DELETE /api/v1/kb/delete ------------------------------------------------
+
+
+def _isolate_global(monkeypatch, tmp_path: Path) -> Path:
+    """Point the global registry at an isolated dir kept OUTSIDE any KB dir, so
+    physically deleting a KB never removes the test's own global.yaml."""
+    gdir = tmp_path / "gconf"
+    gdir.mkdir()
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_DIR", gdir)
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_PATH", gdir / "global.yaml")
+    return gdir
+
+
+def _make_kb(root: Path) -> Path:
+    (root / ".openkb").mkdir(parents=True)
+    (root / "wiki").mkdir(parents=True)
+    return root
+
+
+def test_delete_kb_removes_dir_and_unregisters(monkeypatch, tmp_path):
+    from openkb.config import register_kb_alias, registered_kbs
+
+    _isolate_global(monkeypatch, tmp_path)
+    kb = _make_kb(tmp_path / "mykb")
+    register_kb_alias("gone-kb", kb)
+    assert any(n == "gone-kb" for n, _ in registered_kbs())
+
+    client = _client(monkeypatch)
+    name = _use_named_kb(monkeypatch, kb, name="gone-kb")
+    resp = client.post(
+        "/api/v1/kb/delete", json={"kb": name, "confirm_name": name}, headers=_auth()
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted"] is True
+    assert body["kb"] == "gone-kb"
+    assert not kb.exists()  # physically removed
+    assert all(n != "gone-kb" for n, _ in registered_kbs())  # unregistered
+
+
+def test_delete_kb_confirm_name_mismatch_is_rejected(monkeypatch, tmp_path):
+    kb = _make_kb(tmp_path / "mykb")
+    client = _client(monkeypatch)
+    name = _use_named_kb(monkeypatch, kb, name="keep-kb")
+    resp = client.post(
+        "/api/v1/kb/delete", json={"kb": name, "confirm_name": "WRONG"}, headers=_auth()
+    )
+    assert resp.status_code == 400
+    assert kb.exists()  # guard fires before resolve — nothing deleted
+
+
+def test_delete_kb_rejects_non_kb_target(monkeypatch, tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()  # a real directory, but not a KB (no .openkb/wiki)
+    client = _client(monkeypatch)
+    name = _use_named_kb(monkeypatch, plain, name="ghost-kb")
+    resp = client.post(
+        "/api/v1/kb/delete", json={"kb": name, "confirm_name": name}, headers=_auth()
+    )
+    assert resp.status_code == 400
+    assert plain.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -705,3 +705,40 @@ def test_resolve_kb_alias_degrades_on_non_mapping_global_yaml(
     monkeypatch.delenv("OPENKB_KB_ROOT", raising=False)
     (_isolated_global / "global.yaml").write_text("- a\n- b\n", encoding="utf-8")
     assert resolve_kb_alias("mykb") == (_isolated_global / "kbs" / "mykb").resolve()
+
+
+# --- delete_kb / unregister_kb -----------------------------------------------
+
+
+def test_delete_kb_physical_removal_and_unregister(_isolated_global, tmp_path):
+    from openkb.config import delete_kb, register_kb_alias, registered_kbs
+
+    kb = _make_kb_dir(tmp_path / "doomed")
+    register_kb_alias("doomed", kb)
+    assert any(n == "doomed" for n, _ in registered_kbs())
+
+    delete_kb(kb)
+    assert not kb.exists()  # directory physically removed
+    assert all(n != "doomed" for n, _ in registered_kbs())  # unregistered
+
+
+def test_delete_kb_refuses_non_kb_directory(_isolated_global, tmp_path):
+    from openkb.config import delete_kb
+
+    plain = tmp_path / "not-a-kb"
+    plain.mkdir()
+    (plain / "important.txt").write_text("keep me", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a knowledge base"):
+        delete_kb(plain)
+    assert (plain / "important.txt").exists()  # refused — nothing removed
+
+
+def test_delete_kb_tolerates_ghost_registry_entry(_isolated_global, tmp_path):
+    from openkb.config import delete_kb, register_kb_alias, registered_kbs
+
+    ghost = tmp_path / "ghost"  # registered but its directory never existed
+    register_kb_alias("ghost", ghost)
+    assert any(n == "ghost" for n, _ in registered_kbs())
+
+    delete_kb(ghost)  # no dir to rmtree → just unregister, no error
+    assert all(n != "ghost" for n, _ in registered_kbs())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -711,7 +711,8 @@ def test_resolve_kb_alias_degrades_on_non_mapping_global_yaml(
 
 
 def test_delete_kb_physical_removal_and_unregister(_isolated_global, tmp_path):
-    from openkb.config import delete_kb, register_kb_alias, registered_kbs
+    from openkb.config import register_kb_alias, registered_kbs
+    from openkb.kb_admin import delete_kb
 
     kb = _make_kb_dir(tmp_path / "doomed")
     register_kb_alias("doomed", kb)
@@ -723,7 +724,7 @@ def test_delete_kb_physical_removal_and_unregister(_isolated_global, tmp_path):
 
 
 def test_delete_kb_refuses_non_kb_directory(_isolated_global, tmp_path):
-    from openkb.config import delete_kb
+    from openkb.kb_admin import delete_kb
 
     plain = tmp_path / "not-a-kb"
     plain.mkdir()
@@ -734,7 +735,8 @@ def test_delete_kb_refuses_non_kb_directory(_isolated_global, tmp_path):
 
 
 def test_delete_kb_tolerates_ghost_registry_entry(_isolated_global, tmp_path):
-    from openkb.config import delete_kb, register_kb_alias, registered_kbs
+    from openkb.config import register_kb_alias, registered_kbs
+    from openkb.kb_admin import delete_kb
 
     ghost = tmp_path / "ghost"  # registered but its directory never existed
     register_kb_alias("ghost", ghost)


### PR DESCRIPTION
Completes the Knowledge Workbench's CRUD story: before this, the web UI could only **read** the wiki (browse). This branch adds **delete a KB**, **delete a wiki page**, and **edit a wiki page** — backend endpoints + CLI + UI — reusing the existing lint/mutation machinery so references degrade cleanly.

## Backend

- **`POST /api/v1/kb/delete`** (+ `openkb delete-kb NAME`): physical, irreversible KB deletion with a type-the-name confirmation (re-checked server-side). Unregisters from the global registry; tolerates a ghost entry (registry row whose directory was removed by hand). `delete_kb`/`unregister_kb` live in a new `openkb/kb_admin.py` (keeps `config.py` under the line gate).
- **`POST /api/v1/page/delete`**: delete a concept/entity page. `dry_run` first returns the backlink pages whose inbound `[[links]]` will be demoted to plain text (the impact preview); execute removes the page (under the KB ingest lock), strips its `index.md` entry, and demotes the now-dangling inbound links.
- **`PUT /api/v1/page`**: edit a concept/entity **or summary** page's body. The code-managed OKF frontmatter is preserved; dead `[[links]]` typed by the user are demoted to plain text on save (returned so the UI can warn).
- **`POST /api/v1/page/links`**: outbound + inbound links for the edit panel.
- **`GET /api/v1/list`** already surfaces entities; the page endpoints validate refs to `concepts/`/`entities/` (delete) and `+summaries/` (edit) only — traversal-safe.

## Frontend

- **Delete KB**: a Danger Zone in the KB settings sheet (type-the-name confirm); on success it refreshes the sidebar (`openkb:reload-kbs`) and returns to the KB list.
- **Delete / Edit page**: in the reader header — Delete (concept/entity) shows the dry-run impact then confirms; Edit (concept/entity/summary) opens a body editor with an out/in-links panel, a "recompile may overwrite" note, and a demoted-links warning on save. Summaries are editable but **not** independently deletable (a summary is removed by deleting its source document).

## Model

| Page type | Edit | Delete |
|---|---|---|
| concept / entity | ✅ | ✅ (impact preview) |
| summary | ✅ | ❌ — delete its source document |
| index / reports | ❌ | ❌ (generated) |

## Review

Two `/code-review` passes were run against this branch (`max`, then `xhigh`); all correctness/concurrency findings were fixed — read-modify-write moved inside the KB ingest lock, page deletion no longer touches `AGENTS.md`/`SCHEMA.md`/`log.md`, edit no longer mis-eats a `---`-leading body, cross-platform `delete_kb` (no lock held during `rmtree`), endpoint `OSError` handling, and a KB-registry test-isolation bug.

## Verification

Backend `pytest` **1237 passed**, `mypy`/`ruff` clean, frontend `npm run build` green (i18n guard: zh/en key sets identical). Manually exercised on a running `openkb-web` — delete KB, delete/edit concept/entity, edit summary.

Claude-Session: https://claude.ai/code/session_01XMxbhmAkxxVV8CFWCZDBaG
