### PR TITLE
feat(web): read a document's converted source text in the Documents pane (#197)

### DIFF
--- a/frontend/src/api/wiki.ts
+++ b/frontend/src/api/wiki.ts
@@ -53,6 +53,25 @@ export function getKbInventory(kb: string): Promise<KbInventory> {
   return apiFetch<KbInventory>("/api/v1/list", { body: { kb } })
 }
 
+/** A document's ingested source text (`/api/v1/document/source`). This is the
+ *  READ-ONLY conversion output stored under `wiki/sources/` — short docs are a
+ *  single Markdown string; long docs are per-page text concatenated into one.
+ *  `pages` is the page count for long docs and null for short. */
+export interface DocumentSource {
+  hash: string
+  name: string
+  doc_name: string
+  type: string
+  format: string
+  content: string
+  pages: number | null
+}
+
+/** Fetch a document's converted full text by its `hash` (the /list identifier). */
+export function getDocumentSource(kb: string, hash: string): Promise<DocumentSource> {
+  return apiFetch<DocumentSource>("/api/v1/document/source", { body: { kb, hash } })
+}
+
 /** Result of `/api/v1/page/delete`. `backlinks` are 'section/stem' refs whose
  *  inbound [[links]] will be / were demoted to plain text. */
 export interface PageDeleteResult {

--- a/frontend/src/locales/en/kb.json
+++ b/frontend/src/locales/en/kb.json
@@ -34,6 +34,16 @@
     "empty": "No documents yet · they compile into the KB automatically after upload",
     "pages_one": "{{count}} page",
     "pages_other": "{{count}} pages",
+    "reader": {
+      "open": "Read document",
+      "title": "Document",
+      "readonly": "Read-only",
+      "close": "Close",
+      "loading": "Loading document…",
+      "error": "Couldn't load document: {{error}}",
+      "retry": "Retry",
+      "emptyDoc": "This document has no extracted text."
+    },
     "delete": {
       "action": "Delete document",
       "prompt": "Delete?",

--- a/frontend/src/locales/zh/kb.json
+++ b/frontend/src/locales/zh/kb.json
@@ -34,6 +34,16 @@
     "empty": "暂无文档 · 上传后会自动编译进知识库",
     "pages_one": "{{count}} 页",
     "pages_other": "{{count}} 页",
+    "reader": {
+      "open": "查看文档",
+      "title": "文档",
+      "readonly": "只读",
+      "close": "关闭",
+      "loading": "正在加载文档…",
+      "error": "加载文档失败：{{error}}",
+      "retry": "重试",
+      "emptyDoc": "该文档没有可显示的正文。"
+    },
     "delete": {
       "action": "删除文档",
       "prompt": "确认删除？",

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
-import { motion, useReducedMotion } from 'motion/react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { FileText, Link2, Loader2, Pencil, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle, X, BookOpen } from 'lucide-react'
 import { toast } from 'sonner'
 import { deletePage, editPage, getDocumentSource, getKbInventory, getPage, getPageLinks, type DocumentSource, type KbInventory, type WikiDocument } from '@/api/wiki'
@@ -845,176 +846,160 @@ function UploadStatusIcon({ status }: { status: UploadStatus }) {
   }
 }
 
-/** Documents section: upload dropzone + uploaded-document list + remote
- *  connector cards. Moved verbatim from the old Sources tab body. */
-/** Read-only slide-out drawer showing a document's converted full text.
+/** Read-only slide-out reader for a document's converted source text.
  *
- * Documents are ingestion artifacts ("Do not modify directly"), so this is a
- * viewer only — no edit affordance (unlike the wiki-page Reader). Content is
- * fetched by hash and cached; the memoized body means re-opening a document is
- * instant and the parsed Markdown is not recomputed. A wide panel + narrow
- * measure keeps long docs (many pages concatenated) readable; the body scrolls
- * independently and native find-in-page works because the whole document is
- * rendered (not virtualized). */
+ * Presentational: the parent (DocumentsPane) owns the fetch, per-hash cache,
+ * and memoized body, so this can unmount on close (Radix Dialog) yet re-open
+ * instantly with un-reparsed Markdown. Radix Dialog supplies the modal a11y —
+ * focus trap, initial + return focus, Escape, and background inert — and
+ * `shown` keeps the last doc rendered through the exit animation (doc goes null
+ * on close). The body scrolls independently and native find-in-page works (the
+ * whole document is rendered, not virtualized). Documents are read-only
+ * ingestion artifacts, so there is no edit affordance. */
 function DocumentReaderDrawer({
-  kb,
   doc,
+  body,
+  loading,
+  error,
+  isEmpty,
+  onRetry,
   onClose,
 }: {
-  kb: string
   doc: WikiDocument | null
+  body: ReactNode
+  loading: boolean
+  error: string | null
+  isEmpty: boolean
+  onRetry: () => void
   onClose: () => void
 }) {
   const { t } = useTranslation(['kb', 'common'])
-  const [source, setSource] = useState<DocumentSource | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [reloadSeq, setReloadSeq] = useState(0)
-  // Per-hash cache returns the SAME DocumentSource object on re-open, so the
-  // memoized body below is not re-parsed.
-  const cacheRef = useRef<Map<string, DocumentSource>>(new Map())
+  const reduce = useReducedMotion()
+  // The control that opened the drawer, captured before Radix moves focus in,
+  // so focus returns to it on close (mirrors KbSettingsSheet).
+  const openerRef = useRef<HTMLElement | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const open = doc !== null
-  const hash = doc?.hash ?? null
-
+  // Keep the last doc visible during the exit animation (doc is null once closed).
+  const [shown, setShown] = useState<WikiDocument | null>(doc)
   useEffect(() => {
-    if (!hash) return
-    const cached = cacheRef.current.get(hash)
-    if (cached) {
-      setSource(cached)
-      setError(null)
-      setLoading(false)
-      return
-    }
-    let cancelled = false
-    setLoading(true)
-    setSource(null)
-    setError(null)
-    getDocumentSource(kb, hash)
-      .then((r) => {
-        if (cancelled) return
-        cacheRef.current.set(hash, r)
-        setSource(r)
-      })
-      .catch((e) => {
-        if (!cancelled) setError(errMsg(e))
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [kb, hash, reloadSeq])
-
-  // ESC closes; listener attached only while open.
-  useEffect(() => {
-    if (!open) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open, onClose])
-
+    if (doc) setShown(doc)
+  }, [doc])
   // Reset scroll to top when switching documents.
   useEffect(() => {
-    scrollRef.current?.scrollTo(0, 0)
-  }, [hash])
-
-  // Parse Markdown once per fetched source (cache yields a stable object ref).
-  const body = useMemo(
-    () => (source ? <MarkdownView source={source.content} /> : null),
-    [source],
-  )
-  const hasContent = source != null && source.content.trim().length > 0
+    if (doc) scrollRef.current?.scrollTo(0, 0)
+  }, [doc])
 
   return (
-    <>
-      <div
-        onClick={onClose}
-        aria-hidden
-        className={cn(
-          'fixed inset-0 z-40 bg-black/30 transition-opacity duration-200',
-          open ? 'opacity-100' : 'pointer-events-none opacity-0',
-        )}
-      />
-      <aside
-        role="dialog"
-        aria-modal={open}
-        aria-label={doc?.name ?? t('kb:docs.reader.title')}
-        // Closed = off-screen but still in the DOM (for the slide transition);
-        // `inert` drops it from the a11y tree and tab order so the hidden panel
-        // is never focusable/announced.
-        inert={!open}
-        className={cn(
-          'fixed inset-y-0 right-0 z-50 flex h-full w-[min(70vw,900px)] max-w-full flex-col',
-          'glass border-l border-[hsl(var(--glass-border))] shadow-glass-lg rounded-l-apple-lg',
-          'transition-transform duration-300 ease-out',
-          open ? 'translate-x-0' : 'translate-x-full',
-        )}
-      >
-        <div className="flex shrink-0 items-center gap-3 border-b border-[hsl(var(--glass-border))] px-5 py-3">
-          <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-[hsl(var(--glass-border))] bg-muted">
-            <FileText className="h-4 w-4 text-muted-foreground" />
-          </span>
-          <div className="min-w-0">
-            <div className="truncate text-[13.5px] font-medium text-foreground">{doc?.name}</div>
-            <div className="mt-0.5 flex items-center gap-2 text-[12px] text-muted-foreground">
-              {doc?.display_type && <span>{doc.display_type}</span>}
-              {doc?.pages != null && <span>· {t('kb:docs.pages', { count: doc.pages })}</span>}
-              <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-px text-[11px]">
-                <BookOpen className="h-3 w-3" />
-                {t('kb:docs.reader.readonly')}
-              </span>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            title={t('kb:docs.reader.close')}
-            aria-label={t('kb:docs.reader.close')}
-            className="ml-auto grid h-8 w-8 shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <AnimatePresence>
+        {open && (
+          <Dialog.Portal forceMount>
+            <Dialog.Overlay asChild forceMount>
+              <motion.div
+                className="fixed inset-0 z-40 bg-black/30"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={reduce ? { duration: 0.12 } : { duration: 0.2 }}
+                onClick={onClose}
+              />
+            </Dialog.Overlay>
+            <Dialog.Content
+              asChild
+              forceMount
+              aria-modal="true"
+              aria-describedby={undefined}
+              onOpenAutoFocus={() => {
+                openerRef.current = document.activeElement as HTMLElement | null
+              }}
+              onCloseAutoFocus={(e) => {
+                e.preventDefault()
+                openerRef.current?.focus()
+              }}
+            >
+              <motion.aside
+                className="fixed inset-y-0 right-0 z-50 flex w-[min(70vw,900px)] max-w-full flex-col glass border-l border-[hsl(var(--glass-border))] shadow-glass-lg rounded-l-apple-lg"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, x: 24 }}
+                animate={reduce ? { opacity: 1 } : { opacity: 1, x: 0 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, x: 24 }}
+                transition={reduce ? { duration: 0.12 } : { type: 'spring', bounce: 0, duration: 0.3 }}
+              >
+                <div className="flex shrink-0 items-center gap-3 border-b border-[hsl(var(--glass-border))] px-5 py-3">
+                  <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-[hsl(var(--glass-border))] bg-muted">
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                  </span>
+                  <div className="min-w-0">
+                    <Dialog.Title asChild>
+                      <div className="truncate text-[13.5px] font-medium text-foreground">{shown?.name}</div>
+                    </Dialog.Title>
+                    <div className="mt-0.5 flex items-center gap-2 text-[12px] text-muted-foreground">
+                      {shown?.display_type && <span>{shown.display_type}</span>}
+                      {shown?.pages != null && <span>· {t('kb:docs.pages', { count: shown.pages })}</span>}
+                      <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-px text-[11px]">
+                        <BookOpen className="h-3 w-3" />
+                        {t('kb:docs.reader.readonly')}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={onClose}
+                    title={t('kb:docs.reader.close')}
+                    aria-label={t('kb:docs.reader.close')}
+                    className="ml-auto grid h-8 w-8 shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
 
-        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
-          <div className="mx-auto max-w-[72ch] px-6 py-6">
-            {loading && (
-              <div className="flex items-center justify-center gap-2 py-16 text-[13px] text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t('kb:docs.reader.loading')}
-              </div>
-            )}
-            {error && (
-              <div className="py-16 text-center">
-                <p className="text-[13px] text-red-600 dark:text-red-400">
-                  {t('kb:docs.reader.error', { error })}
-                </p>
-                <button
-                  onClick={() => setReloadSeq((s) => s + 1)}
-                  className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-lg border border-[hsl(var(--glass-border))] px-3 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent"
-                >
-                  <RefreshCw className="h-3 w-3" />
-                  {t('kb:docs.reader.retry')}
-                </button>
-              </div>
-            )}
-            {!loading && !error && !hasContent && source != null && (
-              <div className="py-16 text-center text-[13px] text-muted-foreground">
-                {t('kb:docs.reader.emptyDoc')}
-              </div>
-            )}
-            {!loading && !error && hasContent && (
-              <div className="text-[14px] leading-relaxed text-foreground">{body}</div>
-            )}
-          </div>
-        </div>
-      </aside>
-    </>
+                <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                  <div className="mx-auto max-w-[72ch] px-6 py-6">
+                    {loading && (
+                      <div className="flex items-center justify-center gap-2 py-16 text-[13px] text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        {t('kb:docs.reader.loading')}
+                      </div>
+                    )}
+                    {error && (
+                      <div className="py-16 text-center">
+                        <p className="text-[13px] text-red-600 dark:text-red-400">
+                          {t('kb:docs.reader.error', { error })}
+                        </p>
+                        <button
+                          onClick={onRetry}
+                          className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-lg border border-[hsl(var(--glass-border))] px-3 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent"
+                        >
+                          <RefreshCw className="h-3 w-3" />
+                          {t('kb:docs.reader.retry')}
+                        </button>
+                      </div>
+                    )}
+                    {!loading && !error && isEmpty && (
+                      <div className="py-16 text-center text-[13px] text-muted-foreground">
+                        {t('kb:docs.reader.emptyDoc')}
+                      </div>
+                    )}
+                    {!loading && !error && !isEmpty && (
+                      <div className="text-[14px] leading-relaxed text-foreground">{body}</div>
+                    )}
+                  </div>
+                </div>
+              </motion.aside>
+            </Dialog.Content>
+          </Dialog.Portal>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
   )
 }
+
+/** Documents section: upload dropzone + uploaded-document list + remote
+ *  connector cards. Moved verbatim from the old Sources tab body. */
 
 function DocumentsPane({
   kb,
@@ -1046,8 +1031,64 @@ function DocumentsPane({
   // `deletingName` is the row whose remove request is in flight.
   const [confirmName, setConfirmName] = useState<string | null>(null)
   const [deletingName, setDeletingName] = useState<string | null>(null)
-  // The document whose read-only source drawer is open (null = closed).
+  // Document reader drawer. State lives HERE (not in the drawer, which unmounts
+  // on close via Radix) so the per-hash cache and memoized body survive
+  // open/close and re-opening is instant without re-parsing Markdown.
   const [openDoc, setOpenDoc] = useState<WikiDocument | null>(null)
+  const [docSource, setDocSource] = useState<DocumentSource | null>(null)
+  const [docLoading, setDocLoading] = useState(false)
+  const [docError, setDocError] = useState<string | null>(null)
+  const [docReloadSeq, setDocReloadSeq] = useState(0)
+  const sourceCache = useRef<Map<string, DocumentSource>>(new Map())
+  const closeDrawer = useCallback(() => setOpenDoc(null), [])
+  const openHash = openDoc?.hash ?? null
+
+  // Drop cached content when the inventory changes (a recompile can rewrite a
+  // document's converted text under the same raw hash), so the next open
+  // refetches instead of serving stale text.
+  useEffect(() => {
+    sourceCache.current.clear()
+  }, [documents])
+
+  // Fetch the open document's source (per-hash cache; retry via docReloadSeq).
+  useEffect(() => {
+    if (!openHash) return
+    const cached = sourceCache.current.get(openHash)
+    if (cached) {
+      setDocSource(cached)
+      setDocError(null)
+      setDocLoading(false)
+      return
+    }
+    let cancelled = false
+    setDocLoading(true)
+    setDocSource(null)
+    setDocError(null)
+    getDocumentSource(kb, openHash)
+      .then((r) => {
+        if (cancelled) return
+        sourceCache.current.set(openHash, r)
+        setDocSource(r)
+      })
+      .catch((e) => {
+        if (!cancelled) setDocError(errMsg(e))
+      })
+      .finally(() => {
+        if (!cancelled) setDocLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [kb, openHash, docReloadSeq])
+
+  // Parse Markdown once per fetched source (stable cache ref → no re-parse).
+  const readerBody = useMemo(
+    () =>
+      docSource && docSource.content.trim() ? <MarkdownView source={docSource.content} /> : null,
+    [docSource],
+  )
+  const readerEmpty = docSource != null && docSource.content.trim().length === 0
+
   const handleDelete = async (name: string) => {
     setDeletingName(name)
     try {
@@ -1156,39 +1197,35 @@ function DocumentsPane({
           {documents.map((d, i) => (
             <div
               key={d.hash || d.name || i}
-              role="button"
-              tabIndex={0}
-              onClick={() => setOpenDoc(d)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  setOpenDoc(d)
-                }
-              }}
-              title={t('kb:docs.reader.open')}
               className={cn(
                 'anim-fade-up rounded-2xl border border-[hsl(var(--glass-border))] glass-2 px-4 py-3 flex items-center gap-3',
-                'cursor-pointer transition-colors hover:border-foreground/20 hover:bg-accent/40',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/50',
+                'transition-colors hover:border-foreground/20',
                 `anim-d${Math.min(i + 1, 4)}`,
               )}
             >
-              <span className="w-9 h-9 rounded-xl bg-muted border border-[hsl(var(--glass-border))] grid place-items-center shrink-0">
-                <FileText className="w-4 h-4 text-muted-foreground" />
-              </span>
-              <div className="min-w-0">
-                <div className="text-[13.5px] font-medium text-foreground truncate">{d.name}</div>
-                <div className="text-[12px] text-muted-foreground mt-0.5">
-                  {d.display_type}
-                  {d.pages != null && <> · {t('kb:docs.pages', { count: d.pages })}</>}
-                </div>
-              </div>
-              {/* Trailing controls (hash chip + delete). stopPropagation so a
-                  click here never opens the reader drawer. */}
-              <div
-                className="ml-auto flex items-center gap-2 shrink-0"
-                onClick={(e) => e.stopPropagation()}
+              {/* The open-reader target is a real <button> covering the icon +
+                  title; the delete control is a SIBLING (not nested), so keyboard
+                  activation of delete never bubbles into opening the reader and
+                  no event-propagation guard is needed. */}
+              <button
+                type="button"
+                onClick={() => setOpenDoc(d)}
+                title={t('kb:docs.reader.open')}
+                className="flex min-w-0 flex-1 items-center gap-3 text-left rounded-xl cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/50"
               >
+                <span className="w-9 h-9 rounded-xl bg-muted border border-[hsl(var(--glass-border))] grid place-items-center shrink-0">
+                  <FileText className="w-4 h-4 text-muted-foreground" />
+                </span>
+                <div className="min-w-0">
+                  <div className="text-[13.5px] font-medium text-foreground truncate">{d.name}</div>
+                  <div className="text-[12px] text-muted-foreground mt-0.5">
+                    {d.display_type}
+                    {d.pages != null && <> · {t('kb:docs.pages', { count: d.pages })}</>}
+                  </div>
+                </div>
+              </button>
+              {/* Trailing controls: hash chip + delete, siblings of the open button. */}
+              <div className="flex items-center gap-2 shrink-0">
                 {d.hash && (
                   <span className="font-mono2 text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">
                     {d.hash.slice(0, 8)}
@@ -1239,7 +1276,15 @@ function DocumentsPane({
         </div>
       </div>
     </div>
-    <DocumentReaderDrawer kb={kb} doc={openDoc} onClose={() => setOpenDoc(null)} />
+    <DocumentReaderDrawer
+      doc={openDoc}
+      body={readerBody}
+      loading={docLoading}
+      error={docError}
+      isEmpty={readerEmpty}
+      onRetry={() => setDocReloadSeq((s) => s + 1)}
+      onClose={closeDrawer}
+    />
     </>
   )
 }

--- a/frontend/src/pages/KbDetail.tsx
+++ b/frontend/src/pages/KbDetail.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } fro
 import { useNavigate, useParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { motion, useReducedMotion } from 'motion/react'
-import { FileText, Link2, Loader2, Pencil, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle } from 'lucide-react'
+import { FileText, Link2, Loader2, Pencil, Upload, RefreshCw, Settings2, Trash2, Circle, CheckCircle2, CircleSlash2, XCircle, X, BookOpen } from 'lucide-react'
 import { toast } from 'sonner'
-import { deletePage, editPage, getKbInventory, getPage, getPageLinks, type KbInventory, type WikiDocument } from '@/api/wiki'
+import { deletePage, editPage, getDocumentSource, getKbInventory, getPage, getPageLinks, type DocumentSource, type KbInventory, type WikiDocument } from '@/api/wiki'
 import { streamUpload, removeDocument, type AddResult } from '@/api/maintenance'
 import { ApiError } from '@/api/client'
 import MarkdownView from '@/components/MarkdownView'
@@ -444,6 +444,7 @@ export default function KbDetail() {
           />
         ) : section === 'documents' ? (
           <DocumentsPane
+            kb={id}
             documents={documents}
             invError={invError}
             uploading={uploading}
@@ -846,7 +847,177 @@ function UploadStatusIcon({ status }: { status: UploadStatus }) {
 
 /** Documents section: upload dropzone + uploaded-document list + remote
  *  connector cards. Moved verbatim from the old Sources tab body. */
+/** Read-only slide-out drawer showing a document's converted full text.
+ *
+ * Documents are ingestion artifacts ("Do not modify directly"), so this is a
+ * viewer only — no edit affordance (unlike the wiki-page Reader). Content is
+ * fetched by hash and cached; the memoized body means re-opening a document is
+ * instant and the parsed Markdown is not recomputed. A wide panel + narrow
+ * measure keeps long docs (many pages concatenated) readable; the body scrolls
+ * independently and native find-in-page works because the whole document is
+ * rendered (not virtualized). */
+function DocumentReaderDrawer({
+  kb,
+  doc,
+  onClose,
+}: {
+  kb: string
+  doc: WikiDocument | null
+  onClose: () => void
+}) {
+  const { t } = useTranslation(['kb', 'common'])
+  const [source, setSource] = useState<DocumentSource | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [reloadSeq, setReloadSeq] = useState(0)
+  // Per-hash cache returns the SAME DocumentSource object on re-open, so the
+  // memoized body below is not re-parsed.
+  const cacheRef = useRef<Map<string, DocumentSource>>(new Map())
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const open = doc !== null
+  const hash = doc?.hash ?? null
+
+  useEffect(() => {
+    if (!hash) return
+    const cached = cacheRef.current.get(hash)
+    if (cached) {
+      setSource(cached)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setSource(null)
+    setError(null)
+    getDocumentSource(kb, hash)
+      .then((r) => {
+        if (cancelled) return
+        cacheRef.current.set(hash, r)
+        setSource(r)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(errMsg(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [kb, hash, reloadSeq])
+
+  // ESC closes; listener attached only while open.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  // Reset scroll to top when switching documents.
+  useEffect(() => {
+    scrollRef.current?.scrollTo(0, 0)
+  }, [hash])
+
+  // Parse Markdown once per fetched source (cache yields a stable object ref).
+  const body = useMemo(
+    () => (source ? <MarkdownView source={source.content} /> : null),
+    [source],
+  )
+  const hasContent = source != null && source.content.trim().length > 0
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        aria-hidden
+        className={cn(
+          'fixed inset-0 z-40 bg-black/30 transition-opacity duration-200',
+          open ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+      />
+      <aside
+        role="dialog"
+        aria-modal={open}
+        aria-label={doc?.name ?? t('kb:docs.reader.title')}
+        // Closed = off-screen but still in the DOM (for the slide transition);
+        // `inert` drops it from the a11y tree and tab order so the hidden panel
+        // is never focusable/announced.
+        inert={!open}
+        className={cn(
+          'fixed inset-y-0 right-0 z-50 flex h-full w-[min(70vw,900px)] max-w-full flex-col',
+          'glass border-l border-[hsl(var(--glass-border))] shadow-glass-lg rounded-l-apple-lg',
+          'transition-transform duration-300 ease-out',
+          open ? 'translate-x-0' : 'translate-x-full',
+        )}
+      >
+        <div className="flex shrink-0 items-center gap-3 border-b border-[hsl(var(--glass-border))] px-5 py-3">
+          <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-[hsl(var(--glass-border))] bg-muted">
+            <FileText className="h-4 w-4 text-muted-foreground" />
+          </span>
+          <div className="min-w-0">
+            <div className="truncate text-[13.5px] font-medium text-foreground">{doc?.name}</div>
+            <div className="mt-0.5 flex items-center gap-2 text-[12px] text-muted-foreground">
+              {doc?.display_type && <span>{doc.display_type}</span>}
+              {doc?.pages != null && <span>· {t('kb:docs.pages', { count: doc.pages })}</span>}
+              <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-px text-[11px]">
+                <BookOpen className="h-3 w-3" />
+                {t('kb:docs.reader.readonly')}
+              </span>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            title={t('kb:docs.reader.close')}
+            aria-label={t('kb:docs.reader.close')}
+            className="ml-auto grid h-8 w-8 shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
+          <div className="mx-auto max-w-[72ch] px-6 py-6">
+            {loading && (
+              <div className="flex items-center justify-center gap-2 py-16 text-[13px] text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('kb:docs.reader.loading')}
+              </div>
+            )}
+            {error && (
+              <div className="py-16 text-center">
+                <p className="text-[13px] text-red-600 dark:text-red-400">
+                  {t('kb:docs.reader.error', { error })}
+                </p>
+                <button
+                  onClick={() => setReloadSeq((s) => s + 1)}
+                  className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-lg border border-[hsl(var(--glass-border))] px-3 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent"
+                >
+                  <RefreshCw className="h-3 w-3" />
+                  {t('kb:docs.reader.retry')}
+                </button>
+              </div>
+            )}
+            {!loading && !error && !hasContent && source != null && (
+              <div className="py-16 text-center text-[13px] text-muted-foreground">
+                {t('kb:docs.reader.emptyDoc')}
+              </div>
+            )}
+            {!loading && !error && hasContent && (
+              <div className="text-[14px] leading-relaxed text-foreground">{body}</div>
+            )}
+          </div>
+        </div>
+      </aside>
+    </>
+  )
+}
+
 function DocumentsPane({
+  kb,
   documents,
   invError,
   uploading,
@@ -858,6 +1029,7 @@ function DocumentsPane({
   onRefresh,
   onDelete,
 }: {
+  kb: string
   documents: WikiDocument[]
   invError: string | null
   uploading: boolean
@@ -874,6 +1046,8 @@ function DocumentsPane({
   // `deletingName` is the row whose remove request is in flight.
   const [confirmName, setConfirmName] = useState<string | null>(null)
   const [deletingName, setDeletingName] = useState<string | null>(null)
+  // The document whose read-only source drawer is open (null = closed).
+  const [openDoc, setOpenDoc] = useState<WikiDocument | null>(null)
   const handleDelete = async (name: string) => {
     setDeletingName(name)
     try {
@@ -884,6 +1058,7 @@ function DocumentsPane({
     }
   }
   return (
+    <>
     <div className="h-full overflow-y-auto scroll-edge-top">
       <div className="max-w-[1280px] mx-auto px-8 lg:px-12 py-6">
         <p className="text-[13px] text-muted-foreground">
@@ -981,8 +1156,20 @@ function DocumentsPane({
           {documents.map((d, i) => (
             <div
               key={d.hash || d.name || i}
+              role="button"
+              tabIndex={0}
+              onClick={() => setOpenDoc(d)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setOpenDoc(d)
+                }
+              }}
+              title={t('kb:docs.reader.open')}
               className={cn(
                 'anim-fade-up rounded-2xl border border-[hsl(var(--glass-border))] glass-2 px-4 py-3 flex items-center gap-3',
+                'cursor-pointer transition-colors hover:border-foreground/20 hover:bg-accent/40',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/50',
                 `anim-d${Math.min(i + 1, 4)}`,
               )}
             >
@@ -996,7 +1183,12 @@ function DocumentsPane({
                   {d.pages != null && <> · {t('kb:docs.pages', { count: d.pages })}</>}
                 </div>
               </div>
-              <div className="ml-auto flex items-center gap-2 shrink-0">
+              {/* Trailing controls (hash chip + delete). stopPropagation so a
+                  click here never opens the reader drawer. */}
+              <div
+                className="ml-auto flex items-center gap-2 shrink-0"
+                onClick={(e) => e.stopPropagation()}
+              >
                 {d.hash && (
                   <span className="font-mono2 text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">
                     {d.hash.slice(0, 8)}
@@ -1047,5 +1239,7 @@ function DocumentsPane({
         </div>
       </div>
     </div>
+    <DocumentReaderDrawer kb={kb} doc={openDoc} onClose={() => setOpenDoc(null)} />
+    </>
   )
 }

--- a/openkb/api.py
+++ b/openkb/api.py
@@ -31,6 +31,7 @@ from openkb.agent.chat_session import delete_session, list_sessions, load_sessio
 from openkb.agent.query import build_run_config_from_bundle, run_query
 from openkb.api_config import apply_kb_config_patch, read_kb_config
 from openkb.api_config_router import config_router
+from openkb.api_documents_router import documents_router
 from openkb.api_graph import graph_router
 from openkb.api_helpers import (
     _configure_cors,
@@ -167,6 +168,7 @@ def create_app() -> FastAPI:
     app.include_router(config_router)
     app.include_router(kbs_router)
     app.include_router(pages_router)
+    app.include_router(documents_router)
 
     @app.get("/api/v1/kbs", response_model=KbListResponse)
     async def list_kbs_endpoint(

--- a/openkb/api_documents_router.py
+++ b/openkb/api_documents_router.py
@@ -1,0 +1,30 @@
+"""Document REST endpoints: read a document's ingested source text.
+
+An APIRouter (sibling of api_pages_router.py) so api.py stays under the
+per-file line gate. Read-only: source documents are ``Do not modify directly``
+artifacts, so there is no edit/delete counterpart here (document removal lives
+on ``/api/v1/remove``).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from openkb.api_helpers import _resolve_kb, require_bearer_token
+from openkb.api_models import DocumentSourceRequest, DocumentSourceResponse
+from openkb.documents import read_document_source
+
+documents_router = APIRouter()
+
+
+@documents_router.post("/api/v1/document/source", response_model=DocumentSourceResponse)
+async def document_source_endpoint(
+    request: DocumentSourceRequest,
+    _: None = Depends(require_bearer_token),
+) -> DocumentSourceResponse:
+    kb_dir = _resolve_kb(request.kb)
+    result = await run_in_threadpool(read_document_source, kb_dir, request.hash)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Document source not found.")
+    return DocumentSourceResponse(**result)

--- a/openkb/api_documents_router.py
+++ b/openkb/api_documents_router.py
@@ -24,7 +24,12 @@ async def document_source_endpoint(
     _: None = Depends(require_bearer_token),
 ) -> DocumentSourceResponse:
     kb_dir = _resolve_kb(request.kb)
-    result = await run_in_threadpool(read_document_source, kb_dir, request.hash)
+    try:
+        result = await run_in_threadpool(read_document_source, kb_dir, request.hash)
+    except (OSError, ValueError) as exc:
+        # Corrupt/unreadable source file (bad JSON, unexpected shape, I/O error):
+        # a controlled 500 with a clean message beats an unhandled stack trace.
+        raise HTTPException(status_code=500, detail="Could not read document source.") from exc
     if result is None:
         raise HTTPException(status_code=404, detail="Document source not found.")
     return DocumentSourceResponse(**result)

--- a/openkb/api_models.py
+++ b/openkb/api_models.py
@@ -285,6 +285,24 @@ class PageResponse(BaseModel):
     content: str
 
 
+class DocumentSourceRequest(BaseModel):
+    kb: str = Field(..., min_length=1)
+    # SHA-256 hash key from /list — the unique document identifier (avoids
+    # ambiguity when two documents share a doc_name/filename stem).
+    hash: str = Field(..., min_length=1)
+
+
+class DocumentSourceResponse(BaseModel):
+    hash: str
+    name: str
+    doc_name: str
+    type: str
+    format: str
+    content: str
+    # Page count for long docs (per-page JSON); None for short (single .md).
+    pages: int | None = None
+
+
 class PageDeleteRequest(BaseModel):
     kb: str = Field(..., min_length=1)
     # A '<section>/<name>' wiki-page ref, e.g. "concepts/attention". Only

--- a/openkb/documents.py
+++ b/openkb/documents.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from openkb.cli import _LONG_DOC_TYPES
 from openkb.state import HashRegistry
 
 
@@ -20,9 +21,9 @@ def _render_pages(pages: list[dict[str, Any]]) -> str:
     """Join a long doc's per-page ``content`` into one Markdown string.
 
     Pages are separated by a thematic break (``---``) so the reader keeps
-    page boundaries; blank/missing page content is skipped.
+    page boundaries; blank/missing content and non-dict entries are skipped.
     """
-    parts = [str(page.get("content", "")).strip() for page in pages]
+    parts = [str(page.get("content", "")).strip() for page in pages if isinstance(page, dict)]
     return "\n\n---\n\n".join(part for part in parts if part)
 
 
@@ -39,8 +40,12 @@ def _resolve_source_file(kb_dir: Path, meta: dict, doc_name: str) -> Path | None
     stored = meta.get("source_path")
     if stored:
         candidates.append(kb_dir / stored)
-    candidates.append(sources_dir / f"{doc_name}.md")
-    candidates.append(sources_dir / f"{doc_name}.json")
+    # Long docs are stored as ``<doc_name>.json`` (per-page), short docs as
+    # ``<doc_name>.md``. Order the by-convention fallbacks by THIS doc's type so
+    # two docs sharing a doc_name (one short, one long) each resolve to their
+    # own file rather than whichever extension is tried first.
+    exts = (".json", ".md") if meta.get("type") in _LONG_DOC_TYPES else (".md", ".json")
+    candidates.extend(sources_dir / f"{doc_name}{ext}" for ext in exts)
     for candidate in candidates:
         try:
             resolved = candidate.resolve()
@@ -71,6 +76,8 @@ def read_document_source(kb_dir: Path, file_hash: str) -> dict[str, Any] | None:
 
     if source.suffix == ".json":
         pages = json.loads(source.read_text(encoding="utf-8"))
+        if not isinstance(pages, list):
+            raise ValueError(f"source JSON is not a page list: {source.name}")
         content = _render_pages(pages)
         page_count: int | None = len(pages)
     else:

--- a/openkb/documents.py
+++ b/openkb/documents.py
@@ -1,0 +1,88 @@
+"""Read the ingested source text for a document (REST ``/document/source``).
+
+The Documents pane lists ingested docs by hash; this resolves a hash to the
+converted full text under ``wiki/sources/``. Short docs are stored as
+``<doc_name>.md``; long docs as ``<doc_name>.json`` — a per-page
+``list[{page, content, images}]`` (see ``indexer._write_long_doc_artifacts``).
+Read-only: sources are ``Do not modify directly`` artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from openkb.state import HashRegistry
+
+
+def _render_pages(pages: list[dict[str, Any]]) -> str:
+    """Join a long doc's per-page ``content`` into one Markdown string.
+
+    Pages are separated by a thematic break (``---``) so the reader keeps
+    page boundaries; blank/missing page content is skipped.
+    """
+    parts = [str(page.get("content", "")).strip() for page in pages]
+    return "\n\n---\n\n".join(part for part in parts if part)
+
+
+def _resolve_source_file(kb_dir: Path, meta: dict, doc_name: str) -> Path | None:
+    """Resolve a document's source file, guarding against path traversal.
+
+    Prefers the registry's stored ``source_path`` (a KB-relative posix path),
+    then falls back to the ``wiki/sources/<doc_name>.{md,json}`` convention
+    (older entries carry no ``source_path``). Returns ``None`` when nothing
+    resolves to an existing file inside ``wiki/sources/``.
+    """
+    sources_dir = (kb_dir / "wiki" / "sources").resolve()
+    candidates: list[Path] = []
+    stored = meta.get("source_path")
+    if stored:
+        candidates.append(kb_dir / stored)
+    candidates.append(sources_dir / f"{doc_name}.md")
+    candidates.append(sources_dir / f"{doc_name}.json")
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved.is_file() and resolved.is_relative_to(sources_dir):
+            return resolved
+    return None
+
+
+def read_document_source(kb_dir: Path, file_hash: str) -> dict[str, Any] | None:
+    """Return the ingested source text for the document identified by hash.
+
+    Returns ``None`` when the hash is unknown OR its source file is missing,
+    so the caller maps both to a 404. ``format`` is always ``"markdown"``;
+    ``pages`` is the page count for long docs (per-page JSON) and ``None`` for
+    short docs.
+    """
+    registry = HashRegistry(kb_dir / ".openkb" / "hashes.json")
+    meta = registry.get(file_hash)
+    if meta is None:
+        return None
+
+    doc_name = meta.get("doc_name") or Path(meta.get("name", "")).stem
+    source = _resolve_source_file(kb_dir, meta, doc_name)
+    if source is None:
+        return None
+
+    if source.suffix == ".json":
+        pages = json.loads(source.read_text(encoding="utf-8"))
+        content = _render_pages(pages)
+        page_count: int | None = len(pages)
+    else:
+        content = source.read_text(encoding="utf-8")
+        page_count = None
+
+    return {
+        "hash": file_hash,
+        "name": meta.get("name", doc_name),
+        "doc_name": doc_name,
+        "type": meta.get("type", "unknown"),
+        "format": "markdown",
+        "content": content,
+        "pages": page_count,
+    }

--- a/tests/test_api_documents.py
+++ b/tests/test_api_documents.py
@@ -1,0 +1,130 @@
+"""Tests for the document-source REST endpoint (read a doc's ingested text).
+
+Mirrors the helpers/patterns in tests/test_api.py. The endpoint resolves a
+document hash to the converted full text under wiki/sources/ — short docs are
+``<doc_name>.md``; long docs are ``<doc_name>.json`` (a per-page
+``list[{page, content, images}]``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from openkb.api import create_app
+
+
+def _client(monkeypatch, token: str | None = "secret") -> TestClient:
+    if token is None:
+        monkeypatch.delenv("OPENKB_API_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("OPENKB_API_TOKEN", token)
+    return TestClient(create_app())
+
+
+def _auth(token: str = "secret") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _use_named_kb(monkeypatch, kb_dir, name: str = "test-kb") -> str:
+    def resolve(kb):
+        assert kb == name
+        return kb_dir
+
+    monkeypatch.setattr("openkb.api_helpers.resolve_kb_alias", resolve)
+    return name
+
+
+def _write_hashes(kb_dir, hashes: dict) -> None:
+    (kb_dir / ".openkb" / "hashes.json").write_text(json.dumps(hashes), encoding="utf-8")
+
+
+def test_document_source_short_md(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {"h1": {"name": "notes.md", "doc_name": "notes", "type": "md"}})
+    (kb_dir / "wiki" / "sources" / "notes.md").write_text("# Notes\n\nBody text.", encoding="utf-8")
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h1"}, headers=_auth())
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["content"] == "# Notes\n\nBody text."
+    assert payload["format"] == "markdown"
+    assert payload["pages"] is None
+    assert payload["name"] == "notes.md"
+
+
+def test_document_source_long_json_concatenates_pages(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {"h2": {"name": "paper.pdf", "doc_name": "paper", "type": "long_pdf"}})
+    pages = [
+        {"page": 1, "content": "Page one text.", "images": []},
+        {"page": 2, "content": "Page two text.", "images": []},
+    ]
+    (kb_dir / "wiki" / "sources" / "paper.json").write_text(json.dumps(pages), encoding="utf-8")
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h2"}, headers=_auth())
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "Page one text." in payload["content"]
+    assert "Page two text." in payload["content"]
+    # page boundaries preserved via a thematic break
+    assert "---" in payload["content"]
+    assert payload["pages"] == 2
+
+
+def test_document_source_prefers_stored_source_path(monkeypatch, kb_dir):
+    """When metadata carries source_path, it wins over the doc_name convention."""
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(
+        kb_dir,
+        {
+            "h3": {
+                "name": "report.txt",
+                "doc_name": "report",
+                "type": "md",
+                "source_path": "wiki/sources/report.md",
+            }
+        },
+    )
+    (kb_dir / "wiki" / "sources" / "report.md").write_text("Converted.", encoding="utf-8")
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h3"}, headers=_auth())
+
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "Converted."
+
+
+def test_document_source_unknown_hash_404(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {})
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "nope"}, headers=_auth())
+
+    assert resp.status_code == 404
+
+
+def test_document_source_missing_file_404(monkeypatch, kb_dir):
+    """Hash is known but the source file was deleted → 404, not a 500."""
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {"h4": {"name": "gone.md", "doc_name": "gone", "type": "md"}})
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h4"}, headers=_auth())
+
+    assert resp.status_code == 404
+
+
+def test_document_source_requires_auth(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    _use_named_kb(monkeypatch, kb_dir)
+
+    resp = client.post("/api/v1/document/source", json={"kb": "test-kb", "hash": "h1"})
+
+    assert resp.status_code == 401

--- a/tests/test_api_documents.py
+++ b/tests/test_api_documents.py
@@ -121,6 +121,64 @@ def test_document_source_missing_file_404(monkeypatch, kb_dir):
     assert resp.status_code == 404
 
 
+def test_document_source_doc_name_collision_resolves_by_type(monkeypatch, kb_dir):
+    """Two docs share a doc_name (short .md + long .json), and the long entry has
+    no source_path. Each hash must resolve to its OWN file via the type ordering,
+    not whichever extension is tried first."""
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(
+        kb_dir,
+        {
+            "short": {"name": "dup.md", "doc_name": "dup", "type": "md"},
+            "long": {"name": "dup.pdf", "doc_name": "dup", "type": "long_pdf"},
+        },
+    )
+    (kb_dir / "wiki" / "sources" / "dup.md").write_text("SHORT content", encoding="utf-8")
+    (kb_dir / "wiki" / "sources" / "dup.json").write_text(
+        json.dumps([{"page": 1, "content": "LONG page one", "images": []}]), encoding="utf-8"
+    )
+
+    long_resp = client.post(
+        "/api/v1/document/source", json={"kb": kb, "hash": "long"}, headers=_auth()
+    )
+    assert long_resp.status_code == 200
+    assert "LONG page one" in long_resp.json()["content"]
+    assert "SHORT content" not in long_resp.json()["content"]
+    assert long_resp.json()["pages"] == 1
+
+    short_resp = client.post(
+        "/api/v1/document/source", json={"kb": kb, "hash": "short"}, headers=_auth()
+    )
+    assert short_resp.json()["content"] == "SHORT content"
+
+
+def test_document_source_malformed_json_is_controlled_500(monkeypatch, kb_dir):
+    """A corrupt/unexpected source JSON returns a controlled 500 with a clean
+    message, not an unhandled exception."""
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {"h": {"name": "broken.pdf", "doc_name": "broken", "type": "long_pdf"}})
+    (kb_dir / "wiki" / "sources" / "broken.json").write_text("{not valid json", encoding="utf-8")
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h"}, headers=_auth())
+
+    assert resp.status_code == 500
+    assert "Could not read" in resp.json()["detail"]
+
+
+def test_document_source_non_list_json_is_controlled_500(monkeypatch, kb_dir):
+    """A source JSON that parses but is not a page list is rejected cleanly."""
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    _write_hashes(kb_dir, {"h": {"name": "odd.pdf", "doc_name": "odd", "type": "long_pdf"}})
+    (kb_dir / "wiki" / "sources" / "odd.json").write_text('{"pages": 3}', encoding="utf-8")
+
+    resp = client.post("/api/v1/document/source", json={"kb": kb, "hash": "h"}, headers=_auth())
+
+    assert resp.status_code == 500
+
+
 def test_document_source_requires_auth(monkeypatch, kb_dir):
     client = _client(monkeypatch)
     _use_named_kb(monkeypatch, kb_dir)


### PR DESCRIPTION
## What

Closes #197 — the Documents pane listed each ingested doc (filename, type, hash) with no way to read the actual full text that ingestion produced under `wiki/sources/`. This adds a read-only reader for that converted source text.

## Backend

- New `POST /api/v1/document/source` (`openkb/api_documents_router.py` + `openkb/documents.py`, models in `api_models.py`). Resolves a document **hash** to its converted text:
  - short docs → `wiki/sources/<doc_name>.md`
  - long docs → `wiki/sources/<doc_name>.json` (per-page `list[{page, content, images}]`), pages joined by a thematic break
- Keyed by **hash** (unique) rather than doc_name. Resolution prefers the registry's stored `source_path`, then falls back to the `wiki/sources/<doc_name>.{md,json}` convention **ordered by the doc's type** (long → `.json` first) so two docs sharing a doc_name each resolve to their own file. Path-traversal guarded.
- Read-only: sources are do-not-edit artifacts, so there is no edit/delete counterpart here.

## Frontend

- Document rows are now clickable and open a **wide read-only slide-out reader** rendering the converted Markdown (`MarkdownView`), with a read-only badge, filename, type and page count.
- Built on **Radix Dialog** (same pattern as `KbSettingsSheet`): focus trap, initial + return focus, Escape, background inert. Body scrolls independently; native find-in-page works (the whole doc is rendered, not virtualized). Content is fetched by hash, cached, and the parsed body is memoized, so re-opening is instant.
- The open-reader target and the delete control are **sibling buttons** (no nested interactive markup); the per-hash cache is invalidated when the inventory changes so a reopen after recompile refetches.

## Known limitation

Images embedded in long-doc pages are **not rendered inline** yet — they surface as a literal `![image](...)` reference. This is a separate follow-up (needs Markdown image support + a `wiki/sources/images/*` serving route with the token-blob pattern). Note that OpenKB's ingestion also does not caption/OCR images, so figure/chart content does not reach the LLM regardless.

## Verification

- Backend: `1246 passed` (adds tests for short/long/collision/malformed-JSON/404/auth paths); ruff + mypy clean.
- Frontend: `npm run build` (i18n + tsc + vite) green.
- Manually driven in a browser: short + long docs render; Escape closes and returns focus to the trigger; background is inert while open.

## Review

Ran an xhigh code review over the diff; the 8 findings were addressed in the second commit (keyboard/focus/modal a11y, doc_name-collision resolution, malformed-JSON handling, cache invalidation). One finding (frontmatter stripping) was intentionally not applied — source docs render verbatim, unlike wiki-page OKF metadata.
