### PR TITLE
feat(workbench): configurable entity types (global default + per-KB override)

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -6,6 +6,9 @@ export interface GlobalConfig {
   model: string
   language: string
   pageindex_threshold: number
+  /** CLEANED effective global entity-extraction vocabulary (always includes
+   *  "other"). Mirrors KbConfig.entity_types. */
+  entity_types: string[]
   /** Plaintext global-default LLM base URL (a config value, not a secret);
    *  null if unset. Mirrors KbConfig.openai_api_base. */
   openai_api_base?: string | null
@@ -30,6 +33,9 @@ export interface GlobalConfigPatch {
     model?: string | null
     language?: string | null
     pageindex_threshold?: number | null
+    /** A list sets the global vocabulary; `null` reverts to the built-in
+     *  default. Cleaned server-side (lowercase, `[a-z0-9 _-]`, + "other"). */
+    entity_types?: string[] | null
   }
   api_key?: string | null
   openai_api_base?: string | null

--- a/frontend/src/api/kb.ts
+++ b/frontend/src/api/kb.ts
@@ -54,17 +54,21 @@ export interface KbConfig {
   model: string
   language: string
   pageindex_threshold: number
+  /** CLEANED effective entity-extraction vocabulary (always includes "other"). */
+  entity_types: string[]
   /** Plaintext LLM base URL (a config value, not a credential); null if unset. */
   openai_api_base: string | null
   /** Presence flag only — the raw key value is NEVER returned by the API. */
   has_api_key: boolean
-  /** Which layer supplied each scalar's effective value. */
-  sources: Record<"model" | "language" | "pageindex_threshold", ConfigSource>
-  /** Raw global-layer scalars (null where global.yaml is silent). */
+  /** Which layer supplied each field's effective value. */
+  sources: Record<"model" | "language" | "pageindex_threshold" | "entity_types", ConfigSource>
+  /** Raw global-layer values (null where global.yaml is silent). */
   global_values: {
     model: string | null
     language: string | null
     pageindex_threshold: number | null
+    /** RAW global list (not cleaned) — for the inherited badge. */
+    entity_types: string[] | null
   }
 }
 
@@ -76,7 +80,11 @@ export interface KbConfig {
  * key" request, not "unchanged" or "clear".
  */
 export interface KbConfigPatch {
-  config?: Partial<Pick<KbConfig, "model" | "language" | "pageindex_threshold">>
+  config?: Partial<Pick<KbConfig, "model" | "language" | "pageindex_threshold">> & {
+    /** A list sets/overrides for this KB; `null` reverts to inherited. Values
+     *  are cleaned server-side (lowercase, `[a-z0-9 _-]`, dedupe, + "other"). */
+    entity_types?: string[] | null
+  }
   api_key?: string | null
   openai_api_base?: string | null
 }

--- a/frontend/src/components/EntityTypesEditor.tsx
+++ b/frontend/src/components/EntityTypesEditor.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
+
+/** The backend's catch-all bucket: it is re-appended server-side on every
+ *  write, so the editor renders it as a fixed, non-removable chip. */
+const ALWAYS_INCLUDED = 'other'
+
+/**
+ * Chips editor for the entity-extraction vocabulary, shared by the per-KB
+ * override row (KbSettingsSheet) and the global editor (Settings › general).
+ * Controlled: renders `value` as removable chips + an add input (Enter to add,
+ * commas split), and calls `onChange` with the FULL next list on each
+ * add/remove. Client-side it only trims/lowercases and drops empties/dupes —
+ * the authoritative cleaning (charset, dedupe, "other") happens server-side.
+ */
+export default function EntityTypesEditor({
+  value,
+  disabled,
+  onChange,
+}: {
+  /** Current list (server-cleaned effective list, or local draft state). */
+  value: string[]
+  disabled?: boolean
+  /** Receives the complete next list after an add/remove. */
+  onChange: (next: string[]) => void
+}) {
+  const { t } = useTranslation('common')
+  const [draft, setDraft] = useState('')
+
+  const add = () => {
+    const seen = new Set(value.map((v) => v.toLowerCase()))
+    const added: string[] = []
+    for (const part of draft.split(',')) {
+      const v = part.trim().toLowerCase()
+      if (v === '' || seen.has(v)) continue
+      seen.add(v)
+      added.push(v)
+    }
+    setDraft('')
+    if (added.length > 0) onChange([...value, ...added])
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-input px-2.5 py-2">
+      {value.map((item) => (
+        <span
+          key={item}
+          className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--glass-border))] bg-muted px-2.5 py-1 text-[11.5px] font-mono2 text-foreground"
+        >
+          {item}
+          {item === ALWAYS_INCLUDED ? (
+            <span className="text-[10.5px] text-muted-foreground">{t('entityTypes.always')}</span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onChange(value.filter((x) => x !== item))}
+              disabled={disabled}
+              aria-label={t('entityTypes.removeAria', { type: item })}
+              className="grid h-3.5 w-3.5 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          )}
+        </span>
+      ))}
+      <input
+        value={draft}
+        disabled={disabled}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          // Enter confirms IME composition first; only a real Enter adds.
+          if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+            e.preventDefault()
+            add()
+          }
+        }}
+        placeholder={t('entityTypes.placeholder')}
+        aria-label={t('entityTypes.placeholder')}
+        className="h-6 min-w-[140px] flex-1 bg-transparent text-[12.5px] font-mono2 outline-none placeholder:text-muted-foreground/70 disabled:opacity-60"
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/KbSettingsSheet.tsx
+++ b/frontend/src/components/KbSettingsSheet.tsx
@@ -278,7 +278,6 @@ function KbConfigSection({ kb }: { kb: string }) {
       <EntityTypesRow
         source={config.sources.entity_types}
         effective={config.entity_types}
-        globalValue={config.global_values.entity_types}
         busy={busy}
         onSet={setEntityTypesOverride}
         onRevert={() => setEntityTypesOverride(null)}
@@ -415,13 +414,12 @@ function OverrideRow({
  *  chips list (EntityTypesEditor) and every add/remove persists immediately —
  *  the chips always show the server-cleaned effective list. */
 function EntityTypesRow({
-  source, effective, globalValue, busy, onSet, onRevert,
+  source, effective, busy, onSet, onRevert,
 }: {
   source: ConfigSource
-  /** Cleaned effective list (always includes "other"). */
+  /** Cleaned effective list (always includes "other") — shown as-is in the
+   *  inherited badge, so it matches the vocabulary the compiler actually uses. */
   effective: string[]
-  /** RAW global-layer list; null when global.yaml is silent. */
-  globalValue: string[] | null
   busy: boolean
   onSet: (value: string[]) => void
   onRevert: () => void
@@ -432,7 +430,7 @@ function EntityTypesRow({
 
   const inheritedBadge =
     source === 'global'
-      ? t('kbSettings:inheritGlobal', { value: (globalValue ?? effective).join(', ') })
+      ? t('kbSettings:inheritGlobal', { value: effective.join(', ') })
       : t('kbSettings:inheritDefault', { value: effective.join(', ') })
 
   return (

--- a/frontend/src/components/KbSettingsSheet.tsx
+++ b/frontend/src/components/KbSettingsSheet.tsx
@@ -16,6 +16,7 @@ import type { SseEvent } from '@/api/client'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { UnLanguageDatalist, UN_LANG_LIST_ID } from '@/components/UnLanguageDatalist'
+import EntityTypesEditor from '@/components/EntityTypesEditor'
 
 const errMsg = (e: unknown) => (e instanceof Error ? e.message : String(e))
 
@@ -169,6 +170,22 @@ function KbConfigSection({ kb }: { kb: string }) {
     [kb, apply, t],
   )
 
+  // Persist the entity-types override (list) or revert to inherited (null).
+  // Always adopts the response: the row then shows the server-CLEANED list.
+  const setEntityTypesOverride = useCallback(
+    async (value: string[] | null) => {
+      setBusy(true)
+      try {
+        apply(await patchKbConfig(kb, { config: { entity_types: value } }))
+      } catch (e) {
+        toast.error(t('common:saveError', { error: errMsg(e) }))
+      } finally {
+        setBusy(false)
+      }
+    },
+    [kb, apply, t],
+  )
+
   const saveCredentials = useCallback(async () => {
     if (!config) return
     setBusy(true)
@@ -257,6 +274,14 @@ function KbConfigSection({ kb }: { kb: string }) {
         // convert directly (no silent null-on-invalid — see OverrideRow).
         onSet={(v) => setOverride('pageindex_threshold', Number(v))}
         onRevert={() => setOverride('pageindex_threshold', null)}
+      />
+      <EntityTypesRow
+        source={config.sources.entity_types}
+        effective={config.entity_types}
+        globalValue={config.global_values.entity_types}
+        busy={busy}
+        onSet={setEntityTypesOverride}
+        onRevert={() => setEntityTypesOverride(null)}
       />
 
       <h3 className="pt-2 text-[12px] font-semibold text-muted-foreground tracking-wide">{t('kbSettings:credHeading')}</h3>
@@ -381,6 +406,65 @@ function OverrideRow({
           {inheritedBadge}
         </div>
       )}
+    </div>
+  )
+}
+
+/** OverrideRow's list-shaped sibling for the entity-extraction vocabulary:
+ *  the same 为本库覆盖 switch + inherited badge, but the override editor is a
+ *  chips list (EntityTypesEditor) and every add/remove persists immediately —
+ *  the chips always show the server-cleaned effective list. */
+function EntityTypesRow({
+  source, effective, globalValue, busy, onSet, onRevert,
+}: {
+  source: ConfigSource
+  /** Cleaned effective list (always includes "other"). */
+  effective: string[]
+  /** RAW global-layer list; null when global.yaml is silent. */
+  globalValue: string[] | null
+  busy: boolean
+  onSet: (value: string[]) => void
+  onRevert: () => void
+}) {
+  const { t } = useTranslation(['kbSettings', 'common'])
+  const overridden = source === 'kb'
+  const label = t('common:fields.entityTypes')
+
+  const inheritedBadge =
+    source === 'global'
+      ? t('kbSettings:inheritGlobal', { value: (globalValue ?? effective).join(', ') })
+      : t('kbSettings:inheritDefault', { value: effective.join(', ') })
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <label className="text-[12px] font-medium text-muted-foreground">{label}</label>
+        <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          {t('kbSettings:override')}
+          <Switch
+            checked={overridden}
+            disabled={busy}
+            // ON seeds the override with the current effective list (the
+            // backend then owns it as this KB's own list); OFF reverts to
+            // inherited via an explicit null.
+            onCheckedChange={(v) => (v ? onSet(effective) : onRevert())}
+            aria-label={t('kbSettings:overrideAria', { label })}
+          />
+        </span>
+      </div>
+      {overridden ? (
+        <div className="mt-1.5">
+          <EntityTypesEditor value={effective} disabled={busy} onChange={onSet} />
+        </div>
+      ) : (
+        <div
+          data-field="entity_types"
+          className="mt-1.5 flex min-h-9 items-center rounded-md border border-dashed border-[hsl(var(--glass-border))] px-3 py-1.5 text-[12.5px] text-muted-foreground"
+        >
+          {inheritedBadge}
+        </div>
+      )}
+      <p className="mt-1.5 text-[11.5px] text-muted-foreground">{t('kbSettings:entityTypesNote')}</p>
     </div>
   )
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -13,7 +13,13 @@
   "fields": {
     "model": "Model",
     "wikiLanguage": "Wiki output language",
-    "threshold": "PageIndex threshold (pages)"
+    "threshold": "PageIndex threshold (pages)",
+    "entityTypes": "Entity types"
+  },
+  "entityTypes": {
+    "placeholder": "Add a type, press Enter",
+    "removeAria": "Remove type {{type}}",
+    "always": "always included"
   },
   "errors": {
     "requestFailed": "Request failed",

--- a/frontend/src/locales/en/kbSettings.json
+++ b/frontend/src/locales/en/kbSettings.json
@@ -18,6 +18,7 @@
   "inheritDefault": "Inherited · default ({{value}})",
   "override": "Override for this KB",
   "overrideAria": "Override {{label}} for this KB",
+  "entityTypesNote": "Changes apply to future recompiles only; existing entity pages keep their current type.",
   "unnamed": "(unnamed)",
   "recompileFailed": "Recompile failed",
   "watchStarted": "File watching started",

--- a/frontend/src/locales/en/settings.json
+++ b/frontend/src/locales/en/settings.json
@@ -21,6 +21,8 @@
   },
   "general": {
     "langDesc": "The output language written into the compile prompt, e.g. en / 中文 / 日本語",
+    "entityTypesDesc": "The vocabulary used to classify entities extracted at compile time; each KB can inherit or override it in its own settings.",
+    "entityTypesNote": "Changes apply to future recompiles only; existing entity pages keep their current type.",
     "kbRootLabel": "Knowledge base root",
     "kbRootDesc": "Default location for new knowledge bases (<root>/<name>); leave empty to restore the built-in default. Individual KBs can set a custom path at creation.",
     "kbRootPlaceholder": "e.g. ~/openkb",

--- a/frontend/src/locales/zh/common.json
+++ b/frontend/src/locales/zh/common.json
@@ -13,7 +13,13 @@
   "fields": {
     "model": "模型",
     "wikiLanguage": "Wiki 输出语言",
-    "threshold": "PageIndex 阈值（页数）"
+    "threshold": "PageIndex 阈值（页数）",
+    "entityTypes": "实体类型"
+  },
+  "entityTypes": {
+    "placeholder": "输入类型，按 Enter 添加",
+    "removeAria": "移除类型 {{type}}",
+    "always": "始终包含"
   },
   "errors": {
     "requestFailed": "请求失败",

--- a/frontend/src/locales/zh/kbSettings.json
+++ b/frontend/src/locales/zh/kbSettings.json
@@ -18,6 +18,7 @@
   "inheritDefault": "继承 · 默认({{value}})",
   "override": "为本库覆盖",
   "overrideAria": "{{label}} 为本库覆盖",
+  "entityTypesNote": "改动仅影响之后的重新编译；已有实体页会保留其当前类型。",
   "unnamed": "(未命名)",
   "recompileFailed": "重新编译失败",
   "watchStarted": "已启动文件监听",

--- a/frontend/src/locales/zh/settings.json
+++ b/frontend/src/locales/zh/settings.json
@@ -21,6 +21,8 @@
   },
   "general": {
     "langDesc": "写入编译 prompt 的输出语言，例如 en / 中文 / 日本語",
+    "entityTypesDesc": "编译时为抽取出的实体分类所用的类型词表；各知识库可在其设置中继承或覆盖。",
+    "entityTypesNote": "改动仅影响之后的重新编译；已有实体页会保留其当前类型。",
     "kbRootLabel": "知识库根目录",
     "kbRootDesc": "新建知识库的默认位置（<根目录>/<名称>）；留空则恢复内置默认值。单个知识库可在创建时设置自定义路径。",
     "kbRootPlaceholder": "例如 ~/openkb",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -109,11 +109,12 @@ export default function Settings() {
     if (threshold.trim() !== '' && Number.isInteger(n) && n >= 1 && n !== config.pageindex_threshold) {
       cfg.pageindex_threshold = n
     }
-    // Order-sensitive compare against the last-fetched cleaned list. The
-    // editor only appends/removes, so equal content ⇒ equal order; a reorder
-    // never happens client-side.
-    const baseTypes = config.entity_types
-    if (entityTypes.length !== baseTypes.length || entityTypes.some((v, i) => v !== baseTypes[i])) {
+    // Order-INSENSITIVE compare: the vocabulary is a set (the compiler treats
+    // it as an allowlist), and removing-then-re-adding a type appends it at the
+    // end — so a same-set reorder must NOT dirty the form or persist a no-op.
+    const a = [...entityTypes].sort()
+    const b = [...config.entity_types].sort()
+    if (a.length !== b.length || a.some((v, i) => v !== b[i])) {
       cfg.entity_types = entityTypes
     }
     if (Object.keys(cfg).length > 0) patch.config = cfg

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { getGlobalConfig, patchGlobalConfig, type GlobalConfig, type GlobalConfigPatch } from '@/api/config'
 import ConnectorCards from '@/components/ConnectorCards'
 import AboutTab from '@/components/AboutTab'
+import EntityTypesEditor from '@/components/EntityTypesEditor'
 import { cn } from '@/lib/utils'
 import { UnLanguageDatalist, UN_LANG_LIST_ID } from '@/components/UnLanguageDatalist'
 
@@ -39,6 +40,10 @@ export default function Settings() {
   const [model, setModel] = useState('')
   const [language, setLanguage] = useState('')
   const [threshold, setThreshold] = useState('')
+  // Entity-extraction vocabulary, edited as chips. Seeded from the CLEANED
+  // effective list (always includes "other"); diffed order-sensitively in
+  // buildPatch. Server re-cleans on save, so client edits stay lightweight.
+  const [entityTypes, setEntityTypes] = useState<string[]>([])
   // KB root directory. Emptying a previously-set root clears it (null → default),
   // mirroring the credential-base's empty→null discipline in buildPatch.
   const [kbRoot, setKbRoot] = useState('')
@@ -58,6 +63,7 @@ export default function Settings() {
     setModel(c.model)
     setLanguage(c.language)
     setThreshold(String(c.pageindex_threshold))
+    setEntityTypes(c.entity_types)
     setKbRoot(c.kb_root ?? '')
     setApiBase(c.openai_api_base ?? '')
     setApiKey('')
@@ -103,6 +109,13 @@ export default function Settings() {
     if (threshold.trim() !== '' && Number.isInteger(n) && n >= 1 && n !== config.pageindex_threshold) {
       cfg.pageindex_threshold = n
     }
+    // Order-sensitive compare against the last-fetched cleaned list. The
+    // editor only appends/removes, so equal content ⇒ equal order; a reorder
+    // never happens client-side.
+    const baseTypes = config.entity_types
+    if (entityTypes.length !== baseTypes.length || entityTypes.some((v, i) => v !== baseTypes[i])) {
+      cfg.entity_types = entityTypes
+    }
     if (Object.keys(cfg).length > 0) patch.config = cfg
     // When kb_root is env-pinned the field is read-only and the effective value
     // is the OPENKB_KB_ROOT env root, so never diff/emit it — a Save would
@@ -118,7 +131,7 @@ export default function Settings() {
     if (clearKey) patch.api_key = null
     else if (apiKey !== '') patch.api_key = apiKey
     return { patch, dirty: Object.keys(patch).length > 0 }
-  }, [config, model, language, threshold, kbRoot, apiBase, apiKey, clearKey])
+  }, [config, model, language, threshold, entityTypes, kbRoot, apiBase, apiKey, clearKey])
 
   const dirty = useMemo(() => buildPatch().dirty, [buildPatch])
 
@@ -311,6 +324,19 @@ export default function Settings() {
                   className={cn(inputCls, 'max-w-[240px]')}
                 />
                 <UnLanguageDatalist />
+              </div>
+
+              <div>
+                <label className="text-[13px] font-semibold text-foreground">{t('common:fields.entityTypes')}</label>
+                <p className="mt-0.5 text-[12px] text-muted-foreground">{t('settings:general.entityTypesDesc')}</p>
+                <div className="mt-1.5 max-w-[560px]">
+                  <EntityTypesEditor
+                    value={entityTypes}
+                    disabled={loading || !config}
+                    onChange={setEntityTypes}
+                  />
+                </div>
+                <p className="mt-1.5 text-[11.5px] text-muted-foreground">{t('settings:general.entityTypesNote')}</p>
               </div>
 
               <div>

--- a/openkb/api_config.py
+++ b/openkb/api_config.py
@@ -153,7 +153,7 @@ def read_kb_config(kb_dir: Path) -> KbConfigResponse:
         pageindex_threshold=effective["pageindex_threshold"],
         # Cleaned effective list (what the compiler will use), not the raw stored
         # value — resolve_entity_types defaults + dedupes + ensures "other".
-        entity_types=resolve_entity_types(effective),
+        entity_types=resolve_entity_types(effective, warn=False),
         openai_api_base=bundle.base_url,
         has_api_key=bundle.api_key is not None,
         sources=sources,
@@ -268,7 +268,7 @@ def read_global_config() -> GlobalConfigResponse:
         language=gc.get("language", DEFAULT_CONFIG["language"]),
         pageindex_threshold=gc.get("pageindex_threshold", DEFAULT_CONFIG["pageindex_threshold"]),
         # Effective global vocabulary (cleaned; defaults to DEFAULT_ENTITY_TYPES).
-        entity_types=resolve_entity_types(gc),
+        entity_types=resolve_entity_types(gc, warn=False),
         # Report the EFFECTIVE root (env > global.yaml kb_root > default) via the
         # module object so a test-monkeypatched GLOBAL_CONFIG_DIR is honored.
         kb_root=str(_config_module.kb_root_dir()),

--- a/openkb/api_config.py
+++ b/openkb/api_config.py
@@ -34,6 +34,7 @@ from openkb.config import (
     load_global_config,
     resolve_credential_bundle,
     resolve_effective_config,
+    resolve_entity_types,
     save_config,
 )
 from openkb.locks import atomic_write_text
@@ -150,6 +151,9 @@ def read_kb_config(kb_dir: Path) -> KbConfigResponse:
         model=effective["model"],
         language=effective["language"],
         pageindex_threshold=effective["pageindex_threshold"],
+        # Cleaned effective list (what the compiler will use), not the raw stored
+        # value — resolve_entity_types defaults + dedupes + ensures "other".
+        entity_types=resolve_entity_types(effective),
         openai_api_base=bundle.base_url,
         has_api_key=bundle.api_key is not None,
         sources=sources,
@@ -157,6 +161,7 @@ def read_kb_config(kb_dir: Path) -> KbConfigResponse:
             model=global_config.get("model"),
             language=global_config.get("language"),
             pageindex_threshold=global_config.get("pageindex_threshold"),
+            entity_types=global_config.get("entity_types"),
         ),
     )
 
@@ -262,6 +267,8 @@ def read_global_config() -> GlobalConfigResponse:
         model=gc.get("model", DEFAULT_CONFIG["model"]),
         language=gc.get("language", DEFAULT_CONFIG["language"]),
         pageindex_threshold=gc.get("pageindex_threshold", DEFAULT_CONFIG["pageindex_threshold"]),
+        # Effective global vocabulary (cleaned; defaults to DEFAULT_ENTITY_TYPES).
+        entity_types=resolve_entity_types(gc),
         # Report the EFFECTIVE root (env > global.yaml kb_root > default) via the
         # module object so a test-monkeypatched GLOBAL_CONFIG_DIR is honored.
         kb_root=str(_config_module.kb_root_dir()),

--- a/openkb/api_models.py
+++ b/openkb/api_models.py
@@ -401,6 +401,10 @@ class _KbConfigWritable(BaseModel):
     model: str | None = None
     language: str | None = None
     pageindex_threshold: int | None = None
+    # Entity-type vocabulary for extraction. A list REPLACES the layer below; an
+    # explicit null reverts to inherited. Values are cleaned/deduped and "other"
+    # is always ensured at read time (config.resolve_entity_types).
+    entity_types: list[str] | None = None
 
 
 # Single source of truth for the writable config keys (derived from the model
@@ -409,17 +413,20 @@ _KB_CONFIG_WRITABLE_KEYS = set(_KbConfigWritable.model_fields)
 
 
 class GlobalConfigValues(BaseModel):
-    """Raw global-layer scalar values (null where global.yaml is silent)."""
+    """Raw global-layer values (null where global.yaml is silent)."""
 
     model: str | None = None
     language: str | None = None
     pageindex_threshold: int | None = None
+    entity_types: list[str] | None = None
 
 
 class GlobalConfigResponse(BaseModel):
     model: str
     language: str
     pageindex_threshold: int
+    # Effective global entity-type vocabulary (cleaned; always includes "other").
+    entity_types: list[str]
     # Effective KB root that kb_root_dir() would return (env OPENKB_KB_ROOT >
     # global.yaml kb_root > default <config>/kbs). kb_root_env_pinned is True
     # when OPENKB_KB_ROOT is set — a global.yaml kb_root is then ineffective, so
@@ -453,6 +460,8 @@ class KbConfigResponse(BaseModel):
     model: str
     language: str
     pageindex_threshold: int
+    # Effective entity-type vocabulary (cleaned; always includes "other").
+    entity_types: list[str]
     openai_api_base: str | None
     has_api_key: bool
     # Additive (non-breaking): which layer supplied each scalar's effective

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -15,13 +15,7 @@ from openkb.locks import atomic_write_text, flock, funlock
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG: dict[str, Any] = {
-    "model": "gpt-5.4",
-    "language": "en",
-    "pageindex_threshold": 20,
-}
-
-# Default entity-type vocabulary. Overridable per-KB via the optional
+# Default entity-type vocabulary. Overridable globally / per-KB via the optional
 # ``entity_types:`` config key (see ``resolve_entity_types``).
 DEFAULT_ENTITY_TYPES: tuple[str, ...] = (
     "person",
@@ -32,6 +26,17 @@ DEFAULT_ENTITY_TYPES: tuple[str, ...] = (
     "event",
     "other",
 )
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "model": "gpt-5.4",
+    "language": "en",
+    "pageindex_threshold": 20,
+    # A GLOBAL_SCALAR_KEY like the three above, so the merged `effective` dict
+    # always carries it (the layering/`sources` logic is type-agnostic). A
+    # global/KB list overrides it wholesale; resolve_entity_types cleans the
+    # effective value on read.
+    "entity_types": list(DEFAULT_ENTITY_TYPES),
+}
 
 GLOBAL_CONFIG_DIR = Path.home() / ".config" / "openkb"
 GLOBAL_CONFIG_PATH = GLOBAL_CONFIG_DIR / "global.yaml"
@@ -88,7 +93,7 @@ def _load_global_config_unlocked() -> dict[str, Any]:
     return {}
 
 
-def resolve_entity_types(config: dict) -> list[str]:
+def resolve_entity_types(config: dict, *, warn: bool = True) -> list[str]:
     """Resolve the effective entity-type list from a loaded config dict.
 
     If ``config["entity_types"]`` is a non-empty list, each string item is
@@ -98,18 +103,23 @@ def resolve_entity_types(config: dict) -> list[str]:
     de-duped (order preserving) and ``"other"`` is always appended when missing
     (it is the coercion fallback). Otherwise — key absent, not a list, empty,
     or fully malformed — :data:`DEFAULT_ENTITY_TYPES` is returned, so behavior
-    is byte-identical to the default. A warning is logged only when
-    ``entity_types`` was present-but-malformed.
+    is byte-identical to the default.
+
+    ``warn`` logs a warning when ``entity_types`` is present-but-malformed. It is
+    ``True`` for the compile path (a real config problem the author should see)
+    and passed ``False`` by the config-READ endpoints, which run on every GET and
+    must not spam the log for a malformed value.
     """
     raw = config.get("entity_types")
     if raw is None:
         return list(DEFAULT_ENTITY_TYPES)
     if not isinstance(raw, list):
-        logger.warning(
-            "config: 'entity_types' must be a list of strings, got %s — "
-            "falling back to the default entity types.",
-            type(raw).__name__,
-        )
+        if warn:
+            logger.warning(
+                "config: 'entity_types' must be a list of strings, got %s — "
+                "falling back to the default entity types.",
+                type(raw).__name__,
+            )
         return list(DEFAULT_ENTITY_TYPES)
     cleaned: list[str] = []
     for x in raw:
@@ -119,10 +129,11 @@ def resolve_entity_types(config: dict) -> list[str]:
         if s and s not in cleaned:
             cleaned.append(s)
     if not cleaned:
-        logger.warning(
-            "config: 'entity_types' was present but yielded no usable values — "
-            "falling back to the default entity types.",
-        )
+        if warn:
+            logger.warning(
+                "config: 'entity_types' was present but yielded no usable values — "
+                "falling back to the default entity types.",
+            )
         return list(DEFAULT_ENTITY_TYPES)
     if "other" not in cleaned:
         cleaned.append("other")
@@ -533,10 +544,12 @@ def resolve_effective_config(kb_dir: Path) -> tuple[dict[str, Any], dict[str, st
         if not isinstance(kb_config, dict):
             kb_config = {}
         for key, value in kb_config.items():
-            # A scalar explicitly nulled in config.yaml means "inherit": don't
-            # let it clobber the global/default layer. The gate is on
-            # GLOBAL_SCALAR_KEYS so non-scalar nulls (parallel_tool_calls) stay.
-            if key in GLOBAL_SCALAR_KEYS and value is None:
+            # A GLOBAL_SCALAR_KEYS value explicitly nulled — or an empty
+            # entity_types list, since an empty vocabulary is meaningless —
+            # means "inherit": don't clobber the global/default layer, and keep
+            # `sources` reporting the layer that actually supplied the value. The
+            # gate is on GLOBAL_SCALAR_KEYS so non-scalar nulls (parallel_tool_calls) stay.
+            if key in GLOBAL_SCALAR_KEYS and (value is None or value == []):
                 continue
             effective[key] = value
             if key in GLOBAL_SCALAR_KEYS:

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -483,7 +483,16 @@ def load_global_config() -> dict[str, Any]:
 # Whitelisted scalar keys that global.yaml may provide as shared defaults for
 # every KB. Non-scalar global keys (known_kbs, kb_aliases, default_kb) are NOT
 # config and must never leak into a KB's effective runtime config.
-GLOBAL_SCALAR_KEYS: tuple[str, ...] = ("model", "language", "pageindex_threshold")
+# Config keys that layer global.yaml -> KB config.yaml with per-key `sources`
+# tracking (a KB explicit null = inherit). Mostly scalars; `entity_types` is the
+# one list-valued member — the layering rule (a non-null value wins over the
+# layer below) is type-agnostic, so a KB list overrides the global list wholesale.
+GLOBAL_SCALAR_KEYS: tuple[str, ...] = (
+    "model",
+    "language",
+    "pageindex_threshold",
+    "entity_types",
+)
 
 
 def resolve_effective_config(kb_dir: Path) -> tuple[dict[str, Any], dict[str, str]]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2204,6 +2204,60 @@ def test_kb_config_patch_updates_model_only(monkeypatch, kb_dir):
     assert saved["model"] == "claude-opus"
 
 
+def test_kb_config_patch_sets_and_reverts_entity_types(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    # Set a custom vocabulary: stored raw, read back cleaned (lowercased, unsafe
+    # chars stripped, deduped, "other" ensured) with source 'kb'.
+    r = client.patch(
+        "/api/v1/kb/config",
+        json={"kb": kb, "config": {"entity_types": ["Person", "Team!"]}},
+        headers=_auth(),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["entity_types"] == ["person", "team", "other"]
+    assert body["sources"]["entity_types"] == "kb"
+    saved = yaml.safe_load((kb_dir / ".openkb" / "config.yaml").read_text())
+    assert saved["entity_types"] == ["Person", "Team!"]  # raw value persisted
+
+    # Revert (explicit null) -> inherit; with no global set, falls to default.
+    r = client.patch(
+        "/api/v1/kb/config", json={"kb": kb, "config": {"entity_types": None}}, headers=_auth()
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["sources"]["entity_types"] == "default"
+    assert body["entity_types"][-1] == "other"
+
+
+def test_global_config_patch_entity_types(monkeypatch, tmp_path):
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_PATH", tmp_path / "global.yaml")
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_DIR", tmp_path)
+    monkeypatch.delenv("OPENKB_KB_ROOT", raising=False)
+    client = _client(monkeypatch)
+    r = client.patch(
+        "/api/v1/config", json={"config": {"entity_types": ["Org", "Law!"]}}, headers=_auth()
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["entity_types"] == ["org", "law", "other"]  # cleaned effective list
+
+
+def test_kb_config_get_reports_global_source_for_entity_types(monkeypatch, kb_dir, tmp_path):
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_PATH", tmp_path / "global.yaml")
+    monkeypatch.setattr("openkb.config.GLOBAL_CONFIG_DIR", tmp_path)
+    from openkb.config import save_global_config
+
+    save_global_config({"entity_types": ["team", "org"]})
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+    body = client.get("/api/v1/kb/config", params={"kb": kb}, headers=_auth()).json()
+    assert body["sources"]["entity_types"] == "global"  # inherited from global.yaml
+    assert body["entity_types"] == ["team", "org", "other"]
+    assert body["global_values"]["entity_types"] == ["team", "org"]  # raw global for the badge
+
+
 def test_kb_config_patch_unknown_field_is_400(monkeypatch, kb_dir):
     client = _client(monkeypatch)
     kb = _use_named_kb(monkeypatch, kb_dir)
@@ -2477,6 +2531,8 @@ def test_global_config_get_defaults_when_absent(monkeypatch, tmp_path):
         "model": "gpt-5.4",
         "language": "en",
         "pageindex_threshold": 20,
+        # Default entity-type vocabulary when global.yaml sets none.
+        "entity_types": ["person", "organization", "place", "product", "work", "event", "other"],
         # kb_root reports the EFFECTIVE root; with no env/global override it is
         # the default <GLOBAL_CONFIG_DIR>/kbs, and env_pinned is False.
         "kb_root": str((tmp_path / "kbs").resolve()),


### PR DESCRIPTION
Makes the **entity-extraction vocabulary** (`entity_types`) user-configurable — a global default plus a per-KB override — surfacing a setting the compiler already honored but that was previously only editable by hand-writing `config.yaml`.

## Backend (`92f8f41`)

`entity_types` now flows through the config read/write API, layering `global.yaml → KB config.yaml` exactly like the other config scalars:
- a KB list **overrides** the global list wholesale; an explicit **null inherits**; unset falls back to `DEFAULT_ENTITY_TYPES` (person/organization/place/product/work/event/other).
- `GLOBAL_SCALAR_KEYS` gains `entity_types` (the value-not-None-wins layering + per-key `sources` tracking is type-agnostic, so it works for a list).
- `GET/PATCH /api/v1/kb/config` and `GET/PATCH /api/v1/config` carry `entity_types`. Reads report the **cleaned effective list** (`resolve_entity_types`: lowercased, charset-restricted, deduped, `"other"` ensured) plus the raw global value for the inherited badge.
- The compiler already consumed `config["entity_types"]` via `resolve_entity_types`; nothing there changed.

## Frontend (`9abd2bb`)

- **`EntityTypesEditor`**: a shared chips editor — Enter/comma to add, `×` to remove, `"other"` rendered as a fixed "always included" chip, IME-safe composition.
- **KB settings sheet**: an `EntityTypesRow` with the same inherit/override `Switch` as the scalar rows — override on seeds + persists the KB's own list, off reverts via null; the inherited state shows the global/default list as a badge. Each chip change persists and adopts the server-cleaned response.
- **Global Settings (general tab)**: a global chips editor, order-sensitive diff into the save patch (joins the existing dirty/save-bar flow).
- Both surfaces show a "changes affect future recompiles only; existing entity pages keep their type" note.

## Semantics

- Per-KB list **replaces** the global list (not merged) — same as a scalar override.
- `"other"` is always ensured server-side (the coercion fallback), shown as non-removable.
- Changing the vocabulary only affects **future** compiles; existing entity pages keep their `type:` until recompiled.

## Verification

Backend `pytest` **1240 passed**, `mypy`/`ruff` clean; new tests cover KB override (cleaned + source `kb`) + null revert, global patch, and global-source inheritance. Frontend `npm run build` green (i18n guard: zh/en key sets identical across `common`/`kbSettings`/`settings`). Manually exercised on a running `openkb-web`.

Claude-Session: https://claude.ai/code/session_01XMxbhmAkxxVV8CFWCZDBaG
