### PR TITLE
docs(config): document Eden AI as an EU OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ LLM_API_KEY=your-key-here
 
 # Optional base URL override for OpenAI-compatible gateways
 # OPENAI_API_BASE=https://api.deepseek.com
+# Eden AI (EU-based, OpenAI-compatible, zero data retention): OPENAI_API_BASE=https://api.edenai.run/v3
+#   (or https://api.eu.edenai.run/v3 for EU data residency); then set
+#   model: openai/<vendor>/<model>, e.g. openai/openai/gpt-4o-mini
 
 # --- REST API server variables (read by `openkb-api` / `python -m openkb.api`) ---
 # OPENKB_API_TOKEN=...   # required bearer token clients send as Authorization: Bearer <token>

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -216,6 +216,29 @@ LLM_API_KEY=your-key-here
                               # Write it as bare `null` — not `None` or "null".
   ```
 
+- **Eden AI** (`OPENAI_API_BASE=https://api.edenai.run/v3`) is a French, EU-based
+  OpenAI-compatible gateway. Set `LLM_API_KEY` to your Eden AI key, point
+  `OPENAI_API_BASE` at Eden AI, and use a double-prefixed `model` so LiteLLM
+  keeps Eden AI's vendor-prefixed id intact:
+
+  ```bash
+  # <kb>/.env
+  LLM_API_KEY=your-edenai-key
+  OPENAI_API_BASE=https://api.edenai.run/v3   # or https://api.eu.edenai.run/v3 for EU data residency
+  ```
+
+  ```yaml
+  # <kb>/.openkb/config.yaml
+  model: openai/openai/gpt-4o-mini   # openai/<vendor>/<model>, e.g. openai/anthropic/claude-sonnet-4-5
+  ```
+
+  The leading `openai/` selects LiteLLM's OpenAI-compatible transport (so it uses
+  `OPENAI_API_BASE`); the remaining `<vendor>/<model>` is Eden AI's model id. Eden
+  AI's EU endpoint processes and routes prompts and outputs within the European
+  Union, with zero data retention by default (SOC 2 / ISO 27001, DPA as standard),
+  which is useful for GDPR-sensitive knowledge bases. See
+  https://www.edenai.co/data-compliancy.
+
 **Where keys are read from** (first match wins, existing env always respected):
 
 1. your shell environment


### PR DESCRIPTION
## What

Documents Eden AI as a supported provider. No code change is needed: OpenKB already routes through LiteLLM's `OPENAI_API_BASE` override, so Eden AI works today. This just documents the exact config in the configuration guide and `.env.example`.

Eden AI is a French, EU-based OpenAI-compatible gateway. Config:

```bash
# <kb>/.env
LLM_API_KEY=your-edenai-key
OPENAI_API_BASE=https://api.edenai.run/v3   # or https://api.eu.edenai.run/v3 for EU data residency
```

```yaml
# <kb>/.openkb/config.yaml
model: openai/openai/gpt-4o-mini   # openai/<vendor>/<model>, e.g. openai/anthropic/claude-sonnet-4-5
```

The leading `openai/` selects LiteLLM's OpenAI-compatible transport (so it honors `OPENAI_API_BASE`); the remaining `<vendor>/<model>` is Eden AI's vendor-prefixed model id.

## Why Eden AI (EU / GDPR / data residency)

- **EU data residency**: a dedicated EU endpoint (`https://api.eu.edenai.run/v3`) that processes and routes prompts and outputs within the European Union (non-EU models are rejected).
- **Zero data retention**: prompts and outputs are not stored by default and are removed within 24 hours.
- **Compliance**: SOC 2 and ISO 27001, DPA as standard, designed around GDPR and the EU AI Act.

Useful for GDPR-sensitive knowledge bases. Refs: https://www.edenai.co/post/eu-ai-endpoint-how-to-keep-ai-requests-and-data-in-europe and https://www.edenai.co/data-compliancy

## Changes

- `examples/configuration/README.md`: an Eden AI entry in "3. API keys & providers".
- `.env.example`: an Eden AI example next to the existing `OPENAI_API_BASE` gateway note.

## Testing

- Verified against the real Eden AI API with a real key, through `litellm.completion(model=..., base_url="https://api.edenai.run/v3", api_key=...)` (OpenKB's exact call path). The documented double-prefixed form returns completions for three vendors: `openai/openai/gpt-4o-mini`, `openai/anthropic/claude-sonnet-4-5`, `openai/mistral/mistral-small-latest`. The single-prefixed `openai/gpt-4o-mini` fails (LiteLLM strips the prefix), which is exactly why the docs call out the double prefix.

Happy to adjust wording or move the section if you prefer.
