### PR TITLE
fix: keep add event stream alive

### DIFF
--- a/openkb/api_helpers.py
+++ b/openkb/api_helpers.py
@@ -53,6 +53,7 @@ from openkb.watch_service import WatchRegistry
 
 security = HTTPBearer(auto_error=False)
 UPLOAD_CHUNK_BYTES = 1024 * 1024
+ADD_SSE_KEEPALIVE_SECONDS = 15
 MAX_UPLOAD_FILE_BYTES = int(os.environ.get("OPENKB_MAX_UPLOAD_FILE_BYTES", str(100 * 1024 * 1024)))
 MAX_UPLOAD_REQUEST_BYTES = int(
     os.environ.get("OPENKB_MAX_UPLOAD_REQUEST_BYTES", str(500 * 1024 * 1024))
@@ -366,7 +367,18 @@ async def _stream_add_uploads(
                 "file_start",
                 {"original_name": original_name, "saved_path": str(saved_path)},
             )
-            item = await _add_saved_file(kb_dir, saved_path, original_name, bundle=bundle)
+            add_task = asyncio.create_task(
+                _add_saved_file(kb_dir, saved_path, original_name, bundle=bundle)
+            )
+            try:
+                while not add_task.done():
+                    done, _ = await asyncio.wait({add_task}, timeout=ADD_SSE_KEEPALIVE_SECONDS)
+                    if add_task not in done:
+                        yield ": ping\n\n"
+                item = await add_task
+            finally:
+                if not add_task.done():
+                    add_task.cancel()
             results.append(item)
             yield _sse("file_done", _model_payload(item))
         final = _summarize_add_results(kb, results)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -721,6 +722,40 @@ def test_add_endpoint_streams_events(monkeypatch, kb_dir):
     ]
     assert events[0]["data"]["kb"] == kb
     assert events[-2]["data"]["added_count"] == 1
+
+
+def test_add_endpoint_streams_keepalive_while_file_is_processing(monkeypatch, kb_dir):
+    client = _client(monkeypatch)
+    kb = _use_named_kb(monkeypatch, kb_dir)
+
+    import openkb.api_helpers as api_helpers
+    from openkb.api_models import AddFileItem
+
+    assert 15 <= api_helpers.ADD_SSE_KEEPALIVE_SECONDS <= 30
+
+    async def slow_add(kb_dir, saved_path, original_name, *, bundle=None):
+        await asyncio.sleep(0.03)
+        return AddFileItem(
+            original_name=original_name,
+            saved_path=str(saved_path),
+            status="added",
+            message=f"{original_name} added to knowledge base.",
+        )
+
+    monkeypatch.setattr(api_helpers, "_add_saved_file", slow_add)
+    monkeypatch.setattr(api_helpers, "ADD_SSE_KEEPALIVE_SECONDS", 0.005)
+
+    response = client.post(
+        "/api/v1/add",
+        data={"kb": kb, "stream": "true"},
+        files=[("files", ("paper.md", b"# Paper", "text/markdown"))],
+        headers=_auth(),
+    )
+
+    assert response.status_code == 200
+    assert ": ping\n\n" in response.text
+    assert "event: final" in response.text
+    assert "event: done" in response.text
 
 
 def test_unknown_kb_returns_400(monkeypatch, tmp_path):


### PR DESCRIPTION
> [!WARNING]
> This pull request and its code were generated by AI (OpenAI Codex). Please review the implementation and tests carefully before merging.

## Problem

`POST /api/v1/add` can spend longer than Cloudflare's default **125-second Proxy Read Timeout** processing an uploaded document without emitting another Server-Sent Events (SSE) body chunk. Cloudflare defines this timeout between successive reads from the origin, so an otherwise healthy long-running ingestion can be terminated if the stream stays silent for too long.

An interrupted stream may appear in Chromium-based clients after the response headers have already returned HTTP 200 as:

```text
net::ERR_HTTP2_PROTOCOL_ERROR 200 (OK)
```

This is an observed symptom, not proof by itself that Cloudflare is the root cause. Confirming attribution requires comparing the proxied request with a direct-origin request and checking Cloudflare logs, a CF-Ray/HAR, or a browser NetLog.

## Why this approach

The HTML Standard recommends sending an SSE comment line (a line beginning with `:`) roughly every 15 seconds to protect event streams from proxy timeouts.

This fix therefore emits:

```text
: ping

```

every 15 seconds while a file is being processed. If Cloudflare forwards each SSE chunk normally, the interval stays well below its 125-second read timeout and is expected to prevent this specific timeout.

This condition matters:

- A normal proxied custom hostname or named Cloudflare Tunnel supports SSE.
- A Quick Tunnel on `*.trycloudflare.com` does **not** support SSE and may buffer `text/event-stream`; heartbeat comments cannot solve that configuration. Use a named tunnel or another SSE-capable route instead.
- This change does not address origin crashes, malformed HTTP/2 frames, compression/content-length errors, or request-upload stalls before the streaming response starts.

## What changed

- Run each streamed add operation as an asynchronous task.
- Emit the valid SSE comment `: ping\n\n` every 15 seconds while processing remains in progress.
- Preserve the existing `uploaded`, `file_start`, `file_done`, `final`, `error`, and `done` event contract.
- Cancel an unfinished task when the client closes the stream.
- Add a regression test that simulates slow processing, verifies the configured interval remains within 15-30 seconds, observes the keepalive comment, and confirms the final events are still delivered.

SSE clients ignore comment-only frames, so the frontend event payload contract is unchanged. Non-streaming requests are also unchanged.

## Validation

Application-level validation:

- `pytest -q tests/test_api.py tests/test_file_size.py` — 158 passed
- `mypy openkb/api_helpers.py openkb/api.py` — passed
- `ruff check .` — passed
- `ruff format --check .` — passed
- `git diff --check` — passed

The automated test confirms that Starlette emits the keepalive chunks and subsequently completes the SSE stream. It is not an end-to-end Cloudflare integration test.

## References

- [Cloudflare connection limits](https://developers.cloudflare.com/fundamentals/reference/connection-limits/)
- [Cloudflare Proxy Read Timeout setting](https://developers.cloudflare.com/cache/how-to/cache-rules/settings/)
- [HTML Standard: Server-Sent Events authoring notes](https://html.spec.whatwg.org/dev/server-sent-events.html#authoring-notes)
- [Cloudflare Tunnel setup and Quick Tunnel limitations](https://developers.cloudflare.com/tunnel/setup/)
- [Cloudflare troubleshooting and NetLog/HAR guidance](https://developers.cloudflare.com/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/)
