### PR TITLE
docs(config): document Moonshot/Kimi region-specific API base

### DIFF
--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -216,6 +216,27 @@ LLM_API_KEY=your-key-here
                               # Write it as bare `null` — not `None` or "null".
   ```
 
+- **Moonshot / Kimi** (`model: moonshot/...`) runs two separate platforms, each
+  issuing its own keys — a key from one will not authenticate against the
+  other's endpoint:
+
+  | Platform | Console | API base |
+  | --- | --- | --- |
+  | International | `platform.moonshot.ai` | `https://api.moonshot.ai/v1` (default) |
+  | China | `platform.moonshot.cn` | `https://api.moonshot.cn/v1` |
+
+  LiteLLM's `moonshot/` provider always uses the international endpoint unless
+  told otherwise. If your key is from `platform.moonshot.cn`, point LiteLLM at
+  the China base explicitly in `<kb>/.env`:
+
+  ```bash
+  MOONSHOT_API_BASE=https://api.moonshot.cn/v1
+  ```
+
+  A `litellm.AuthenticationError: ... MoonshotException - Invalid
+  Authentication` from a Moonshot/Kimi key you know is valid usually means
+  this region mismatch, not a bad key (#196).
+
 **Where keys are read from** (first match wins, existing env always respected):
 
 1. your shell environment

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -233,9 +233,9 @@ LLM_API_KEY=your-key-here
   MOONSHOT_API_BASE=https://api.moonshot.cn/v1
   ```
 
-  A `litellm.AuthenticationError: ... MoonshotException - Invalid
-  Authentication` from a Moonshot/Kimi key you know is valid usually means
-  this region mismatch, not a bad key (#196).
+  Seeing `litellm.AuthenticationError: ... MoonshotException - Invalid Authentication`
+  from a Moonshot/Kimi key you know is valid usually means this region
+  mismatch, not a bad key (#196).
 
 **Where keys are read from** (first match wins, existing env always respected):
 


### PR DESCRIPTION
## Summary
- Moonshot/Kimi issues separate keys per platform (`platform.moonshot.ai` vs `platform.moonshot.cn`), and LiteLLM's `moonshot/` provider always defaults to the international `.ai` endpoint
- A `.cn` key against that default fails with `litellm.AuthenticationError: ... MoonshotException - Invalid Authentication`, which reads like a bad key but is actually a region mismatch
- Documents the `MOONSHOT_API_BASE` override in `examples/configuration/README.md`, matching the existing Bedrock callout in the same file

**Scope note:** this is documentation only — it doesn't change any runtime behavior. A future user hitting this for the first time still gets the same opaque `AuthenticationError` with no in-product pointer to this doc. A follow-up could catch `AuthenticationError` for `moonshot/` models and print a hint at the source; this PR just answers the question #196 asked.

Fixes #196

## Test plan
- [x] Docs-only change — no code touched
- [x] Verified `MOONSHOT_API_BASE` is read by LiteLLM's moonshot provider (`litellm/llms/moonshot/chat/transformation.py`, `_get_openai_compatible_provider_info`)
- [x] Checked the added Markdown table/formatting renders correctly