### PR TITLE
docs: add OrcaRouter as a named OpenAI-compatible gateway provider

### DIFF
--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -175,6 +175,36 @@ It's opt-in by design: responses are stored on OpenRouter, so leave it off for
 zero-data-retention / regulated content. Only `openrouter/*` models read these
 headers; other providers ignore them.
 
+#### OrcaRouter (OpenAI-compatible gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model router
+that serves 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax
+and xAI from a single endpoint and API key. It also runs gateway-level,
+zero-trust security for AI agents on the same endpoint — screening every
+prompt/response and governing every tool call on a default-deny basis, with no
+application code changes.
+
+OrcaRouter routes by **provider-prefixed** model IDs (`openai/gpt-5.5`,
+`google/gemini-3-flash-preview`), so use the double-prefix form: LiteLLM strips
+the leading `openai/` provider prefix and sends the remaining id — which
+OrcaRouter requires to stay namespaced — to `OPENAI_API_BASE`. A bare
+`gpt-5.5` is rejected with a `503`.
+
+```yaml
+model: openai/openai/gpt-5.5     # LiteLLM strips one prefix; OrcaRouter sees openai/gpt-5.5
+language: en
+```
+
+```bash
+# <kb>/.env
+LLM_API_KEY=sk-orca-...
+OPENAI_API_BASE=https://api.orcarouter.ai/v1
+```
+
+Any provider-prefixed OrcaRouter id works the same way — write it as
+`openai/<id>`: `openai/google/gemini-3-flash-preview`,
+`openai/deepseek/deepseek-v4-flash`, or the router's own `openai/orcarouter/auto`.
+
 ---
 
 ## 3. API keys & providers


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a named OpenAI-compatible gateway in the configuration reference, wired the same way the existing OpenRouter provider section is documented. OrcaRouter is an OpenAI-compatible gateway: one API key (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `examples/configuration/README.md`: new "OrcaRouter (OpenAI-compatible gateway)" subsection, mirroring the existing OpenRouter / Copilot / Bedrock provider sections. It documents the double-prefix model form LiteLLM needs (`openai/openai/gpt-5.5` — LiteLLM strips one `openai/` provider prefix and OrcaRouter sees the namespaced `openai/gpt-5.5`) plus the `<kb>/.env` setup (`LLM_API_KEY` + `OPENAI_API_BASE`).

## Why the double prefix?

OrcaRouter routes by provider-prefixed model IDs. LiteLLM strips the leading `openai/` provider prefix before the request leaves, so the id OrcaRouter receives must still be namespaced — a bare `gpt-5.5` is rejected with a 503.

## Verification

- Live, through the exact wire path OpenKB uses (`litellm.acompletion` with `base_url` — the same call the agents SDK `LitellmModel` makes):
  - `openai/openai/gpt-5.5` → 200, resolves to `gpt-5.5-2026-04-24`
  - `openai/google/gemini-3-flash-preview` → 200
  - `openai/deepseek/deepseek-v4-flash` → 200
  - `openai/orcarouter/auto` → 200
  - `openai/gpt-5.5` (single prefix) → 503, confirming the double-prefix requirement
- Code trace: `OPENAI_API_BASE` is resolved by `resolve_credential_bundle` and threaded into `LitellmModel(base_url=...)`; LiteLLM also reads it natively for the `openai/` provider.
- Docs-only change (no Python, deps, or workflow files touched).

I'm an engineer on the OrcaRouter team.
