### PR TITLE
feat: add temporal claims to wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ When you add a document, the LLM:
 
 A single source might touch 10--15 wiki pages. Knowledge accumulates: each document enriches the existing wiki rather than sitting in isolation.
 
+### Temporal Claims
+
+Summary, concept, and entity pages can store time-based evidence in the
+`claims` frontmatter field. The field contains a one-line JSON array. OpenKB
+keeps old claims as history. OpenKB creates each `id` field. OpenKB also records
+candidate supersession links from the `supersedes` field. OpenKB validates each
+candidate link before OpenKB applies the link. OpenKB creates the
+`superseded_by` supersession links for the applied links.
+
+For strict current reads, OpenKB returns claims that have a `status` value of
+`validated`. OpenKB does not return claims that have a `status` value of
+`proposed`, `superseded`, or `abandoned`. A caller can request claims that have
+a `status` value of `proposed`.
+
+The optional `authority` field can have a value of `first_party`, `document`, or
+`assistant`. If an assistant claim has a `status` value of `validated`, OpenKB
+changes the value to `proposed`. An assistant claim cannot supersede a claim
+that has a `status` value of `validated`. Only a claim with an `authority` value
+of `first_party` can supersede another claim with an `authority` value of
+`first_party`.
+
+OpenKB applies the same `as_of` and `status` rules to claims that have an
+`authority` value of `document` and claims that do not have an `authority`
+field.
+
+The document compiler sets the `authority` field to `document` for each claim
+that a model creates. The compiler ignores the model value in the `authority`
+field. An external adapter can verify source authority. The adapter can then set
+the `authority` field to `first_party` or `assistant` through the public claims
+API. If a stored claim has the same `id` value as an incoming duplicate claim,
+OpenKB keeps the stored claim. OpenKB ignores every field and every supersession
+link from the incoming duplicate claim.
+
 # ⚙️ Usage
 
 OpenKB commands fall into two layers: the **wiki foundation** (compile + manage your knowledge) and **generators** (turn that wiki into useful output). Each links to a concrete walkthrough — a real artifact OpenKB generated from one sample paper (browse them all in [`examples/`](examples/)).

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -14,6 +14,32 @@ promote it into a lint (see `tests/test_file_size.py` for the pattern).
 - **Prefer shared utilities over hand-rolled helpers** so invariants stay
   centralized. Check `openkb/` for an existing helper before writing a new one.
 
+## Temporal claims
+- **Keep claim history.** OpenKB appends new claim records. OpenKB controls the
+  `id` field and the `superseded_by` supersession links. OpenKB does not define
+  the format of the `source_anchor` field.
+- **Use strict current reads.** By default, return only claims that have a
+  `status` value of `validated`. Return claims that have a `status` value of
+  `proposed` only after an explicit request. A claim that has a `status` value
+  of `proposed` cannot supersede a claim that has a `status` value of
+  `validated`. A claim that has a `status` value of `validated` or `abandoned`
+  can supersede a claim that has a `status` value of `validated` when all other
+  rules permit the supersession link.
+- **Limit assistant authority.** If an assistant claim has a `status` value of
+  `validated`, change the value to `proposed`. An assistant claim cannot enter
+  strict current reads. An assistant claim cannot supersede a claim that has a
+  `status` value of `validated`. Only a claim with an `authority` value of
+  `first_party` can supersede another claim with an `authority` value of
+  `first_party`. Claims with an `authority` value of `document` use the same
+  `as_of` and `status` rules as claims without an `authority` field.
+- **Ignore duplicate claim input.** If a stored claim has the same `id` value as
+  an incoming duplicate claim, keep the stored claim. Ignore every field and
+  every supersession link from the incoming duplicate claim.
+- **Limit compiler authority.** For each claim from a document compiler model,
+  set the `authority` field to `document`. An external adapter can verify source
+  authority. The adapter can then set the `authority` field to `first_party` or
+  `assistant` through the public claims API.
+
 ## I/O and state
 - **All wiki file writes go through `openkb/locks.py` / `openkb/mutation.py`**
   (atomic, crash-safe). No ad-hoc writes to the wiki tree.

--- a/openkb/agent/compiler.py
+++ b/openkb/agent/compiler.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import litellm
 
 from openkb import frontmatter
+from openkb.claims import claims_for_prompt, extract_raw_claims, merge_claims, normalize_claims
 from openkb.config import (
     DEFAULT_ENTITY_TYPES,
     get_extra_headers,
@@ -67,7 +68,7 @@ Full text:
 
 Write a summary page for this document in Markdown.
 
-Return a JSON object with two keys:
+Return a JSON object. Include these fields:
 - "description": A single sentence (under 100 chars) describing the document's main contribution
 - "content": The full summary in Markdown. Include key concepts, findings, ideas, \
 and [[wikilinks]] to concepts that could become cross-document concept pages
@@ -148,7 +149,7 @@ Write the concept page for: {title}
 This concept relates to the document "{doc_name}" summarized above.
 {update_instruction}
 
-Return a JSON object with two keys:
+Return a JSON object. Include these fields:
 - "description": A single sentence (under 100 chars) defining this concept
 - "content": The full concept page in Markdown. Include clear explanation, \
 key details from the source document, and [[wikilinks]] to related concepts \
@@ -164,17 +165,27 @@ Update the concept page for: {title}
 Current content of this page:
 {existing_content}
 
+Existing values from the "claims" field:
+{existing_claims}
+When you correct a claim, copy its exact "id" value to the "supersedes" field.
+
 New information from document "{doc_name}" (summarized above) should be \
 integrated into this page. Rewrite the full page incorporating the new \
 information naturally — do not just append. Preserve the existing structure \
 and intent of the page.
+
+Write the latest state that the source evidence supports.
+If you keep an old claim, identify the old claim as historical.
+If the old claim has a "status" value of "superseded", identify the old claim as superseded.
+If the old claim has a "status" value of "abandoned", identify the old claim as abandoned.
+Do not present an old claim as current.
 
 For [[wikilinks]] in the rewrite, follow the whitelist rules from the \
 message above: keep links whose target is in the whitelist, convert any \
 existing links whose target is NOT in the whitelist to plain text, and do \
 not invent new wikilink targets.
 
-Return a JSON object with two keys:
+Return a JSON object. Include these fields:
 - "description": A single sentence (under 100 chars) defining this concept (may differ from before)
 - "content": The rewritten full concept page in Markdown
 
@@ -186,7 +197,7 @@ Write the entity page for: {title} (type: {type})
 
 This entity relates to the document "{doc_name}" summarized above.
 
-Return a JSON object with three keys:
+Return a JSON object. Include these fields:
 - "description": A single sentence (under 100 chars) identifying this entity
 - "type": one of __ENTITY_TYPES__
 - "content": The full entity page in Markdown — what this entity is, the key
@@ -203,18 +214,58 @@ Update the entity page for: {title} (type: {type})
 Current content of this page:
 {existing_content}
 
+Existing values from the "claims" field:
+{existing_claims}
+When you correct a claim, copy its exact "id" value to the "supersedes" field.
+
 Integrate the new facts about this entity from document "{doc_name}"
 (summarized above). Rewrite the full page — do not just append. Preserve the
 existing structure and intent. Follow the whitelist rules from the message
 above for all [[wikilinks]].
 
-Return a JSON object with three keys:
+Write the latest state that the source evidence supports.
+If you keep an old claim, identify the old claim as historical.
+If the old claim has a "status" value of "superseded", identify the old claim as superseded.
+If the old claim has a "status" value of "abandoned", identify the old claim as abandoned.
+Do not present an old claim as current.
+
+Return a JSON object. Include these fields:
 - "description": A single sentence (under 100 chars) identifying this entity
 - "type": one of __ENTITY_TYPES__
 - "content": The rewritten full entity page in Markdown
 
 Return ONLY valid JSON, no fences.
 """
+
+_CLAIMS_FIELD_GUIDANCE = """\
+
+The JSON object can include a top-level "claims" field.
+The "claims" field must contain a JSON array.
+Each claim object must cite evidence from the source document.
+The "text" field must contain a non-empty string.
+The "as_of" field must contain an ISO-8601 date or datetime from the source evidence.
+The "status" field must have a value of "proposed", "validated", "superseded", or "abandoned".
+The "source_anchor" field must contain a non-empty evidence identifier.
+Set the "authority" field to "document".
+OpenKB sets the "authority" field to "document" before it writes the claim.
+Do not set the "authority" field to "first_party" or "assistant".
+An external adapter can verify source authority. The adapter can then set the "authority" field to "first_party" or "assistant" through the public claims API.
+Do not set the "id" field.
+Do not set the "superseded_by" field.
+OpenKB controls the "id" and "superseded_by" fields.
+When you correct a claim, copy its exact "id" value to the "supersedes" field.
+A claim with a "status" value of "proposed" cannot supersede a claim with a "status" value of "validated".
+Only a claim with a "status" value of "validated" or "abandoned" can supersede a claim with a "status" value of "validated".
+Do not invent a value for the "as_of" field.
+Do not invent a value for the "source_anchor" field.
+Do not set the "status" field to "validated" when the source evidence refutes the claim.
+If the source provides no time-based claim with evidence, set the "claims" field to [].
+"""
+_SUMMARY_USER += _CLAIMS_FIELD_GUIDANCE
+_CONCEPT_PAGE_USER += _CLAIMS_FIELD_GUIDANCE
+_CONCEPT_UPDATE_USER += _CLAIMS_FIELD_GUIDANCE
+_ENTITY_PAGE_USER += _CLAIMS_FIELD_GUIDANCE
+_ENTITY_UPDATE_USER += _CLAIMS_FIELD_GUIDANCE
 
 # NOTE: the prompt templates intentionally KEEP the literal ``__ENTITY_TYPES__``
 # token at import time. The effective entity-type list is resolved per-compile
@@ -938,23 +989,37 @@ def _remove_section_entry(lines: list[str], heading: str, link: str) -> bool:
 
 
 def _write_summary(
-    wiki_dir: Path, doc_name: str, summary: str, doc_type: str = "short", description: str = ""
+    wiki_dir: Path,
+    doc_name: str,
+    summary: str,
+    doc_type: str = "short",
+    description: str = "",
+    claims: list | None = None,
 ) -> None:
-    """Write summary page with frontmatter."""
+    """Write a summary page. Merge normalized claims when the caller supplies claims."""
     parts = frontmatter.split(summary)
     if parts is not None:
         _, summary = parts
         summary = summary.lstrip("\n")
     summaries_dir = wiki_dir / "summaries"
     summaries_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = summaries_dir / f"{doc_name}.md"
+    claims_to_write = None if claims is None else merge_claims([], claims)
+    if summary_path.exists():
+        existing_claims = _read_claims_from_text(summary_path.read_text(encoding="utf-8"))
+        claims_to_write = (
+            existing_claims if claims is None else merge_claims(existing_claims, claims)
+        )
     ext = "md" if doc_type == "short" else "json"
     fm_lines = [_yaml_kv_line("type", "Summary")]
     if description:
         fm_lines.append(_yaml_kv_line("description", description))
     fm_lines.append(f"doc_type: {doc_type}")
     fm_lines.append(_yaml_kv_line("full_text", f"sources/{doc_name}.{ext}"))
+    if claims_to_write:
+        fm_lines.append(frontmatter.json_line("claims", claims_to_write))
     fm_block = "---\n" + "\n".join(fm_lines) + "\n---\n\n"
-    atomic_write_text(summaries_dir / f"{doc_name}.md", fm_block + summary)
+    atomic_write_text(summary_path, fm_block + summary)
 
 
 _SAFE_NAME_RE = re.compile(r"[^\w\-]")
@@ -972,8 +1037,52 @@ _yaml_list_line = frontmatter.list_line
 _parse_yaml_list_value = frontmatter.parse_list_value
 
 
+def _read_claims_from_text(text: str) -> list[dict]:
+    """Read the stored `claims` field. Normalize each claim."""
+    return normalize_claims(frontmatter.parse(text).get("claims"), log_label="page-claims")
+
+
+def _claims_from_model(page_object: dict | None, *, log_label: str) -> list[dict] | None:
+    """Set each model `authority` field to `document`. Normalize each claim."""
+    raw = extract_raw_claims(page_object)
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        raw = [
+            {**item, "authority": "document"} if isinstance(item, dict) else item for item in raw
+        ]
+    return normalize_claims(
+        raw,
+        log_label=log_label,
+        preserve_superseded_by=False,
+    )
+
+
+def _apply_claims_line(fm_block: str, claims: list[dict] | None) -> str:
+    """Keep the `claims` field when `claims` is `None`. Replace the field for all other values."""
+    if claims is None:
+        return fm_block
+    if claims:
+        return frontmatter.set_json_line(fm_block, "claims", claims)
+    return frontmatter.drop_line(fm_block, "claims")
+
+
+def _merge_page_claims(existing_text: str | None, new_claims: list | None) -> list[dict] | None:
+    """Merge new claims with stored claims. Return `None` when `new_claims` is `None`."""
+    if new_claims is None:
+        return None
+    existing = _read_claims_from_text(existing_text) if existing_text else []
+    return merge_claims(existing, new_claims)
+
+
 def _write_concept(
-    wiki_dir: Path, name: str, content: str, source_file: str, is_update: bool, brief: str = ""
+    wiki_dir: Path,
+    name: str,
+    content: str,
+    source_file: str,
+    is_update: bool,
+    brief: str = "",
+    claims: list | None = None,
 ) -> None:
     """Write or update a concept page, managing the sources frontmatter."""
     concepts_dir = wiki_dir / "concepts"
@@ -986,6 +1095,7 @@ def _write_concept(
 
     if is_update and path.exists():
         existing = path.read_text(encoding="utf-8")
+        merged_claims = _merge_page_claims(existing, claims)
         if source_file not in existing:
             existing = _prepend_source_to_frontmatter(existing, source_file)
         # Strip frontmatter from LLM content to avoid duplicate blocks
@@ -1015,6 +1125,8 @@ def _write_concept(
             ]
             if brief:
                 fm_lines.append(_yaml_kv_line("description", brief))
+            if merged_claims:
+                fm_lines.append(frontmatter.json_line("claims", merged_claims))
             existing = frontmatter.block(fm_lines) + clean
             atomic_write_text(path, existing)
             return
@@ -1027,18 +1139,22 @@ def _write_concept(
                 fm_block = _set_fm_line(fm_block, "description", brief)
             # Drop legacy brief: lines (migrated to description:).
             fm_block = frontmatter.drop_line(fm_block, "brief")
+            fm_block = _apply_claims_line(fm_block, merged_claims)
             existing = fm_block + body
         atomic_write_text(path, existing)
     else:
         clean_parts = frontmatter.split(content)
         if clean_parts is not None:
             content = clean_parts[1].lstrip("\n")
+        merged_claims = _merge_page_claims(None, claims)
         fm_lines = [
             _yaml_kv_line("type", "Concept"),
             _yaml_list_line("sources", [source_file]),
         ]
         if brief:
             fm_lines.append(_yaml_kv_line("description", brief))
+        if merged_claims:
+            fm_lines.append(frontmatter.json_line("claims", merged_claims))
         fm_block = "---\n" + "\n".join(fm_lines) + "\n---\n\n"
         atomic_write_text(path, fm_block + content)
 
@@ -1052,6 +1168,7 @@ def _write_entity(
     brief: str = "",
     type_: str = "other",
     aliases: list[str] | None = None,
+    claims: list | None = None,
 ) -> None:
     """Write or update an entity page in entities/, managing frontmatter.
 
@@ -1072,17 +1189,20 @@ def _write_entity(
     clean_parts = frontmatter.split(content)
     clean = clean_parts[1].lstrip("\n") if clean_parts is not None else content
 
-    def _build_entity_frontmatter(sources: list[str]) -> str:
+    def _build_entity_frontmatter(sources: list[str], page_claims: list[dict] | None) -> str:
         fm_lines = [_yaml_list_line("sources", sources)]
         fm_lines.append(_yaml_kv_line("type", (type_ or "other").title()))
         if brief:
             fm_lines.append(_yaml_kv_line("description", brief))
         if aliases:
             fm_lines.append(_yaml_list_line("aliases", aliases))
+        if page_claims:
+            fm_lines.append(frontmatter.json_line("claims", page_claims))
         return "---\n" + "\n".join(fm_lines) + "\n---\n\n"
 
     if is_update and path.exists():
         existing = path.read_text(encoding="utf-8")
+        merged_claims = _merge_page_claims(existing, claims)
         if source_file not in existing:
             existing = _prepend_source_to_frontmatter(existing, source_file)
         ex_parts = frontmatter.split(existing)
@@ -1093,6 +1213,7 @@ def _write_entity(
             # Drop any legacy ``brief:`` key (migrated to ``description:``),
             # mirroring _write_concept's update path.
             fm_block = frontmatter.drop_line(fm_block, "brief")
+            fm_block = _apply_claims_line(fm_block, merged_claims)
             existing = fm_block + "\n" + clean
         else:
             # Malformed/absent frontmatter (opening ``---`` with no closing
@@ -1108,11 +1229,12 @@ def _write_entity(
                         recovered = parsed
                     break
             merged = [source_file] + [s for s in recovered if s != source_file]
-            existing = _build_entity_frontmatter(merged) + clean
+            existing = _build_entity_frontmatter(merged, merged_claims) + clean
         atomic_write_text(path, existing)
         return
 
-    atomic_write_text(path, _build_entity_frontmatter([source_file]) + clean)
+    merged_claims = _merge_page_claims(None, claims)
+    atomic_write_text(path, _build_entity_frontmatter([source_file], merged_claims) + clean)
 
 
 _set_fm_line = frontmatter.set_line
@@ -1604,6 +1726,7 @@ async def _compile_concepts(
     rewrite_summary: bool = False,
     entity_types: list[str] | None = None,
     bundle=None,
+    summary_claims: list | None = None,
 ) -> None:
     """Shared Steps 2-4: concepts plan → generate/update → index.
 
@@ -1669,7 +1792,7 @@ async def _compile_concepts(
                 doc_name,
                 ghosts[:5],
             )
-        _write_summary(wiki_dir, doc_name, cleaned, description=doc_brief)
+        _write_summary(wiki_dir, doc_name, cleaned, description=doc_brief, claims=summary_claims)
 
     try:
         parsed = _parse_json(plan_raw)
@@ -1832,7 +1955,7 @@ async def _compile_concepts(
     # --- Step 3: Generate/update concept pages concurrently (A cached) ---
     semaphore = asyncio.Semaphore(max_concurrency)
 
-    async def _gen_create(concept: dict) -> tuple[str, str, bool, str]:
+    async def _gen_create(concept: dict) -> tuple[str, str, bool, str, list | None]:
         name = concept["name"]
         title = concept.get("title", name)
         async with semaphore:
@@ -1856,18 +1979,20 @@ async def _compile_concepts(
                 response_format=_JSON_RESPONSE_FORMAT,
                 bundle=bundle,
             )
-        brief, content, _ = _page_fields(raw)
+        brief, content, obj = _page_fields(raw)
         _require_nonempty_content(content, name)
-        return name, content, False, brief
+        return name, content, False, brief, _claims_from_model(obj, log_label=f"concept:{name}")
 
-    async def _gen_update(concept: dict) -> tuple[str, str, bool, str]:
+    async def _gen_update(concept: dict) -> tuple[str, str, bool, str, list | None]:
         name = concept["name"]
         title = concept.get("title", name)
         concept_path = wiki_dir / "concepts" / f"{_sanitize_concept_name(name)}.md"
+        existing_claims_prompt = "(none)"
         if concept_path.exists():
             raw_text = concept_path.read_text(encoding="utf-8")
             ex_parts = frontmatter.split(raw_text)
             existing_content = ex_parts[1].strip() if ex_parts is not None else raw_text
+            existing_claims_prompt = claims_for_prompt(_read_claims_from_text(raw_text))
         else:
             existing_content = "(page not found — create from scratch)"
         async with semaphore:
@@ -1884,6 +2009,7 @@ async def _compile_concepts(
                             title=title,
                             doc_name=doc_name,
                             existing_content=existing_content,
+                            existing_claims=existing_claims_prompt,
                         ),
                     },
                 ],
@@ -1891,11 +2017,11 @@ async def _compile_concepts(
                 response_format=_JSON_RESPONSE_FORMAT,
                 bundle=bundle,
             )
-        brief, content, _ = _page_fields(raw)
+        brief, content, obj = _page_fields(raw)
         _require_nonempty_content(content, name)
-        return name, content, True, brief
+        return name, content, True, brief, _claims_from_model(obj, log_label=f"concept:{name}")
 
-    async def _gen_entity_create(ent: dict) -> tuple[str, str, str, str]:
+    async def _gen_entity_create(ent: dict) -> tuple[str, str, str, str, list | None]:
         name = ent["name"]
         title = ent.get("title", name)
         etype = ent.get("type", "other")
@@ -1921,19 +2047,25 @@ async def _compile_concepts(
                 bundle=bundle,
             )
         brief, content, obj = _page_fields(raw)
-        etype_out = obj.get("type") if obj and obj.get("type") in valid_types else etype
+        etype_out = etype
+        if obj:
+            candidate_type = obj.get("type")
+            if isinstance(candidate_type, str) and candidate_type in valid_types:
+                etype_out = candidate_type
         _require_nonempty_content(content, name)
-        return name, content, brief, etype_out
+        return name, content, brief, etype_out, _claims_from_model(obj, log_label=f"entity:{name}")
 
-    async def _gen_entity_update(ent: dict) -> tuple[str, str, str, str]:
+    async def _gen_entity_update(ent: dict) -> tuple[str, str, str, str, list | None]:
         name = ent["name"]
         title = ent.get("title", name)
         etype = ent.get("type", "other")
         epath = wiki_dir / "entities" / f"{_sanitize_concept_name(name)}.md"
+        existing_claims_prompt = "(none)"
         if epath.exists():
             raw_text = epath.read_text(encoding="utf-8")
             ex_parts = frontmatter.split(raw_text)
             existing_content = ex_parts[1].strip() if ex_parts is not None else raw_text
+            existing_claims_prompt = claims_for_prompt(_read_claims_from_text(raw_text))
         else:
             existing_content = "(page not found — create from scratch)"
         async with semaphore:
@@ -1951,6 +2083,7 @@ async def _compile_concepts(
                             type=etype,
                             doc_name=doc_name,
                             existing_content=existing_content,
+                            existing_claims=existing_claims_prompt,
                         ).replace("__ENTITY_TYPES__", types_str),
                     },
                 ],
@@ -1959,9 +2092,13 @@ async def _compile_concepts(
                 bundle=bundle,
             )
         brief, content, obj = _page_fields(raw)
-        etype_out = obj.get("type") if obj and obj.get("type") in valid_types else etype
+        etype_out = etype
+        if obj:
+            candidate_type = obj.get("type")
+            if isinstance(candidate_type, str) and candidate_type in valid_types:
+                etype_out = candidate_type
         _require_nonempty_content(content, name)
-        return name, content, brief, etype_out
+        return name, content, brief, etype_out, _claims_from_model(obj, log_label=f"entity:{name}")
 
     tasks = []
     tasks.extend(_gen_create(c) for c in create_items)
@@ -1977,10 +2114,10 @@ async def _compile_concepts(
 
     concept_names: list[str] = []
     concept_briefs_map: dict[str, str] = {}
-    pending_writes: list[tuple[str, str, bool, str]] = []
+    pending_writes: list[tuple[str, str, bool, str, list | None]] = []
     entity_names: list[str] = []
     entity_meta: dict[str, tuple[str, str]] = {}
-    entity_pending: list[tuple[str, str, str, str]] = []
+    entity_pending: list[tuple[str, str, str, str, list | None]] = []
 
     # Concepts and entities are independent and share the cached prompt
     # context + the same concurrency ``semaphore``, so overlap them in one
@@ -2010,8 +2147,8 @@ async def _compile_concepts(
                 logger.warning("Concept generation failed: %s", r)
                 failure_types.append(type(r).__name__)
                 continue
-            name, page_content, is_update, brief = r
-            pending_writes.append((name, page_content, is_update, brief))
+            name, page_content, is_update, brief, page_claims = r
+            pending_writes.append((name, page_content, is_update, brief, page_claims))
             safe_name = _sanitize_concept_name(name)
             concept_names.append(safe_name)
             if brief:
@@ -2035,8 +2172,8 @@ async def _compile_concepts(
                 logger.warning("Entity generation failed: %s", r)
                 entity_failure_types.append(type(r).__name__)
                 continue
-            name, page_content, brief, etype = r
-            entity_pending.append((name, page_content, brief, etype))
+            name, page_content, brief, etype, page_claims = r
+            entity_pending.append((name, page_content, brief, etype, page_claims))
 
         ewritten = len(entity_pending)
         if ewritten < etotal:
@@ -2052,7 +2189,7 @@ async def _compile_concepts(
             sys.stdout.flush()
 
     # Strip ghost wikilinks from entity bodies and write each page.
-    for name, page_content, brief, etype in entity_pending:
+    for name, page_content, brief, etype, page_claims in entity_pending:
         cleaned, ghosts = strip_ghost_wikilinks(page_content, known_targets)
         if ghosts:
             logger.info(
@@ -2063,14 +2200,23 @@ async def _compile_concepts(
             )
         safe = _sanitize_concept_name(name)
         is_update = (wiki_dir / "entities" / f"{safe}.md").exists()
-        _write_entity(wiki_dir, name, cleaned, source_file, is_update, brief=brief, type_=etype)
+        _write_entity(
+            wiki_dir,
+            name,
+            cleaned,
+            source_file,
+            is_update,
+            brief=brief,
+            type_=etype,
+            claims=page_claims,
+        )
         entity_names.append(safe)
         entity_meta[safe] = (etype, brief)
 
     # Strip unresolved wikilinks from concept bodies before writing. The
     # whitelist includes existing files + this round's planned slugs +
     # the summary for this document.
-    for i, (name, page_content, is_update, brief) in enumerate(pending_writes):
+    for i, (name, page_content, is_update, brief, page_claims) in enumerate(pending_writes):
         cleaned, ghosts = strip_ghost_wikilinks(page_content, known_targets)
         if ghosts:
             logger.info(
@@ -2079,7 +2225,7 @@ async def _compile_concepts(
                 name,
                 ghosts[:5],
             )
-        pending_writes[i] = (name, cleaned, is_update, brief)
+        pending_writes[i] = (name, cleaned, is_update, brief, page_claims)
 
     # --- Optional Step 3a: LLM rewrite the summary with full whitelist ---
     # Only for the short-doc path. The long-doc path leaves the indexer-
@@ -2150,10 +2296,16 @@ async def _compile_concepts(
                     doc_name,
                     fallback_ghosts[:5],
                 )
-        _write_summary(wiki_dir, doc_name, final_summary, description=doc_brief)
+        _write_summary(
+            wiki_dir,
+            doc_name,
+            final_summary,
+            description=doc_brief,
+            claims=summary_claims,
+        )
 
     # --- Write concept pages to disk ---
-    for name, page_content, is_update, brief in pending_writes:
+    for name, page_content, is_update, brief, page_claims in pending_writes:
         _write_concept(
             wiki_dir,
             name,
@@ -2161,6 +2313,7 @@ async def _compile_concepts(
             source_file,
             is_update,
             brief=brief,
+            claims=page_claims,
         )
 
     # --- Step 3b: Process related items (code only, no LLM) ---
@@ -2257,13 +2410,24 @@ async def compile_short_doc(
         response_format=_JSON_RESPONSE_FORMAT,
         bundle=bundle,
     )
+    summary_claims: list | None = None
     try:
         summary_parsed = _parse_json(summary_raw)
-        doc_brief = summary_parsed.get("description", "")
-        summary = summary_parsed.get("content", summary_raw)
+        if isinstance(summary_parsed, dict):
+            doc_brief = summary_parsed.get("description", "")
+            summary = summary_parsed.get("content", summary_raw)
+            summary_claims = _claims_from_model(
+                summary_parsed,
+                log_label=f"summary:{doc_name}",
+            )
+        else:
+            doc_brief = ""
+            summary = summary_raw
+            summary_claims = None
     except (json.JSONDecodeError, ValueError):
         doc_brief = ""
         summary = summary_raw
+        summary_claims = None
 
     # --- Steps 2-4: Concept plan → generate/update → summary rewrite → index ---
     try:
@@ -2281,6 +2445,7 @@ async def compile_short_doc(
             rewrite_summary=True,
             entity_types=entity_types,
             bundle=bundle,
+            summary_claims=summary_claims,
         )
     finally:
         # Close per-loop litellm async clients before asyncio.run tears this

--- a/openkb/agent/query.py
+++ b/openkb/agent/query.py
@@ -10,6 +10,7 @@ from agents import Agent, Runner, ToolOutputImage, ToolOutputText, function_tool
 from openkb.agent.tools import (
     artifact_event_from_write,
     get_wiki_page_content,
+    read_current_claims,
     read_wiki_file,
     read_wiki_image,
     write_kb_file,
@@ -33,18 +34,25 @@ You are OpenKB, a knowledge-base Q&A agent. You answer questions by searching th
 3. Read concept pages (concepts/) for cross-document synthesis.
 4. For "who/what is X" questions about a specific named person, organization,
    place, or product, read the matching page in entities/ first.
-5. When you need detailed source document content, each summary page has a
+5. For current claims, find the wiki page for the question topic. Then call
+   read_current_page_claims(path). By default, the tool uses strict current
+   reads. Strict current reads return claims that have a "status" value of
+   "validated". Set include_proposed=true only when the question asks for claims
+   that have a "status" value of "proposed". Do not report a claim with a
+   "status" value of "proposed" as a claim with a "status" value of
+   "validated".
+6. When you need detailed source document content, each summary page has a
    `full_text` frontmatter field with the path to the original document content:
    - Short documents (doc_type: short): read_file with that path.
    - PageIndex documents (doc_type: pageindex): use get_page_content(doc_name, pages)
      with tight page ranges. The summary shows document tree structure with page
      ranges to help you target. Never fetch the whole document.
-6. Source content may reference images. Short-doc .md pages link them
+7. Source content may reference images. Short-doc .md pages link them
    note-relative (e.g. ![image](images/doc/file.png), resolved from
    wiki/sources/); long-doc JSON page metadata lists them wiki-root-relative
    (e.g. sources/images/doc/file.png). Pass either form as seen to the
    get_image tool — it accepts both.
-7. Synthesize a clear, concise, well-cited answer grounded in wiki content.
+8. Synthesize a clear, concise, well-cited answer grounded in wiki content.
 
 Answer based only on wiki content. Be concise.
 Before each tool call, output one short sentence explaining the reason.
@@ -101,6 +109,18 @@ def build_query_agent(
             return ToolOutputImage(image_url=result["image_url"])
         return ToolOutputText(text=result["text"])
 
+    @function_tool
+    def read_current_page_claims(path: str, include_proposed: bool = False) -> str:
+        """Read page claims. Return the claims as JSON.
+
+        Args:
+            path: File path relative to wiki root.
+            include_proposed: Include claims that have a `status` value of `proposed`.
+
+        By default, this tool uses strict current reads.
+        """
+        return read_current_claims(path, wiki_root, include_proposed=include_proposed)
+
     from agents.model_settings import ModelSettings
 
     if bundle is not None:
@@ -117,7 +137,7 @@ def build_query_agent(
     return Agent(
         name="wiki-query",
         instructions=instructions,
-        tools=[read_file, get_page_content, get_image],
+        tools=[read_file, get_page_content, get_image, read_current_page_claims],
         model=f"litellm/{model}",
         model_settings=ModelSettings(**model_settings),
     )

--- a/openkb/agent/tools.py
+++ b/openkb/agent/tools.py
@@ -11,6 +11,8 @@ import contextlib
 import json as _json
 from pathlib import Path, PurePosixPath
 
+from openkb import frontmatter
+from openkb.claims import current_claims
 from openkb.locks import atomic_write_text
 
 
@@ -55,6 +57,24 @@ def read_wiki_file(path: str, wiki_root: str) -> str:
     if not full_path.exists():
         return f"File not found: {path}"
     return full_path.read_text(encoding="utf-8")
+
+
+def read_current_claims(path: str, wiki_root: str, *, include_proposed: bool = False) -> str:
+    """Return page claims as JSON.
+
+    By default, use strict current reads. Strict current reads return claims that
+    have a `status` value of `validated`. If `include_proposed` is `True`, also
+    return claims that have a `status` value of `proposed`.
+    """
+    root = Path(wiki_root).resolve()
+    full_path = (root / path).resolve()
+    if not full_path.is_relative_to(root):
+        return "Access denied. The path is outside the wiki root."
+    if not full_path.is_file():
+        return f"OpenKB cannot find the file: {path}"
+    page = frontmatter.parse(full_path.read_text(encoding="utf-8"))
+    claims = current_claims(page.get("claims"), include_proposed=include_proposed)
+    return _json.dumps(claims, ensure_ascii=False)
 
 
 def parse_pages(pages: str) -> list[int]:

--- a/openkb/claims.py
+++ b/openkb/claims.py
@@ -1,0 +1,325 @@
+"""Manage deterministic claims in OpenKB page frontmatter.
+
+Each claim is a JSON evidence record. OpenKB controls the `id` and
+`superseded_by` fields. Input can contain a `supersedes` field. OpenKB validates
+each supersession link in the `supersedes` field. An external adapter can define
+the format of the `source_anchor` field before it calls this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import date, datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CLAIM_STATUSES = frozenset({"proposed", "validated", "superseded", "abandoned"})
+AUTHORITY_ROLES = frozenset({"first_party", "assistant", "document"})
+_ISO_AS_OF_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}"
+    r"(?:[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?"
+    r"(?:Z|[+-]\d{2}:?\d{2})?)?$"
+)
+
+
+def claim_id(text: str, as_of: str, source_anchor: str) -> str:
+    """Return a stable `id` value from `text`, `as_of`, and `source_anchor`.
+
+    Ignore a model-supplied `id` value. Use the first 16 characters of the
+    SHA-256 digest.
+    """
+    payload = json.dumps(
+        [text.strip(), as_of.strip(), source_anchor.strip()],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _parse_as_of(value: str) -> tuple[str, date | datetime] | None:
+    """Parse the `as_of` field as an ISO date or datetime."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or not _ISO_AS_OF_RE.fullmatch(candidate):
+        return None
+    if len(candidate) == 10:
+        try:
+            return "date", date.fromisoformat(candidate)
+        except ValueError:
+            return None
+
+    normalized = candidate.replace(" ", "T")
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    if len(normalized) >= 5 and normalized[-5] in "+-" and normalized[-3] != ":":
+        normalized = normalized[:-2] + ":" + normalized[-2:]
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return "datetime", parsed
+
+
+def as_of_allows_supersession(incoming_as_of: str, old_as_of: str) -> bool:
+    """Return `True` when the new `as_of` value is not earlier than the old value."""
+    incoming = _parse_as_of(incoming_as_of)
+    old = _parse_as_of(old_as_of)
+    if incoming is None or old is None:
+        return False
+    if incoming[0] == "date" or old[0] == "date":
+        incoming_date = _calendar_day(incoming[1])
+        old_date = _calendar_day(old[1])
+        return incoming_date >= old_date
+    return incoming[1] >= old[1]
+
+
+def _calendar_day(value: date | datetime) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def normalize_claim(
+    raw: Any,
+    *,
+    log_label: str = "claim",
+    preserve_superseded_by: bool = True,
+) -> dict[str, Any] | None:
+    """Validate one claim. Set its `id` field from the claim identity fields."""
+    if not isinstance(raw, dict):
+        logger.warning("%s: OpenKB dropped a claim that is not a JSON object.", log_label)
+        return None
+
+    text = raw.get("text")
+    as_of = raw.get("as_of")
+    status = raw.get("status")
+    source_anchor = raw.get("source_anchor")
+    if not isinstance(text, str) or not text.strip():
+        logger.warning("%s: OpenKB dropped a claim because the `text` field is empty.", log_label)
+        return None
+    if not isinstance(as_of, str) or _parse_as_of(as_of) is None:
+        logger.warning(
+            "%s: OpenKB dropped a claim because the `as_of` field is invalid.",
+            log_label,
+        )
+        return None
+    if not isinstance(status, str) or status not in CLAIM_STATUSES:
+        logger.warning(
+            "%s: OpenKB dropped a claim because the `status` field is invalid.",
+            log_label,
+        )
+        return None
+    if not isinstance(source_anchor, str) or not source_anchor.strip():
+        logger.warning(
+            "%s: OpenKB dropped a claim because the `source_anchor` field is empty.",
+            log_label,
+        )
+        return None
+
+    authority = raw.get("authority")
+    if authority is not None and (
+        not isinstance(authority, str) or authority not in AUTHORITY_ROLES
+    ):
+        logger.warning(
+            "%s: OpenKB dropped a claim because the `authority` field is invalid.",
+            log_label,
+        )
+        return None
+    if authority == "assistant" and status == "validated":
+        logger.warning(
+            "%s: OpenKB changed the assistant claim `status` value from `validated` to `proposed`.",
+            log_label,
+        )
+        status = "proposed"
+
+    text = text.strip()
+    as_of = as_of.strip()
+    source_anchor = source_anchor.strip()
+    normalized: dict[str, Any] = {
+        "id": claim_id(text, as_of, source_anchor),
+        "text": text,
+        "as_of": as_of,
+        "status": status,
+        "source_anchor": source_anchor,
+        "supersedes": _string_list(raw.get("supersedes")),
+        "superseded_by": (_string_list(raw.get("superseded_by")) if preserve_superseded_by else []),
+    }
+    if authority is not None:
+        normalized["authority"] = authority
+    return normalized
+
+
+def normalize_claims(
+    raw: Any,
+    *,
+    log_label: str = "claims",
+    preserve_superseded_by: bool = True,
+) -> list[dict[str, Any]]:
+    """Normalize the `claims` JSON array. Keep the first claim for each `id` value."""
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        logger.warning(
+            "%s: OpenKB ignored the `claims` field because it is not a JSON array.",
+            log_label,
+        )
+        return []
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in raw:
+        claim = normalize_claim(
+            item,
+            log_label=log_label,
+            preserve_superseded_by=preserve_superseded_by,
+        )
+        if claim is not None and claim["id"] not in seen:
+            result.append(claim)
+            seen.add(claim["id"])
+    return result
+
+
+def merge_claims(existing: list | None, new: list | None) -> list[dict[str, Any]]:
+    """Append new claims. Then apply page-local supersession links.
+
+    Keep a stored claim when an incoming duplicate claim has the same `id` value.
+    Ignore every field and every supersession link from the incoming duplicate
+    claim. Ignore each new `superseded_by` field.
+    Apply a supersession link only to a claim on the same page.
+    Ignore a supersession link that points to its own claim.
+    Apply a supersession link only when the `as_of`, `status`, and `authority`
+    fields permit the supersession link.
+    Repeated input does not create duplicate claims or links.
+    """
+    prior = normalize_claims(existing or [], log_label="existing-claims")
+    incoming = normalize_claims(
+        new or [],
+        log_label="new-claims",
+        preserve_superseded_by=False,
+    )
+    by_id = {claim["id"]: dict(claim) for claim in prior}
+    order = [claim["id"] for claim in prior]
+    pending: list[tuple[str, str, list[str]]] = []
+
+    for claim in incoming:
+        claim_id_value = claim["id"]
+        if claim_id_value in by_id:
+            continue
+        by_id[claim_id_value] = dict(claim)
+        order.append(claim_id_value)
+        pending.append(
+            (
+                claim_id_value,
+                claim["as_of"],
+                list(claim.get("supersedes", [])),
+            )
+        )
+
+    for incoming_id, incoming_as_of, superseded_ids in pending:
+        for old_id in superseded_ids:
+            if old_id == incoming_id:
+                continue
+            old = by_id.get(old_id)
+            if old is None:
+                continue
+            stored_incoming = by_id[incoming_id]
+            stored_incoming_status = stored_incoming["status"]
+            if old["status"] == "validated" and stored_incoming.get("authority") == "assistant":
+                logger.warning(
+                    "OpenKB rejected supersession link %s <- %s. An assistant claim cannot "
+                    "supersede a claim that has a `status` value of `validated`.",
+                    old_id,
+                    incoming_id,
+                )
+                continue
+            if (
+                old.get("authority") == "first_party"
+                and stored_incoming.get("authority") != "first_party"
+            ):
+                logger.warning(
+                    "OpenKB rejected supersession link %s <- %s. Only a claim that has an "
+                    "`authority` value of `first_party` can supersede a claim that has an "
+                    "`authority` value of `first_party`.",
+                    old_id,
+                    incoming_id,
+                )
+                continue
+            if old["status"] == "validated" and stored_incoming_status not in {
+                "validated",
+                "abandoned",
+            }:
+                logger.warning(
+                    "OpenKB rejected supersession link %s <- %s. The new claim must have a "
+                    "`status` value of `validated` or `abandoned`.",
+                    old_id,
+                    incoming_id,
+                )
+                continue
+            if not as_of_allows_supersession(incoming_as_of, old["as_of"]):
+                logger.warning(
+                    "OpenKB rejected supersession link %s <- %s. The new `as_of` value is "
+                    "earlier than the old `as_of` value, or OpenKB cannot compare the values.",
+                    old_id,
+                    incoming_id,
+                )
+                continue
+            old["status"] = "superseded"
+            reverse = old.setdefault("superseded_by", [])
+            if incoming_id not in reverse:
+                reverse.append(incoming_id)
+
+    return [by_id[claim_id_value] for claim_id_value in order]
+
+
+def current_claims(
+    claims: list[dict] | None,
+    *,
+    include_proposed: bool = False,
+) -> list[dict[str, Any]]:
+    """Return current claims. Do not change the input.
+
+    By default, use strict current reads. Strict current reads return claims that
+    have a `status` value of `validated`. If `include_proposed` is `True`, also
+    return claims that have a `status` value of `proposed`. Do not return claims
+    that have a `status` value of `superseded` or `abandoned`.
+    """
+    allowed = {"validated", "proposed"} if include_proposed else {"validated"}
+    normalized = normalize_claims(claims or [], log_label="current-claims")
+    return [dict(claim) for claim in normalized if claim["status"] in allowed]
+
+
+def claims_for_prompt(claims: list[dict] | None) -> str:
+    """Return compact JSON for an update prompt. Include `id` values and evidence."""
+    normalized = normalize_claims(claims or [], log_label="prompt-claims")
+    if not normalized:
+        return "(none)"
+    fields = (
+        "id",
+        "text",
+        "as_of",
+        "status",
+        "source_anchor",
+        "authority",
+        "supersedes",
+    )
+    compact = [{key: claim[key] for key in fields if key in claim} for claim in normalized]
+    return json.dumps(compact, ensure_ascii=False, separators=(",", ":"))
+
+
+def extract_raw_claims(page_object: dict | None) -> Any:
+    """Return the optional `claims` field from a compiler response."""
+    return page_object.get("claims") if isinstance(page_object, dict) else None

--- a/openkb/frontmatter.py
+++ b/openkb/frontmatter.py
@@ -30,6 +30,11 @@ def list_line(key: str, items) -> str:
     return f"{key}: {json.dumps(list(items), ensure_ascii=False)}"
 
 
+def json_line(key: str, value) -> str:
+    """Return one YAML field. Write `value` as one line of JSON."""
+    return f"{key}: {json.dumps(value, ensure_ascii=False)}"
+
+
 def block(lines: list[str]) -> str:
     """Assemble a complete frontmatter block (with delimiters + trailing blank)."""
     return "---\n" + "\n".join(lines) + "\n---\n\n"
@@ -99,7 +104,16 @@ def set_line(fm_block: str, key: str, value: str) -> str:
     opening ``---``. A lambda replacement is used so values containing regex
     backrefs (``\\1``, ``\\g<…>``) are inserted literally.
     """
-    line = kv_line(key, value)
+    return set_raw_line(fm_block, key, kv_line(key, value))
+
+
+def set_json_line(fm_block: str, key: str, value) -> str:
+    """Set one JSON field in a frontmatter block. Add the field if it is absent."""
+    return set_raw_line(fm_block, key, json_line(key, value))
+
+
+def set_raw_line(fm_block: str, key: str, line: str) -> str:
+    """Set one complete frontmatter line. Add the line if it is absent."""
     if re.search(rf"^{re.escape(key)}:", fm_block, flags=re.MULTILINE):
         return re.sub(
             rf"^{re.escape(key)}:.*", lambda _m: line, fm_block, count=1, flags=re.MULTILINE

--- a/openkb/schema.py
+++ b/openkb/schema.py
@@ -56,6 +56,45 @@ Operations: ingest, query, lint
   `Concept`, or a capitalized entity subtype (e.g. `Organization`). This is the
   one field OKF requires; consumers use it for routing/filtering/presentation.
 - `description:` — a single-sentence one-liner (the field formerly named `brief`).
+- `claims:` — optional one-line JSON array of time-based evidence claims.
+  - Each claim must have a non-empty `text` field.
+  - Each claim must have an ISO-8601 `as_of` field.
+  - Each claim must have a non-empty `source_anchor` field.
+  - The `status` field must have a value of `proposed`, `validated`,
+    `superseded`, or `abandoned`.
+  - OpenKB creates the `id` field.
+  - The optional `authority` field can have a value of `first_party`,
+    `assistant`, or `document`.
+  - If an assistant claim has a `status` value of `validated`, OpenKB changes
+    the value to `proposed`.
+  - Assistant claims do not enter strict current reads.
+  - An assistant claim cannot supersede a claim that has a `status` value of
+    `validated`.
+  - Only a claim with an `authority` value of `first_party` can supersede
+    another claim with an `authority` value of `first_party`.
+  - Claims with an `authority` value of `document` use the same `as_of` and
+    `status` rules as claims without an `authority` field.
+  - The `supersedes` field contains `id` values for old claims on the same page.
+  - OpenKB applies supersession links only when the new `as_of` value is not
+    earlier than the old `as_of` value.
+  - OpenKB creates the `superseded_by` supersession links.
+  - A claim with a `status` value of `proposed` cannot supersede a claim that has
+    a `status` value of `validated`.
+  - A claim with a `status` value of `validated` or `abandoned` can supersede a
+    claim with a `status` value of `validated` when all other rules permit the
+    supersession link.
+  - Strict current reads return claims that have a `status` value of `validated`.
+  - An adapter can define the format of the `source_anchor` field.
+  - OpenKB does not require a specific transport or provider.
+  - If a stored claim has the same `id` value as an incoming duplicate claim,
+    OpenKB keeps the stored claim.
+  - OpenKB ignores every field and every supersession link from the incoming
+    duplicate claim.
+  - The document compiler sets the `authority` field to `document` for every
+    claim that a model creates.
+  - An external adapter can verify source authority.
+  - The adapter can then set the `authority` field to `first_party` or
+    `assistant` through the public claims API.
 - Do not include YAML frontmatter (---) in generated content; it is managed by code.
 """
 

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -1,0 +1,401 @@
+"""Test deterministic claim behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from openkb.claims import (
+    AUTHORITY_ROLES,
+    CLAIM_STATUSES,
+    as_of_allows_supersession,
+    claim_id,
+    claims_for_prompt,
+    current_claims,
+    merge_claims,
+    normalize_claim,
+)
+
+
+def raw(**overrides):
+    claim = {
+        "text": "A synthetic fact is true.",
+        "as_of": "2026-01-01",
+        "status": "validated",
+        "source_anchor": "fixture:turn-1",
+        "authority": "document",
+        "supersedes": [],
+    }
+    claim.update(overrides)
+    return claim
+
+
+class TestNormalization:
+    def test_id_is_code_owned_and_deterministic(self):
+        claim = normalize_claim(raw(id="model-invented-id"))
+        assert claim is not None
+        expected = hashlib.sha256(
+            '["A synthetic fact is true.","2026-01-01","fixture:turn-1"]'.encode()
+        ).hexdigest()[:16]
+        assert claim["id"] == expected
+        assert claim["id"] != "model-invented-id"
+
+    def test_required_fields_and_statuses(self):
+        for status in CLAIM_STATUSES:
+            assert normalize_claim(raw(status=status)) is not None
+        assert normalize_claim(raw(text="")) is None
+        assert normalize_claim(raw(as_of="yesterday")) is None
+        assert normalize_claim(raw(source_anchor="")) is None
+        assert normalize_claim(raw(status="confirmed")) is None
+
+    def test_optional_generic_authority_is_validated(self):
+        assert AUTHORITY_ROLES == {"first_party", "assistant", "document"}
+        first_party = normalize_claim(raw(authority="first_party"))
+        assert first_party is not None
+        assert first_party["authority"] == "first_party"
+        assert normalize_claim(raw(authority="provider-specific")) is None
+        no_authority = normalize_claim(raw(authority=None))
+        assert no_authority is not None
+        assert "authority" not in no_authority
+
+    @pytest.mark.parametrize(
+        ("incoming", "old", "allowed"),
+        [
+            ("2026-01-02", "2026-01-01", True),
+            ("2026-01-01", "2026-01-01", True),
+            ("2025-12-31", "2026-01-01", False),
+            ("2026-01-01T12:00:00Z", "2026-01-01T07:00:00-05:00", True),
+        ],
+    )
+    def test_chronology_guard(self, incoming, old, allowed):
+        assert as_of_allows_supersession(incoming, old) is allowed
+
+
+class TestSyntheticCorrectionRegression:
+    """A first-party correction must supersede old assistant claims.
+
+    The old assistant claims have a `status` value of `proposed`.
+    """
+
+    def test_without_correction_stale_proposal_remains_proposed(self):
+        revision = raw(
+            text="Synthetic Device uses revision A.",
+            status="proposed",
+            authority="assistant",
+        )
+        operating_limit = raw(
+            text="Synthetic Device has an operating limit of 40 units.",
+            source_anchor="fixture:turn-2",
+            status="proposed",
+            authority="assistant",
+        )
+        merged = merge_claims([], [revision, operating_limit])
+        assert [claim["text"] for claim in current_claims(merged)] == []
+        assert {claim["text"] for claim in current_claims(merged, include_proposed=True)} == {
+            revision["text"],
+            operating_limit["text"],
+        }
+
+    def test_first_party_correction_is_current_and_old_records_remain(self):
+        revision = raw(
+            text="Synthetic Device uses revision A.",
+            status="proposed",
+            authority="assistant",
+        )
+        operating_limit = raw(
+            text="Synthetic Device has an operating limit of 40 units.",
+            source_anchor="fixture:turn-2",
+            status="proposed",
+            authority="assistant",
+        )
+        revision_id = claim_id(revision["text"], revision["as_of"], revision["source_anchor"])
+        operating_limit_id = claim_id(
+            operating_limit["text"],
+            operating_limit["as_of"],
+            operating_limit["source_anchor"],
+        )
+        correction_revision = raw(
+            text="Synthetic Device uses revision B.",
+            as_of="2026-01-02",
+            source_anchor="fixture:turn-3",
+            authority="first_party",
+            supersedes=[revision_id],
+        )
+        correction_limit = raw(
+            text="Synthetic Device has an operating limit of 100 units.",
+            as_of="2026-01-02",
+            source_anchor="fixture:turn-3",
+            authority="first_party",
+            supersedes=[operating_limit_id],
+        )
+
+        merged = merge_claims(
+            [],
+            [revision, operating_limit, correction_revision, correction_limit],
+        )
+        correction_revision_id = claim_id(
+            correction_revision["text"],
+            correction_revision["as_of"],
+            correction_revision["source_anchor"],
+        )
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[revision_id]["status"] == "superseded"
+        assert by_id[operating_limit_id]["status"] == "superseded"
+        assert correction_revision["text"] in {claim["text"] for claim in current_claims(merged)}
+        assert correction_limit["text"] in {claim["text"] for claim in current_claims(merged)}
+        assert correction_revision["text"] not in {
+            claim["text"]
+            for claim in current_claims(merged, include_proposed=True)
+            if claim["status"] == "superseded"
+        }
+        assert revision_id in by_id and operating_limit_id in by_id
+        assert by_id[revision_id]["superseded_by"] == [correction_revision_id]
+
+    def test_replay_is_idempotent(self):
+        old = raw(text="The synthetic value was 10.", as_of="2026-01-01")
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        new = raw(
+            text="The synthetic value is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:turn-2",
+            supersedes=[old_id],
+        )
+        once = merge_claims([old], [new])
+        twice = merge_claims(once, [new])
+        assert twice == once
+
+    def test_duplicate_identity_cannot_inject_supersession_edge(self):
+        claim_a = raw(
+            text="Synthetic value A is 10.",
+            authority="first_party",
+            source_anchor="fixture:first-party-a",
+        )
+        claim_b = raw(
+            text="Synthetic value B is 20.",
+            authority="first_party",
+            source_anchor="fixture:first-party-b",
+        )
+        claim_b_id = claim_id(claim_b["text"], claim_b["as_of"], claim_b["source_anchor"])
+        duplicate_a = {
+            **claim_a,
+            "authority": "assistant",
+            "supersedes": [claim_b_id],
+        }
+        merged = merge_claims([claim_a, claim_b], [duplicate_a])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[claim_b_id]["status"] == "validated"
+        assert by_id[claim_b_id]["superseded_by"] == []
+        assert {item["text"] for item in current_claims(merged)} == {
+            claim_a["text"],
+            claim_b["text"],
+        }
+
+    def test_backward_time_link_is_rejected(self):
+        old = raw(as_of="2026-02-01")
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        earlier = raw(
+            text="The proposed synthetic value is 12.",
+            as_of="2026-01-01",
+            source_anchor="fixture:turn-0",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [earlier])
+        assert merged[0]["status"] == "validated"
+        assert merged[0]["superseded_by"] == []
+
+    def test_proposed_claim_cannot_remove_validated_current_fact(self):
+        old = raw(text="The synthetic value is 10.")
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        proposed = raw(
+            text="The proposed synthetic value is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:proposal",
+            status="proposed",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [proposed])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+        assert [item["text"] for item in current_claims(merged)] == [old["text"]]
+
+    def test_duplicate_proposed_identity_cannot_launder_validated_status(self):
+        old = raw(text="The synthetic value is 10.")
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        stored_proposal = raw(
+            text="The proposed synthetic value is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:proposal",
+            status="proposed",
+        )
+        relabel = {**stored_proposal, "status": "validated", "supersedes": [old_id]}
+        merged = merge_claims([old, stored_proposal], [relabel])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+        assert [item["text"] for item in current_claims(merged)] == [old["text"]]
+
+    def test_validated_assistant_cannot_supersede_first_party(self):
+        old = raw(
+            text="The synthetic value is 10.",
+            authority="first_party",
+        )
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        assistant = raw(
+            text="The assistant claim conflicts with the stored claim.",
+            as_of="2026-01-02",
+            source_anchor="fixture:assistant",
+            authority="assistant",
+            status="validated",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [assistant])
+        by_id = {claim["id"]: claim for claim in merged}
+        assistant_id = claim_id(assistant["text"], assistant["as_of"], assistant["source_anchor"])
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+        assert by_id[assistant_id]["status"] == "proposed"
+        assert [item["text"] for item in current_claims(merged)] == [old["text"]]
+
+    def test_assistant_abandonment_cannot_remove_validated_document_fact(self):
+        old = raw(
+            text="The document value is 10.",
+            authority="document",
+        )
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        assistant = raw(
+            text="The assistant claim marks the document fact as abandoned.",
+            as_of="2026-01-02",
+            source_anchor="fixture:assistant-abandonment",
+            authority="assistant",
+            status="abandoned",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [assistant])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+        assert [item["text"] for item in current_claims(merged)] == [old["text"]]
+
+    def test_duplicate_assistant_identity_cannot_launder_first_party_authority(self):
+        old = raw(
+            text="The synthetic value is 10.",
+            authority="first_party",
+        )
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        stored_assistant = raw(
+            text="The assistant claim conflicts with the stored claim.",
+            as_of="2026-01-02",
+            source_anchor="fixture:assistant",
+            authority="assistant",
+            status="validated",
+        )
+        relabel = {
+            **stored_assistant,
+            "authority": "first_party",
+            "supersedes": [old_id],
+        }
+        merged = merge_claims([old, stored_assistant], [relabel])
+        by_id = {claim["id"]: claim for claim in merged}
+        assistant_id = claim_id(
+            stored_assistant["text"],
+            stored_assistant["as_of"],
+            stored_assistant["source_anchor"],
+        )
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+        assert by_id[assistant_id]["authority"] == "assistant"
+        assert by_id[assistant_id]["status"] == "proposed"
+        assert [item["text"] for item in current_claims(merged)] == [old["text"]]
+
+    def test_document_cannot_supersede_first_party(self):
+        old = raw(
+            text="The synthetic value is 10.",
+            authority="first_party",
+        )
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        document = raw(
+            text="The document claim says that the value is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:document",
+            authority="document",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [document])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "validated"
+        assert by_id[old_id]["superseded_by"] == []
+
+    def test_first_party_can_supersede_first_party(self):
+        old = raw(
+            text="The synthetic measurement was 10.",
+            authority="first_party",
+        )
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        replacement = raw(
+            text="The synthetic measurement is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:first-party-replacement",
+            authority="first_party",
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [replacement])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "superseded"
+        assert [item["text"] for item in current_claims(merged)] == [replacement["text"]]
+
+    @pytest.mark.parametrize("authority", ["document", None])
+    def test_generic_non_first_party_supersession_is_preserved(self, authority):
+        old = raw(text="The synthetic measurement was 10.", authority=authority)
+        old_id = claim_id(old["text"], old["as_of"], old["source_anchor"])
+        replacement = raw(
+            text="The synthetic measurement is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:replacement",
+            authority=authority,
+            supersedes=[old_id],
+        )
+        merged = merge_claims([old], [replacement])
+        by_id = {claim["id"]: claim for claim in merged}
+        assert by_id[old_id]["status"] == "superseded"
+        assert [item["text"] for item in current_claims(merged)] == [replacement["text"]]
+
+    def test_supersession_is_page_local_and_self_links_are_ignored(self):
+        local = raw(text="The local synthetic value is 10.")
+        local_id = claim_id(local["text"], local["as_of"], local["source_anchor"])
+        incoming = raw(
+            text="The local synthetic value is 12.",
+            as_of="2026-01-02",
+            source_anchor="fixture:turn-2",
+            supersedes=["foreign-page-id", local_id],
+        )
+        merged = merge_claims([local], [incoming])
+        assert len(merged) == 2
+        assert merged[0]["status"] == "superseded"
+        self_ref = raw(
+            text="This claim has a supersession link to itself.",
+            source_anchor="fixture:turn-9",
+        )
+        self_id = claim_id(self_ref["text"], self_ref["as_of"], self_ref["source_anchor"])
+        self_ref["supersedes"] = [self_id]
+        assert merge_claims([], [self_ref])[0]["superseded_by"] == []
+
+
+class TestReadHelpers:
+    def test_prompt_serialization_is_compact_and_exposes_page_ids(self):
+        claim = normalize_claim(raw())
+        assert claim is not None
+        serialized = claims_for_prompt([claim])
+        parsed = json.loads(serialized)
+        assert parsed[0]["id"] == claim["id"]
+        assert parsed[0]["source_anchor"] == "fixture:turn-1"
+        assert "superseded_by" not in parsed[0]
+
+    def test_current_claims_does_not_mutate_input(self):
+        claim = normalize_claim(raw())
+        assert claim is not None
+        original = [dict(claim)]
+        assert current_claims(original) == original
+        assert original == [dict(claim)]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -17,9 +17,9 @@ class TestBuildQueryAgent:
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
         assert agent.name == "wiki-query"
 
-    def test_agent_has_three_tools(self, tmp_path):
+    def test_agent_has_four_tools(self, tmp_path):
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
-        assert len(agent.tools) == 3
+        assert len(agent.tools) == 4
 
     def test_agent_tool_names(self, tmp_path):
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
@@ -27,6 +27,7 @@ class TestBuildQueryAgent:
         assert "read_file" in names
         assert "get_page_content" in names
         assert "get_image" in names
+        assert "read_current_page_claims" in names
 
     def test_instructions_mention_get_page_content(self, tmp_path):
         agent = build_query_agent(str(tmp_path), "gpt-4o-mini")
@@ -80,6 +81,21 @@ def test_query_strategy_mentions_entities():
 
     text = query_mod._QUERY_INSTRUCTIONS_TEMPLATE
     assert "entities/" in text
+
+
+def test_query_strategy_requires_strict_current_claim_reads():
+    from openkb.agent import query as query_mod
+
+    text = query_mod._QUERY_INSTRUCTIONS_TEMPLATE
+    normalized = " ".join(text.split())
+    assert "read_current_page_claims" in text
+    assert (
+        'Strict current reads return claims that have a "status" value of "validated".'
+    ) in normalized
+    assert (
+        'Do not report a claim with a "status" value of "proposed" as a claim '
+        'with a "status" value of "validated".'
+    ) in normalized
 
 
 class TestResolveToolCallId:

--- a/tests/test_temporal_compiler.py
+++ b/tests/test_temporal_compiler.py
@@ -1,0 +1,280 @@
+"""Test compiler and query integration for claims."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openkb import frontmatter
+from openkb.agent.compiler import (
+    _CLAIMS_FIELD_GUIDANCE,
+    _CONCEPT_UPDATE_USER,
+    _ENTITY_UPDATE_USER,
+    _SUMMARY_USER,
+    _claims_from_model,
+    _write_concept,
+    _write_entity,
+    _write_summary,
+)
+from openkb.agent.tools import read_current_claims
+from openkb.claims import claim_id, normalize_claim
+
+
+def claim(
+    text: str,
+    *,
+    as_of: str = "2026-01-01",
+    status: str = "validated",
+    anchor: str = "fixture:1",
+    **extra,
+):
+    value = {
+        "text": text,
+        "as_of": as_of,
+        "status": status,
+        "source_anchor": anchor,
+        "supersedes": [],
+    }
+    value.update(extra)
+    normalized = normalize_claim(value)
+    assert normalized is not None
+    return normalized
+
+
+def test_compiler_prompts_request_code_managed_claims():
+    for prompt in (_SUMMARY_USER, _CONCEPT_UPDATE_USER, _ENTITY_UPDATE_USER):
+        assert '"source_anchor"' in prompt
+        assert '"as_of"' in prompt
+        assert '"status"' in prompt
+        assert '"supersedes"' in prompt
+    assert '"id"' in _CLAIMS_FIELD_GUIDANCE
+    assert 'Do not set the "id" field' in _CLAIMS_FIELD_GUIDANCE
+    assert "latest state that the source evidence supports" in _CONCEPT_UPDATE_USER
+
+
+def test_frontmatter_structured_claims_round_trip():
+    stored = claim("The synthetic value is 10.")
+    page = (
+        frontmatter.block(
+            [frontmatter.kv_line("type", "Summary"), frontmatter.json_line("claims", [stored])]
+        )
+        + "The page contains a synthetic value."
+    )
+    parsed = frontmatter.parse(page)
+    assert parsed["claims"][0]["id"] == stored["id"]
+    assert "\nclaims: " in page
+    assert "--- not a delimiter ---" not in page
+
+
+def test_summary_writer_stores_single_line_claims(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    stored = claim("The synthetic summary value is 10.")
+    _write_summary(
+        wiki,
+        "fixture",
+        "# Summary\n\nThe page contains a synthetic value.",
+        claims=[stored],
+    )
+    text = (wiki / "summaries/fixture.md").read_text(encoding="utf-8")
+    assert frontmatter.parse(text)["claims"][0]["text"] == stored["text"]
+    assert len([line for line in text.splitlines() if line.startswith("claims:")]) == 1
+
+
+def test_fresh_summary_write_normalizes_model_claim_fields(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    raw = {
+        "id": "model-invented",
+        "text": "The raw synthetic value is 10.",
+        "as_of": "2026-01-01",
+        "status": "validated",
+        "source_anchor": "fixture:raw",
+        "supersedes": [],
+        "superseded_by": ["model-invented-reverse-link"],
+    }
+    _write_summary(wiki, "raw", "# Summary\n\nThe page contains a synthetic value.", claims=[raw])
+    stored = frontmatter.parse((wiki / "summaries/raw.md").read_text())["claims"][0]
+    assert stored["id"] != "model-invented"
+    assert stored["superseded_by"] == []
+
+
+@pytest.mark.parametrize("page_kind", ["summary", "concept", "entity"])
+def test_model_first_party_is_capped_before_page_write(tmp_path, page_kind):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    old = claim(
+        "The stored value is 10.",
+        anchor="fixture:first-party",
+        authority="first_party",
+    )
+    raw_model_claim = {
+        "text": "The compiler model claims that the value is 12.",
+        "as_of": "2026-01-02",
+        "status": "validated",
+        "source_anchor": "fixture:model",
+        "authority": "first_party",
+        "supersedes": [old["id"]],
+    }
+    model_claims = _claims_from_model(
+        {"claims": [raw_model_claim]},
+        log_label=f"test:{page_kind}",
+    )
+    assert model_claims is not None
+    assert model_claims[0]["authority"] == "document"
+
+    if page_kind == "summary":
+        _write_summary(wiki, "fixture", "# Summary\n\nThe old value is 10.", claims=[old])
+        _write_summary(wiki, "fixture", "# Summary\n\nThe new value is 12.", claims=model_claims)
+        path = wiki / "summaries/fixture.md"
+    elif page_kind == "concept":
+        _write_concept(
+            wiki,
+            "fixture",
+            "# Concept\n\nThe old value is 10.",
+            "summaries/old.md",
+            False,
+            claims=[old],
+        )
+        _write_concept(
+            wiki,
+            "fixture",
+            "# Concept\n\nThe new value is 12.",
+            "summaries/new.md",
+            True,
+            claims=model_claims,
+        )
+        path = wiki / "concepts/fixture.md"
+    else:
+        _write_entity(
+            wiki,
+            "fixture",
+            "# Entity\n\nThe old value is 10.",
+            "summaries/old.md",
+            False,
+            claims=[old],
+        )
+        _write_entity(
+            wiki,
+            "fixture",
+            "# Entity\n\nThe new value is 12.",
+            "summaries/new.md",
+            True,
+            claims=model_claims,
+        )
+        path = wiki / "entities/fixture.md"
+
+    stored = frontmatter.parse(path.read_text())["claims"]
+    by_id = {item["id"]: item for item in stored}
+    assert by_id[old["id"]]["status"] == "validated"
+    assert by_id[old["id"]]["superseded_by"] == []
+    model_id = claim_id(
+        raw_model_claim["text"],
+        raw_model_claim["as_of"],
+        raw_model_claim["source_anchor"],
+    )
+    assert by_id[model_id]["authority"] == "document"
+
+
+def test_summary_rewrite_merges_existing_claim_history(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    old = claim("The synthetic summary value was 10.", anchor="fixture:old")
+    _write_summary(wiki, "fixture", "# Summary\n\nThe old value is 10.", claims=[old])
+    replacement = claim(
+        "The synthetic summary value is 12.",
+        as_of="2026-01-02",
+        anchor="fixture:new",
+        supersedes=[old["id"]],
+    )
+    _write_summary(wiki, "fixture", "# Summary\n\nThe new value is 12.", claims=[replacement])
+    parsed = frontmatter.parse((wiki / "summaries/fixture.md").read_text())
+    by_id = {item["id"]: item for item in parsed["claims"]}
+    assert by_id[old["id"]]["status"] == "superseded"
+    assert replacement["id"] in by_id[old["id"]]["superseded_by"]
+
+
+def test_concept_update_merges_history_and_preserves_old_body_history(tmp_path):
+    wiki = tmp_path / "wiki"
+    concepts = wiki / "concepts"
+    concepts.mkdir(parents=True)
+    old = claim("The synthetic threshold was 10.", anchor="fixture:old")
+    _write_concept(
+        wiki,
+        "synthetic-threshold",
+        "# Threshold\n\nThe old threshold is 10.",
+        "summaries/old.md",
+        False,
+        claims=[old],
+    )
+    replacement = claim(
+        "The synthetic threshold is 12.",
+        as_of="2026-01-02",
+        anchor="fixture:new",
+        supersedes=[old["id"]],
+    )
+    _write_concept(
+        wiki,
+        "synthetic-threshold",
+        "# Threshold\n\nThe new threshold is 12.",
+        "summaries/new.md",
+        True,
+        claims=[replacement],
+    )
+    parsed = frontmatter.parse((concepts / "synthetic-threshold.md").read_text())
+    by_id = {item["id"]: item for item in parsed["claims"]}
+    assert by_id[old["id"]]["status"] == "superseded"
+    assert replacement["id"] in by_id[old["id"]]["superseded_by"]
+    assert "The new threshold is 12." in (concepts / "synthetic-threshold.md").read_text()
+
+
+def test_entity_writer_round_trips_claims(tmp_path):
+    stored = claim("The synthetic entity is a document fixture.", anchor="fixture:entity")
+    _write_entity(
+        tmp_path,
+        "synthetic-entity",
+        "# Entity\n\nThe page contains a synthetic value.",
+        "summaries/fixture.md",
+        False,
+        type_="other",
+        claims=[stored],
+    )
+    path = tmp_path / "entities/synthetic-entity.md"
+    assert frontmatter.parse(path.read_text())["claims"][0]["id"] == stored["id"]
+
+
+def test_query_read_helper_returns_validated_only_by_default(tmp_path):
+    wiki = tmp_path / "wiki"
+    page = wiki / "summaries/fixture.md"
+    page.parent.mkdir(parents=True)
+    validated = claim("The synthetic value is 10.")
+    proposed = claim(
+        "The proposed synthetic value is 12.",
+        status="proposed",
+        anchor="fixture:proposal",
+        authority="assistant",
+    )
+    page.write_text(
+        frontmatter.block(
+            [
+                frontmatter.kv_line("type", "Summary"),
+                frontmatter.json_line("claims", [validated, proposed]),
+            ]
+        )
+        + "The page contains a synthetic value."
+    )
+    strict = json.loads(read_current_claims("summaries/fixture.md", str(wiki)))
+    broad = json.loads(
+        read_current_claims("summaries/fixture.md", str(wiki), include_proposed=True)
+    )
+    assert [item["text"] for item in strict] == [validated["text"]]
+    assert {item["text"] for item in broad} == {validated["text"], proposed["text"]}
+    assert (
+        claim_id(validated["text"], validated["as_of"], validated["source_anchor"])
+        == validated["id"]
+    )
+
+
+def test_query_read_helper_rejects_path_escape(tmp_path):
+    assert read_current_claims("../outside.md", str(tmp_path / "wiki")).startswith("Access denied")


### PR DESCRIPTION
# Add temporal claims to OpenKB pages

Closes #222

## Problem

OpenKB stores factual state as prose. A page cannot identify the date of a claim. A page cannot separate assistant output from source evidence. A page also cannot show how new evidence corrects an old claim.

## Approach

This change adds claims to summary, concept, and entity pages.

- Store the `claims` field as a one-line JSON array in YAML frontmatter.
- Require a non-empty `text` field.
- Require an ISO-8601 `as_of` field.
- Require a non-empty `source_anchor` field.
- Require the `status` field to have a value of `proposed`, `validated`, `superseded`, or `abandoned`.
- Create the `id` field in OpenKB code.
- Ignore each model-supplied `id` field.
- Keep old claims as page history.
- Apply page-local supersession links after OpenKB adds new claims.
- Accept candidate supersession links in the `supersedes` field.
- Validate each candidate supersession link before OpenKB applies the link.
- Create the `superseded_by` supersession links for the applied links.
- Use `read_current_page_claims()` for strict current reads.
- Return claims that have a `status` value of `proposed` only after an explicit request.

## Authority rules

The optional `authority` field can have a value of `first_party`, `document`, or `assistant`.

- If an assistant claim has a `status` value of `validated`, OpenKB changes the value to `proposed`.
- Assistant claims do not enter strict current reads.
- An assistant claim cannot supersede a claim that has a `status` value of `validated`.
- Only a claim with an `authority` value of `first_party` can supersede another claim with an `authority` value of `first_party`.
- If a stored claim has the same `id` value as an incoming duplicate claim, OpenKB keeps the stored claim.
- OpenKB ignores every field and every supersession link from the incoming duplicate claim.
- The document compiler sets the `authority` field to `document` before it writes a model claim.
- The document compiler sets the `authority` field to `document` for summary, concept, and entity pages.
- An external adapter can verify source authority. The adapter can then set the `authority` field to `first_party` or `assistant` through the public claims API.
- Claims with an `authority` value of `document` use the same `as_of` and `status` rules as claims without an `authority` field.

## Synthetic regression case

The tests use a synthetic device.

- One assistant claim says that the device uses revision A.
- A second assistant claim says that the operating limit is 40 units.
- Both assistant claims have a `status` value of `proposed`.
- A later claim has an `authority` value of `first_party`.
- The first-party claim says that the device uses revision B.
- The first-party claim says that the operating limit is 100 units.
- Without the later claims, strict current reads exclude claims that have a `status` value of `proposed`.
- With the later claims, `current_claims()` returns the corrections from the claims that have an `authority` value of `first_party`.
- OpenKB keeps the old assistant claims with a `status` value of `superseded`.

The tests also cover direct authority changes. The tests cover duplicate-identity authority changes. The tests cover supersession link injection through a duplicate `id` value.

## Aggregate production case study

A conversation-ingestion deployment supplied these aggregate lessons. The deployment filtered private data before model inference.

- The external source remained the source of truth.
- The compiled wiki remained a read-only projection.
- The materializer cleaned messages before model inference.
- The materializer removed duplicate synthetic payloads before model inference.
- The materializer kept source, speaker, authority, and evidence identifiers.
- One verified export contained 280 conversations.
- The materializer created 537 documents from the 280 conversations.
- Initial materialization used a document limit of 240,000 characters.
- Recovery after a context overflow used a document limit of 40,000 characters.
- A later materializer used a message limit of 40,000 characters.
- The later materializer used a document limit of 120,000 characters.
- The materializer did not change a window after it closed the window.
- Content hashes and idempotent manifests prevented duplicate knowledge.
- Replay-safe compilation also prevented duplicate knowledge.
- One complex document exceeded a timeout of 600 seconds.
- The document completed in 885 seconds during a later run.
- Tests set the timeout to 1,200 seconds for each document.
- Each batch contained no more than two documents.
- The scheduler guard remained 3,600 seconds.
- The scheduler processed the oldest pending documents first.
- Caller code applied privacy filters before model inference.
- OpenKB core does not contain a project-specific regular expression for privacy.
- Caller code controls the closed-window delay.
- Caller code controls the list of transport sources.

## Public documentation

- `README.md` explains the `claims` field and strict current reads.
- `README.md` explains the `authority` field.
- `openkb/schema.py` defines each JSON field and each allowed field value.
- `docs/golden-principles.md` defines the history, authority, and duplicate-ID rules.

## Tests

The deterministic tests cover these cases:

- OpenKB creates the `id` field.
- OpenKB validates the `text`, `as_of`, `status`, `source_anchor`, and `authority` fields.
- OpenKB rejects a backward supersession link.
- OpenKB limits supersession links to one page.
- Repeated input gives the same result.
- OpenKB records the `supersedes` and `superseded_by` supersession links.
- Strict current reads return claims that have a `status` value of `validated`.
- An assistant claim cannot supersede a claim with an `authority` value of `first_party`.
- An assistant claim with a `status` value of `abandoned` cannot supersede a claim with a `status` value of `validated`.
- A document claim cannot supersede a claim with an `authority` value of `first_party`.
- A duplicate `id` value cannot change the stored `authority` or `status` field.
- A duplicate `id` value cannot add a supersession link.
- The document compiler sets the `authority` field to `document` before each summary, concept, or entity write.
- A document claim can supersede another document claim when the `as_of` and `status` fields permit the supersession link.
- A claim without an `authority` field can supersede another claim without an `authority` field when the `as_of` and `status` fields permit the supersession link.
- Frontmatter keeps the `claims` JSON array.
- `read_current_page_claims()` rejects a path outside the wiki root.

Run these commands:

```text
python -m pytest
python -m ruff check .
python -m ruff format --check .
python -m mypy openkb/claims.py
git diff --check
```

The last run gave these results:

- Full `pytest`: 1,286 passed.
- `ruff check .`: passed.
- `ruff format --check .`: 122 files already formatted.
- `mypy openkb/claims.py`: passed.
- `git diff --check`: passed.

## Risks and non-goals

- OpenKB cannot prove that source evidence is true.
- An external adapter must verify source authority before it sets the `authority` field to `first_party`.
- A raw page read includes claim history.
- A consumer must use `current_claims()` for strict current reads.
- The long-document path keeps existing summary claims.
- The long-document path does not extract new claims from the PageIndex overview.
- This change does not compact claim history.
- This change does not add a transport adapter.
- This change does not add scheduler rules.
- This change does not add privacy rules.
- This change does not add live-ingestion code.

## Relation to existing work

- This change does not depend on OpenKB PR #179.
- This change does not modify OpenKB PR #179.
- ChatIndex is not a dependency.
- ChatIndex conversation trees do not provide page-local authority rules or supersession links.
- OpenKB chat persistence stores OpenKB query chats.
- OpenKB chat persistence does not ingest external conversations.

## Follow-up

Create a separate conversation adapter that does not depend on a transport. Create a separate materialization interface. The adapter and the interface can provide deterministic cleaning. The adapter and the interface can provide source identifiers. The adapter and the interface can provide speaker identifiers. The adapter and the interface can provide authority values. The adapter and the interface can provide evidence identifiers. The adapter and the interface can provide bounded documents. The adapter and the interface can provide recovery splits. The adapter and the interface can provide closed windows. The adapter and the interface can provide content hashes. The adapter and the interface can provide idempotent manifests. The adapter and the interface can provide timeouts. The adapter and the interface can provide replay-safe compilation.

Caller code must control transport lists. Caller code must control closed-window delays. Caller code must control privacy filters. Caller code must control credentials. Caller code must control scheduler limits. The adapter design and the interface design must not depend on PR #179.
