### PR TITLE
feat(cli): default 'add' to raw/ with summary + cleanup, auto_delete_added_files config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ OpenKB commands fall into two layers: the **wiki foundation** (compile + manage 
 | Command                                                      | Description                                                                             |
 | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
 | `openkb init`                                                | Initialize a new knowledge base (interactive)                                           |
-| <code>openkb&nbsp;add&nbsp;&lt;file_or_dir_or_URL&gt;</code> | Add files, directories, or URLs and compile to wiki (URL content type is auto-detected) |
+| <code>openkb&nbsp;add&nbsp;[file_or_dir_or_URL]</code>       | Add files, directories, or URLs and compile to wiki (URL content type is auto-detected); omit the argument to process `raw/` recursively with a summary |
 | `openkb list`                                                | List indexed documents and concepts                                                     |
 | `openkb status`                                              | Show knowledge base stats                                                               |
 | `openkb watch`                                               | Watch `raw/` and auto-compile new files                                                 |

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -455,7 +455,10 @@ def add_single_file(
 def _delete_if_auto_cleanup_enabled(
     file_path: Path, status: Literal["added", "skipped", "failed"], config: dict
 ) -> bool:
-    """Delete file if addition succeeded and auto_delete_added_files is enabled.
+    """Delete file if auto_delete_added_files is enabled and ingestion succeeded/skipped.
+
+    Deletes on both "added" (successful ingestion) and "skipped" (duplicate already
+    in KB) to keep raw/ directory clean. Preserves files on "failed" to allow retries.
 
     Args:
         file_path: Path to the file to potentially delete.
@@ -465,7 +468,7 @@ def _delete_if_auto_cleanup_enabled(
     Returns:
         True if file was deleted, False otherwise.
     """
-    if status == "added" and config.get("auto_delete_added_files", False):
+    if status in ("added", "skipped") and config.get("auto_delete_added_files", False):
         try:
             file_path.unlink(missing_ok=True)
             return True
@@ -1110,8 +1113,9 @@ def add(ctx, path, from_pageindex_cloud):
     that is already indexed in PageIndex Cloud, with no local file. Requires
     the PAGEINDEX_API_KEY environment variable.
 
-    If ``auto_delete_added_files`` is enabled in config.yaml, successfully
-    added files are automatically deleted after ingestion.
+    If ``auto_delete_added_files`` is enabled in config.yaml, files are
+    automatically deleted after ingestion (both on successful addition and
+    on skip/duplicate).
     """
     kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
     if kb_dir is None:
@@ -1194,8 +1198,8 @@ def add_all(ctx):
 
     This command walks the ``raw/`` directory recursively for all supported
     document types and ingests them into the KB. If ``auto_delete_added_files``
-    is enabled in config.yaml, successfully added files are automatically deleted
-    after ingestion.
+    is enabled in config.yaml, files are automatically deleted after ingestion
+    (both on successful addition and on skip/duplicate).
 
     Returns a summary of the operation (added, skipped, failed, deleted counts).
     """

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -452,6 +452,29 @@ def add_single_file(
         return _add_single_file_locked(file_path, kb_dir, stage=stage, bundle=bundle)
 
 
+def _delete_if_auto_cleanup_enabled(
+    file_path: Path, status: Literal["added", "skipped", "failed"], config: dict
+) -> bool:
+    """Delete file if addition succeeded and auto_delete_added_files is enabled.
+
+    Args:
+        file_path: Path to the file to potentially delete.
+        status: Result status from add_single_file ("added", "skipped", or "failed").
+        config: Configuration dict (typically from resolve_effective_config).
+
+    Returns:
+        True if file was deleted, False otherwise.
+    """
+    if status == "added" and config.get("auto_delete_added_files", False):
+        try:
+            file_path.unlink(missing_ok=True)
+            return True
+        except Exception as exc:
+            logger.warning(f"Failed to delete {file_path.name}: {exc}")
+            return False
+    return False
+
+
 def _add_single_file_locked(
     file_path: Path, kb_dir: Path, *, stage: bool = True, bundle=None
 ) -> Literal["added", "skipped", "failed"]:
@@ -1086,6 +1109,9 @@ def add(ctx, path, from_pageindex_cloud):
     Alternatively, pass --from-pageindex-cloud <DOC_ID> to import a document
     that is already indexed in PageIndex Cloud, with no local file. Requires
     the PAGEINDEX_API_KEY environment variable.
+
+    If ``auto_delete_added_files`` is enabled in config.yaml, successfully
+    added files are automatically deleted after ingestion.
     """
     kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
     if kb_dir is None:
@@ -1106,6 +1132,8 @@ def add(ctx, path, from_pageindex_cloud):
         click.echo("Provide a PATH or use --from-pageindex-cloud <DOC_ID>.")
         return
 
+    config = resolve_effective_config(kb_dir)[0]
+
     # URL ingest: download into raw/ first, then call add_single_file explicitly.
     # Keep staged conversion enabled so converted source artifacts do not touch
     # the live KB before the mutation snapshot exists. The tri-state outcome
@@ -1123,6 +1151,8 @@ def add(ctx, path, from_pageindex_cloud):
         # indexing has already succeeded but compilation didn't.
         if outcome == "skipped":
             fetched.unlink(missing_ok=True)
+        else:
+            _delete_if_auto_cleanup_enabled(fetched, outcome, config)
         return
 
     target = Path(path)
@@ -1143,7 +1173,8 @@ def add(ctx, path, from_pageindex_cloud):
         click.echo(f"Found {total} supported file(s) in {path}.")
         for i, f in enumerate(files, 1):
             click.echo(f"\n[{i}/{total}] ", nl=False)
-            add_single_file(f, kb_dir)
+            outcome = add_single_file(f, kb_dir)
+            _delete_if_auto_cleanup_enabled(f, outcome, config)
     else:
         if target.suffix.lower() not in SUPPORTED_EXTENSIONS:
             click.echo(
@@ -1151,7 +1182,62 @@ def add(ctx, path, from_pageindex_cloud):
                 f"Supported: {', '.join(sorted(SUPPORTED_EXTENSIONS))}"
             )
             return
-        add_single_file(target, kb_dir)
+        outcome = add_single_file(target, kb_dir)
+        _delete_if_auto_cleanup_enabled(target, outcome, config)
+
+
+@cli.command()
+@click.pass_context
+@_with_kb_lock(exclusive=True)
+def add_all(ctx):
+    """Process all files in the ``raw/`` directory and add them to the knowledge base.
+
+    This command walks the ``raw/`` directory recursively for all supported
+    document types and ingests them into the KB. If ``auto_delete_added_files``
+    is enabled in config.yaml, successfully added files are automatically deleted
+    after ingestion.
+
+    Returns a summary of the operation (added, skipped, failed, deleted counts).
+    """
+    kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
+    if kb_dir is None:
+        click.echo("No knowledge base found. Run `openkb init` first.")
+        return
+
+    raw_dir = kb_dir / "raw"
+    if not raw_dir.is_dir():
+        click.echo(f"No raw/ directory found at {raw_dir}")
+        return
+
+    files = [
+        f
+        for f in sorted(raw_dir.rglob("*"))
+        if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS
+    ]
+    if not files:
+        click.echo("No supported files found in raw/ directory.")
+        return
+
+    config = resolve_effective_config(kb_dir)[0]
+    total = len(files)
+    added = skipped = failed = deleted = 0
+
+    click.echo(f"Processing {total} file(s) from raw/ directory...")
+    for i, f in enumerate(files, 1):
+        click.echo(f"\n[{i}/{total}] ", nl=False)
+        outcome = add_single_file(f, kb_dir)
+        if outcome == "added":
+            added += 1
+        elif outcome == "skipped":
+            skipped += 1
+        else:
+            failed += 1
+        if _delete_if_auto_cleanup_enabled(f, outcome, config):
+            deleted += 1
+
+    click.echo(
+        f"\n\nSummary: Added: {added}, Skipped: {skipped}, Failed: {failed}, Deleted: {deleted}"
+    )
 
 
 def _stream_to_tty() -> bool:

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -478,6 +478,33 @@ def _delete_if_auto_cleanup_enabled(
     return False
 
 
+def _cleanup_empty_directories(start_dir: Path) -> int:
+    """Recursively delete empty directories under start_dir.
+
+    Walks from deepest subdirectories up, deleting directories that become
+    empty after file cleanup.
+
+    Args:
+        start_dir: Root directory to clean up (e.g., kb_dir / "raw").
+
+    Returns:
+        Number of directories deleted.
+    """
+    deleted_count = 0
+    try:
+        for directory in sorted(start_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+            if directory.is_dir() and directory != start_dir:
+                try:
+                    if not list(directory.iterdir()):
+                        directory.rmdir()
+                        deleted_count += 1
+                except OSError:
+                    pass
+    except Exception as exc:
+        logger.warning(f"Error during directory cleanup: {exc}")
+    return deleted_count
+
+
 def _add_single_file_locked(
     file_path: Path, kb_dir: Path, *, stage: bool = True, bundle=None
 ) -> Literal["added", "skipped", "failed"]:
@@ -1199,7 +1226,8 @@ def add_all(ctx):
     This command walks the ``raw/`` directory recursively for all supported
     document types and ingests them into the KB. If ``auto_delete_added_files``
     is enabled in config.yaml, files are automatically deleted after ingestion
-    (both on successful addition and on skip/duplicate).
+    (both on successful addition and on skip/duplicate), and empty subdirectories
+    are cleaned up.
 
     Returns a summary of the operation (added, skipped, failed, deleted counts).
     """
@@ -1224,7 +1252,7 @@ def add_all(ctx):
 
     config = resolve_effective_config(kb_dir)[0]
     total = len(files)
-    added = skipped = failed = deleted = 0
+    added = skipped = failed = deleted = dirs_deleted = 0
 
     click.echo(f"Processing {total} file(s) from raw/ directory...")
     for i, f in enumerate(files, 1):
@@ -1239,9 +1267,14 @@ def add_all(ctx):
         if _delete_if_auto_cleanup_enabled(f, outcome, config):
             deleted += 1
 
-    click.echo(
-        f"\n\nSummary: Added: {added}, Skipped: {skipped}, Failed: {failed}, Deleted: {deleted}"
-    )
+    # Clean up empty subdirectories if auto-cleanup is enabled
+    if config.get("auto_delete_added_files", False):
+        dirs_deleted = _cleanup_empty_directories(raw_dir)
+
+    summary = f"Added: {added}, Skipped: {skipped}, Failed: {failed}, Deleted: {deleted}"
+    if dirs_deleted > 0:
+        summary += f", Empty dirs cleaned: {dirs_deleted}"
+    click.echo(f"\n\nSummary: {summary}")
 
 
 def _stream_to_tty() -> bool:

--- a/openkb/cli.py
+++ b/openkb/cli.py
@@ -1136,6 +1136,13 @@ def add(ctx, path, from_pageindex_cloud):
     magic-byte sniff) are saved as ``.pdf``; HTML responses are run
     through trafilatura's main-content extractor and saved as ``.md``.
 
+    If PATH is omitted (and --from-pageindex-cloud is not used), the KB's
+    ``raw/`` directory is used instead: all supported files under it are
+    walked recursively and added, an aggregated summary (added/skipped/
+    failed/deleted counts) is printed at the end, and — if
+    ``auto_delete_added_files`` is enabled — now-empty subdirectories under
+    ``raw/`` are cleaned up.
+
     Alternatively, pass --from-pageindex-cloud <DOC_ID> to import a document
     that is already indexed in PageIndex Cloud, with no local file. Requires
     the PAGEINDEX_API_KEY environment variable.
@@ -1159,37 +1166,41 @@ def add(ctx, path, from_pageindex_cloud):
             ctx.exit(1)
         return
 
-    if path is None:
-        click.echo("Provide a PATH or use --from-pageindex-cloud <DOC_ID>.")
-        return
-
     config = resolve_effective_config(kb_dir)[0]
 
-    # URL ingest: download into raw/ first, then call add_single_file explicitly.
-    # Keep staged conversion enabled so converted source artifacts do not touch
-    # the live KB before the mutation snapshot exists. The tri-state outcome
-    # still lets us clean up the just-downloaded raw file on dedup.
-    from openkb.url_ingest import looks_like_url, fetch_url_to_raw
-
-    if looks_like_url(path):
-        fetched = fetch_url_to_raw(path, kb_dir)
-        if fetched is None:
+    if path is None:
+        # No PATH given: default to the KB's raw/ directory (mirrors the
+        # former standalone `add-all` command).
+        target = kb_dir / "raw"
+        if not target.is_dir():
+            click.echo(f"No raw/ directory found at {target}")
             return
-        outcome = add_single_file(fetched, kb_dir)
-        # Only clean up on dedup-skip. On "failed" we keep the file so
-        # the user can retry (e.g. transient LLM error during compile)
-        # without re-downloading — and so they don't lose data when
-        # indexing has already succeeded but compilation didn't.
-        if outcome == "skipped":
-            fetched.unlink(missing_ok=True)
-        else:
-            _delete_if_auto_cleanup_enabled(fetched, outcome, config)
-        return
+    else:
+        # URL ingest: download into raw/ first, then call add_single_file explicitly.
+        # Keep staged conversion enabled so converted source artifacts do not touch
+        # the live KB before the mutation snapshot exists. The tri-state outcome
+        # still lets us clean up the just-downloaded raw file on dedup.
+        from openkb.url_ingest import looks_like_url, fetch_url_to_raw
 
-    target = Path(path)
-    if not target.exists():
-        click.echo(f"Path does not exist: {path}")
-        return
+        if looks_like_url(path):
+            fetched = fetch_url_to_raw(path, kb_dir)
+            if fetched is None:
+                return
+            outcome = add_single_file(fetched, kb_dir)
+            # Only clean up on dedup-skip. On "failed" we keep the file so
+            # the user can retry (e.g. transient LLM error during compile)
+            # without re-downloading — and so they don't lose data when
+            # indexing has already succeeded but compilation didn't.
+            if outcome == "skipped":
+                fetched.unlink(missing_ok=True)
+            else:
+                _delete_if_auto_cleanup_enabled(fetched, outcome, config)
+            return
+
+        target = Path(path)
+        if not target.exists():
+            click.echo(f"Path does not exist: {path}")
+            return
 
     if target.is_dir():
         files = [
@@ -1198,14 +1209,30 @@ def add(ctx, path, from_pageindex_cloud):
             if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS
         ]
         if not files:
-            click.echo(f"No supported files found in {path}.")
+            click.echo(f"No supported files found in {target}.")
             return
         total = len(files)
-        click.echo(f"Found {total} supported file(s) in {path}.")
+        added = skipped = failed = deleted = dirs_deleted = 0
+        click.echo(f"Found {total} supported file(s) in {target}.")
         for i, f in enumerate(files, 1):
             click.echo(f"\n[{i}/{total}] ", nl=False)
             outcome = add_single_file(f, kb_dir)
-            _delete_if_auto_cleanup_enabled(f, outcome, config)
+            if outcome == "added":
+                added += 1
+            elif outcome == "skipped":
+                skipped += 1
+            else:
+                failed += 1
+            if _delete_if_auto_cleanup_enabled(f, outcome, config):
+                deleted += 1
+
+        if config.get("auto_delete_added_files", False):
+            dirs_deleted = _cleanup_empty_directories(target)
+
+        summary = f"Added: {added}, Skipped: {skipped}, Failed: {failed}, Deleted: {deleted}"
+        if dirs_deleted > 0:
+            summary += f", Empty dirs cleaned: {dirs_deleted}"
+        click.echo(f"\n\nSummary: {summary}")
     else:
         if target.suffix.lower() not in SUPPORTED_EXTENSIONS:
             click.echo(
@@ -1215,66 +1242,6 @@ def add(ctx, path, from_pageindex_cloud):
             return
         outcome = add_single_file(target, kb_dir)
         _delete_if_auto_cleanup_enabled(target, outcome, config)
-
-
-@cli.command()
-@click.pass_context
-@_with_kb_lock(exclusive=True)
-def add_all(ctx):
-    """Process all files in the ``raw/`` directory and add them to the knowledge base.
-
-    This command walks the ``raw/`` directory recursively for all supported
-    document types and ingests them into the KB. If ``auto_delete_added_files``
-    is enabled in config.yaml, files are automatically deleted after ingestion
-    (both on successful addition and on skip/duplicate), and empty subdirectories
-    are cleaned up.
-
-    Returns a summary of the operation (added, skipped, failed, deleted counts).
-    """
-    kb_dir = _find_kb_dir(ctx.obj.get("kb_dir_override"))
-    if kb_dir is None:
-        click.echo("No knowledge base found. Run `openkb init` first.")
-        return
-
-    raw_dir = kb_dir / "raw"
-    if not raw_dir.is_dir():
-        click.echo(f"No raw/ directory found at {raw_dir}")
-        return
-
-    files = [
-        f
-        for f in sorted(raw_dir.rglob("*"))
-        if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS
-    ]
-    if not files:
-        click.echo("No supported files found in raw/ directory.")
-        return
-
-    config = resolve_effective_config(kb_dir)[0]
-    total = len(files)
-    added = skipped = failed = deleted = dirs_deleted = 0
-
-    click.echo(f"Processing {total} file(s) from raw/ directory...")
-    for i, f in enumerate(files, 1):
-        click.echo(f"\n[{i}/{total}] ", nl=False)
-        outcome = add_single_file(f, kb_dir)
-        if outcome == "added":
-            added += 1
-        elif outcome == "skipped":
-            skipped += 1
-        else:
-            failed += 1
-        if _delete_if_auto_cleanup_enabled(f, outcome, config):
-            deleted += 1
-
-    # Clean up empty subdirectories if auto-cleanup is enabled
-    if config.get("auto_delete_added_files", False):
-        dirs_deleted = _cleanup_empty_directories(raw_dir)
-
-    summary = f"Added: {added}, Skipped: {skipped}, Failed: {failed}, Deleted: {deleted}"
-    if dirs_deleted > 0:
-        summary += f", Empty dirs cleaned: {dirs_deleted}"
-    click.echo(f"\n\nSummary: {summary}")
 
 
 def _stream_to_tty() -> bool:

--- a/openkb/config.py
+++ b/openkb/config.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     # global/KB list overrides it wholesale; resolve_entity_types cleans the
     # effective value on read.
     "entity_types": list(DEFAULT_ENTITY_TYPES),
+    "auto_delete_added_files": False,
 }
 
 GLOBAL_CONFIG_DIR = Path.home() / ".config" / "openkb"

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -284,6 +284,30 @@ class TestAddCommand:
         mock_add.assert_called_once()
         assert mock_add.call_args.args[0].name == "a.md"
 
+    def test_add_directory_prints_summary_and_cleans_empty_dirs(self, tmp_path):
+        kb_dir = self._setup_kb(tmp_path)
+        (kb_dir / ".openkb" / "config.yaml").write_text(
+            "model: gpt-4o-mini\nauto_delete_added_files: true\n", encoding="utf-8"
+        )
+        docs_dir = tmp_path / "docs"
+        sub_dir = docs_dir / "sub"
+        sub_dir.mkdir(parents=True)
+        doc = sub_dir / "a.md"
+        doc.write_text("# A")
+
+        runner = CliRunner()
+        with (
+            patch("openkb.cli.add_single_file", return_value="added"),
+            patch("openkb.cli._find_kb_dir", return_value=kb_dir),
+        ):
+            result = runner.invoke(cli, ["add", str(docs_dir)])
+            assert not doc.exists()
+            assert not sub_dir.exists()
+            assert (
+                "Summary: Added: 1, Skipped: 0, Failed: 0, Deleted: 1, Empty dirs cleaned: 1"
+                in result.output
+            )
+
     def test_add_unsupported_extension(self, tmp_path):
         kb_dir = self._setup_kb(tmp_path)
         doc = tmp_path / "file.xyz"
@@ -448,12 +472,61 @@ class TestAddCommand:
             mock_imp.assert_not_called()
             mock_add.assert_not_called()
 
-    def test_add_requires_path_or_cloud(self, tmp_path):
+    def test_add_no_path_processes_raw_dir_by_default(self, tmp_path):
+        kb_dir = self._setup_kb(tmp_path)
+        (kb_dir / "raw" / "a.md").write_text("# A")
+        (kb_dir / "raw" / "b.txt").write_text("B content")
+        (kb_dir / "raw" / "ignore.xyz").write_text("skip me")
+
+        runner = CliRunner()
+        with (
+            patch("openkb.cli.add_single_file", return_value="added") as mock_add,
+            patch("openkb.cli._find_kb_dir", return_value=kb_dir),
+        ):
+            result = runner.invoke(cli, ["add"])
+            assert mock_add.call_count == 2
+            called_names = {call.args[0].name for call in mock_add.call_args_list}
+            assert called_names == {"a.md", "b.txt"}
+            assert "Summary: Added: 2, Skipped: 0, Failed: 0, Deleted: 0" in result.output
+
+    def test_add_no_path_empty_raw_dir_reports_no_files(self, tmp_path):
         kb_dir = self._setup_kb(tmp_path)
         runner = CliRunner()
         with patch("openkb.cli._find_kb_dir", return_value=kb_dir):
             result = runner.invoke(cli, ["add"])
-            assert "Provide a PATH" in result.output
+            assert "No supported files found" in result.output
+
+    def test_add_no_path_no_cloud_missing_raw_dir_errors(self, tmp_path):
+        # KB without a raw/ directory (e.g. deleted by the user).
+        openkb_dir = tmp_path / ".openkb"
+        openkb_dir.mkdir()
+        (openkb_dir / "config.yaml").write_text("model: gpt-4o-mini\n")
+        (openkb_dir / "hashes.json").write_text(json.dumps({}))
+
+        runner = CliRunner()
+        with patch("openkb.cli._find_kb_dir", return_value=tmp_path):
+            result = runner.invoke(cli, ["add"])
+            assert "No raw/ directory found" in result.output
+
+    def test_add_no_path_auto_cleanup_deletes_files_and_empty_dirs(self, tmp_path):
+        kb_dir = self._setup_kb(tmp_path)
+        (kb_dir / ".openkb" / "config.yaml").write_text(
+            "model: gpt-4o-mini\nauto_delete_added_files: true\n", encoding="utf-8"
+        )
+        sub_dir = kb_dir / "raw" / "sub"
+        sub_dir.mkdir()
+        doc = sub_dir / "a.md"
+        doc.write_text("# A")
+
+        runner = CliRunner()
+        with (
+            patch("openkb.cli.add_single_file", return_value="added"),
+            patch("openkb.cli._find_kb_dir", return_value=kb_dir),
+        ):
+            result = runner.invoke(cli, ["add"])
+            assert not doc.exists()
+            assert not sub_dir.exists()
+            assert "Empty dirs cleaned: 1" in result.output
 
 
 class TestImportFromPageindexCloud:


### PR DESCRIPTION
> [!NOTE]
> This PR was created in collaboration between a human and AI: implementation, tests, and
> PR text were created by an AI assistant under the guidance and review of the human author.

### Problem
The `openkb add` command supports adding directories recursively, but users who frequently
download documents to `raw/` had to manually invoke `openkb add raw/` and then manually
delete processed files. There was no batch-processing shortcut for the `raw/` staging
directory, no summary of the outcome, and no configuration option to auto-delete successfully
ingested files and duplicates.

An earlier version of this PR addressed this by adding a separate `openkb add-all` command.
On further review this duplicated almost the entire `add` directory-processing code path
(same file walk, same filtering, same per-file ingestion call). This PR now consolidates that
functionality directly into `add` instead of introducing a second, largely redundant command.

### Solution / Changes

**`openkb add` (no changes for existing usage):**
- `add <path>` behaves exactly as before for files, directories, and URLs.
- `add` with **no PATH argument** (and no `--from-pageindex-cloud`) now defaults to the
  KB's `raw/` directory, walks it recursively, and ingests all supported file types
  (PDF, Markdown, DOCX, PPTX, XLSX, XLS, HTML, TXT, CSV).
- When processing a directory (default `raw/` or an explicit path), `add` now prints an
  aggregated summary at the end: `Added: X, Skipped: Y, Failed: Z, Deleted: W`.
- If `auto_delete_added_files` is enabled, now-empty subdirectories are cleaned up after a
  directory run (in addition to per-file deletion, which already existed).

**New configuration parameter:**
- `auto_delete_added_files` (boolean, default: `false`)
- When enabled, `add` automatically deletes files after processing
- Deletes on both **"added"** (successful ingestion) and **"skipped"** (duplicate/already in KB)
- Preserves **"failed"** files to allow user retries
- Applies to all ingest methods: direct files, directories (including the default `raw/`), and URLs

**Implementation:**
- Added `_delete_if_auto_cleanup_enabled()` helper function to handle cleanup logic
- Added `_cleanup_empty_directories()` for post-run empty-subdirectory cleanup
- Removed the standalone `add-all` command entirely (unreleased, no deprecation/alias needed)
  in favor of `add` with no PATH argument
- Updated `add`'s docstring to document the default-`raw/`, summary, and cleanup behavior
- Updated tests and README accordingly

### Issues
- Resolves #231
