### PR TITLE
fix(converter): cap doc_name length to avoid Windows path-length errors

### DIFF
--- a/openkb/converter.py
+++ b/openkb/converter.py
@@ -48,11 +48,24 @@ def _registry_path(path: Path, kb_dir: Path) -> str:
 
 _SAFE_STEM_RE = re.compile(r"[^\w\-]+")
 _SUFFIX_LEN = 8
+_MAX_STEM_LEN = 40
 
 
 def _sanitize_stem(stem: str) -> str:
+    """Sanitize and cap ``stem``, appending a hash suffix if truncated.
+
+    ``doc_name`` (this function's return value) can appear twice in the
+    per-add staging path (staging dir name + images subdir), so an
+    unbounded stem risks Windows' ~260-char path limit. The suffix is a
+    hash of the FULL cleaned stem (not just the truncated prefix) so two
+    different overlong stems sharing the same prefix don't collide.
+    """
     normalized = unicodedata.normalize("NFKC", stem)
-    return _SAFE_STEM_RE.sub("-", normalized).strip("-") or "document"
+    cleaned = _SAFE_STEM_RE.sub("-", normalized).strip("-") or "document"
+    if len(cleaned) > _MAX_STEM_LEN:
+        digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:_SUFFIX_LEN]
+        cleaned = f"{cleaned[:_MAX_STEM_LEN].rstrip('-')}-{digest}"
+    return cleaned
 
 
 def _name_taken(candidate: str, registry: HashRegistry) -> bool:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -218,6 +218,40 @@ class TestRegistryPath:
 
 
 # ---------------------------------------------------------------------------
+# _sanitize_stem
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeStem:
+    def test_short_stem_is_unchanged(self):
+        from openkb.converter import _sanitize_stem
+
+        assert _sanitize_stem("report") == "report"
+
+    def test_long_stem_is_capped_with_hash_suffix(self):
+        from openkb.converter import _MAX_STEM_LEN, _sanitize_stem
+
+        stem = "bulkQuery_result_" + "a" * 60
+        result = _sanitize_stem(stem)
+        assert len(result) == _MAX_STEM_LEN + 1 + 8  # prefix + "-" + 8-hex digest
+        assert result.startswith(stem[:_MAX_STEM_LEN])
+
+    def test_long_stem_truncation_is_deterministic(self):
+        from openkb.converter import _sanitize_stem
+
+        stem = "x" * 100
+        assert _sanitize_stem(stem) == _sanitize_stem(stem)
+
+    def test_different_long_stems_with_same_prefix_do_not_collide(self):
+        from openkb.converter import _MAX_STEM_LEN, _sanitize_stem
+
+        prefix = "a" * _MAX_STEM_LEN
+        first = _sanitize_stem(prefix + "-one")
+        second = _sanitize_stem(prefix + "-two")
+        assert first != second
+
+
+# ---------------------------------------------------------------------------
 # resolve_doc_name
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> [!NOTE]
> This PR was created in collaboration between a human and AI: implementation, tests, and
> PR text were created by an AI assistant under the guidance and review of the human author.

### Problem
`openkb add` can fail on Windows with `OSError [WinError 206]` ("The filename or extension is too long") when ingesting a source file with a long filename. The sanitized wiki name (`doc_name`, derived from the original filename's stem) is used unmodified and unbounded in length as a directory/file name component, and appears twice within the per-add staging tree (`.openkb/staging/add-{doc_name}-{uuid8}/wiki/sources/images/{doc_name}/`). Combined with an already-nested KB path, the total path length can exceed Windows' ~260-char limit.

### Root Cause
`_sanitize_stem()` in `openkb/converter.py` only replaces disallowed characters, never bounds length. `doc_name` (its return value) is used unmodified in `cli.py::_staging_dir_for` (staging directory name) and `converter.py::convert_document` (`wiki/sources/images/{doc_name}/`), so an overlong original filename appears twice in the same path. `openkb/url_ingest.py`'s `_sanitize_filename` already caps stems at 80 chars (`_MAX_FILENAME_STEM`) for URL-derived downloads, but that cap wasn't shared with the local-file ingest path.

### Solution / Changes
- `openkb/converter.py`: `_sanitize_stem()` now caps the cleaned stem at `_MAX_STEM_LEN = 40` chars (conservative, since `doc_name` can appear twice in the staging path) and appends a deterministic 8-hex-char SHA256 digest of the *full* cleaned stem when truncated, e.g. `bulkQuery_result_...-a1b2c3d4`. Hashing the full stem (not just the truncated prefix) avoids silent collisions between different overlong names sharing the same prefix.
  - Unlike `url_ingest.py`'s counter-based `_unique_path` (collisions resolved by an on-disk existence check), `converter.py`'s existing collision handling (`_name_taken` + `resolve_doc_name`/`resolve_doc_name_from_key`) is registry-based, so a deterministic hash suffix (not an incremental counter) is used here.
  - `_staging_dir_for` (`cli.py`) and `resolve_doc_name`/`resolve_doc_name_from_key` (`converter.py`) already call `_sanitize_stem()`, so both the staging directory and the images directory are fixed by this single change — no other call sites needed updates.
  - The existing collision suffix mechanism (`-{sha256(path_key)[:8]}`) is unchanged and can stack with the new truncation suffix (max length 40+1+8+1+8 = 58 chars — still well within filesystem limits).
- `tests/test_converter.py`: new `TestSanitizeStem` class covering truncation + hash-suffix format, determinism (same input → same output), and no silent collision between different overlong stems sharing the same 40-char prefix. Existing tests are unaffected (their stems are well under 40 chars).

### Issues
- `Resolves #252`
