### PR TITLE
fix(locks): retry atomic_write_bytes on transient PermissionError (WinError 5)

### DIFF
--- a/openkb/locks.py
+++ b/openkb/locks.py
@@ -14,10 +14,13 @@ import logging
 import os
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import IO, Iterator
 
 import portalocker
+
+logger = logging.getLogger(__name__)
 
 
 def flock(fh: IO, *, exclusive: bool) -> None:
@@ -220,6 +223,40 @@ def _target_mode(path: Path) -> int:
         return _default_file_mode()
 
 
+_REPLACE_RETRY_ATTEMPTS = 5
+_REPLACE_RETRY_BASE_DELAY = 0.05  # seconds, doubles each attempt
+
+
+def _replace_with_retry(tmp_path: Path, path: Path) -> None:
+    """Rename *tmp_path* onto *path*, retrying a transient Windows file lock.
+
+    A freshly written temp file can be briefly opened by another process
+    (real-time antivirus scanning, the search indexer, backup/sync agents)
+    right before the rename, which makes ``os.replace()`` raise
+    ``PermissionError`` (Windows ``WinError 5``) even though nothing in this
+    process holds the file open and the lock typically clears within
+    milliseconds. Only ``PermissionError`` is retried; any other ``OSError``
+    (e.g. a real permissions problem) is raised immediately.
+    """
+    delay = _REPLACE_RETRY_BASE_DELAY
+    for attempt in range(_REPLACE_RETRY_ATTEMPTS):
+        try:
+            os.replace(tmp_path, path)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_RETRY_ATTEMPTS - 1:
+                raise
+            logger.debug(
+                "os.replace(%s, %s) hit a transient PermissionError, retrying (attempt %d/%d)",
+                tmp_path,
+                path,
+                attempt + 1,
+                _REPLACE_RETRY_ATTEMPTS,
+            )
+            time.sleep(delay)
+            delay *= 2
+
+
 def atomic_write_bytes(path: Path, content: bytes) -> None:
     """Atomically replace *path* with binary *content*."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -232,7 +269,7 @@ def atomic_write_bytes(path: Path, content: bytes) -> None:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp_path, path)
+        _replace_with_retry(tmp_path, path)
         _fsync_directory(path.parent)
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 import threading
 
@@ -127,3 +128,59 @@ def test_atomic_write_json_replaces_file(tmp_path):
     atomic_write_json(target, {"a": {"name": "doc.pdf"}}, ensure_ascii=False)
 
     assert json.loads(target.read_text(encoding="utf-8")) == {"a": {"name": "doc.pdf"}}
+
+
+def test_atomic_write_bytes_retries_transient_permission_error(tmp_path, monkeypatch):
+    target = tmp_path / "file.txt"
+    real_replace = os.replace
+    calls = []
+
+    def flaky_replace(src, dst):
+        calls.append((src, dst))
+        if len(calls) < 3:
+            raise PermissionError("simulated transient lock")
+        real_replace(src, dst)
+
+    monkeypatch.setattr("openkb.locks.os.replace", flaky_replace)
+    monkeypatch.setattr("openkb.locks.time.sleep", lambda _seconds: None)
+
+    atomic_write_text(target, "content")
+
+    assert len(calls) == 3
+    assert target.read_text(encoding="utf-8") == "content"
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_reraises_after_exhausting_retries(tmp_path, monkeypatch):
+    target = tmp_path / "file.txt"
+    calls = []
+
+    def always_fails(src, dst):
+        calls.append((src, dst))
+        raise PermissionError("simulated persistent lock")
+
+    monkeypatch.setattr("openkb.locks.os.replace", always_fails)
+    monkeypatch.setattr("openkb.locks.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(PermissionError):
+        atomic_write_text(target, "content")
+
+    assert len(calls) == 5
+    assert not target.exists()
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_does_not_retry_other_os_error(tmp_path, monkeypatch):
+    target = tmp_path / "file.txt"
+    calls = []
+
+    def not_a_lock(src, dst):
+        calls.append((src, dst))
+        raise OSError("simulated unrelated failure")
+
+    monkeypatch.setattr("openkb.locks.os.replace", not_a_lock)
+
+    with pytest.raises(OSError, match="simulated unrelated failure"):
+        atomic_write_text(target, "content")
+
+    assert len(calls) == 1


### PR DESCRIPTION
### Problem
`atomic_write_bytes()` in `openkb/locks.py` (the shared helper behind `atomic_write_text`/`atomic_write_json`, used by the compiler, indexer, converter, config, and page_ops) performed a single, unretried `os.replace(tmp_path, path)` to publish a write. On Windows, a freshly-written temp file can be briefly locked by an external process (real-time antivirus scanning, the search indexer, backup/sync agents) right before the rename — `os.replace()` then raises `PermissionError` (`WinError 5`, Access is denied) even though the lock typically clears within milliseconds to a couple of seconds.

Because this exception surfaced all the way up, `_run_compile_with_retry()` in `cli.py` (added in #229) treated it like any other failure: it discarded the fully-generated summary/concept/entity content already held in memory and re-ran the **entire** LLM compile pipeline from scratch just to retry a single file rename — wasting the LLM cost and time of a full document compile for a transient, typically self-clearing lock.

### Root Cause
`_compile_concepts()` already holds all LLM-generated content (summary, concept/entity pages) in memory and only writes it to disk at the very end of the pipeline — so a write failure at that point has nothing to do with generation. The actual gap was one level lower: `atomic_write_bytes()`'s `os.replace()` call had no retry of its own, so any transient OS-level lock immediately propagated up to the much more expensive full-pipeline retry instead of being absorbed where it occurred.

### Solution / Changes
- `openkb/locks.py`: new `_replace_with_retry()` wraps the `os.replace()` call in `atomic_write_bytes()` with a bounded retry (5 attempts, exponential backoff starting at 50ms). Only `PermissionError` is retried — any other `OSError` (a real permissions problem) is raised immediately, unchanged from before. Each retry logs at DEBUG level (surfaces in the per-file debug log when `debug: true`/`-v` is enabled).
- `tests/test_locks.py`: three new tests — succeeds after transient `PermissionError`s, re-raises after exhausting all attempts (and still cleans up the temp file), and does not retry an unrelated `OSError`.
- No config/CLI surface changes; behavior is unchanged on the happy path and for genuine (non-transient) permission errors.

### Issues
Resolves #254. Related to #229 (origin of `_run_compile_with_retry`, whose full-pipeline retry this change makes largely unnecessary for this failure class).
